### PR TITLE
Fix CCL weekend service adjustment recurrence window

### DIFF
--- a/data/source/issue/2026-04-11-ccl-weekend-service-adjustment.json
+++ b/data/source/issue/2026-04-11-ccl-weekend-service-adjustment.json
@@ -9,14 +9,14 @@
   "lineIdsAffected": [
     "CCL"
   ],
-  "startAt": "2026-04-11T00:00:00.000+08:00",
-  "endAt": "2026-05-18T00:00:00.000+08:00",
+  "startAt": "2026-04-11T23:00:00.000+08:00",
+  "endAt": "2026-04-12T09:00:00.000+08:00",
   "type": "maintenance",
   "cancelledAt": null,
   "subtypes": [
     "track.work"
   ],
-  "rrule": null,
+  "rrule": "DTSTART;TZID=Asia/Singapore:20260411T230000\nRRULE:FREQ=WEEKLY;UNTIL=20260517T000000;WKST=MO;BYDAY=SA",
   "updates": [
     {
       "type": "planned",


### PR DESCRIPTION
### Motivation
- The issue JSON declared a multi-week continuous `startAt`/`endAt` while the update text describes impact only on Saturday nights and Sunday mornings, causing interval generation to treat the maintenance as ongoing across weekdays. 
- The change makes the data accurately represent a recurring weekend maintenance window so `computeIssueIntervals` produces discrete weekend intervals.

### Description
- Updated `data/source/issue/2026-04-11-ccl-weekend-service-adjustment.json` to set `startAt` to `2026-04-11T23:00:00.000+08:00` and `endAt` to `2026-04-12T09:00:00.000+08:00` to represent a single Saturday 11:00pm–Sunday 9:00am occurrence. 
- Added an `rrule` value `DTSTART;TZID=Asia/Singapore:20260411T230000\nRRULE:FREQ=WEEKLY;UNTIL=20260517T000000;WKST=MO;BYDAY=SA` so intervals are generated weekly on Saturdays through the final affected weekend. 
- This aligns the data with the textual update so `computeIssueIntervals` will create recurring weekend intervals instead of one continuous interval.

### Testing
- Ran `npx tsc` and the TypeScript build check passed. 
- Ran `npm run build` which failed in the postbuild step due to a missing environment variable `DUCKDB_DATABASE_PATH`, which is unrelated to the data fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7d81ee7c88320b0a0cf7bd56807c0)