### PR TITLE
chore: add agent harness foundation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,6 +2,9 @@
 
 **Always reference these instructions first and fallback to search or bash commands only when you encounter unexpected information that does not match the info here.**
 
+Also read `AGENTS.md`. It is the maintained short map for agents and points to
+the current data-overhaul split plan.
+
 ## Project Overview
 
 mrtdown-data is a comprehensive data repository and API system that tracks Singapore's MRT (Mass Rapid Transit) service disruptions, maintenance, and infrastructure issues. It functions as a status monitoring system for Singapore's public transportation network.
@@ -28,6 +31,11 @@ npm run build                  # ~6.4 seconds - NEVER CANCEL. Set timeout to 300
 **Run tests:**
 ```bash
 npm test                       # ~1.3 seconds - very fast
+```
+
+**Run harness checks:**
+```bash
+npm run check                  # Fast deterministic docs/boundary checks
 ```
 
 **Lint and format code:**

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,50 @@
+name: Validate
+
+on:
+  pull_request:
+    paths:
+      - 'AGENTS.md'
+      - 'CLAUDE.md'
+      - 'README.md'
+      - '.github/**'
+      - 'api/**'
+      - 'data/**'
+      - 'docs/**'
+      - 'package*.json'
+      - 'scripts/**'
+      - 'src/**'
+      - 'tsconfig.json'
+      - 'biome.json'
+  push:
+    branches:
+      - main
+    paths:
+      - 'AGENTS.md'
+      - 'CLAUDE.md'
+      - 'README.md'
+      - '.github/**'
+      - 'api/**'
+      - 'data/**'
+      - 'docs/**'
+      - 'package*.json'
+      - 'scripts/**'
+      - 'src/**'
+      - 'tsconfig.json'
+      - 'biome.json'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
+      - run: npm run check
+      - run: npm run typecheck
+      - run: npm run db:generate
+        env:
+          DUCKDB_DATABASE_PATH: mrtdown.duckdb
+      - run: npm test -- --run

--- a/.gitignore
+++ b/.gitignore
@@ -147,3 +147,9 @@ dist
 
 # Sentry Config File
 .sentryclirc
+
+# Local caches and migration scratch files
+.turbo
+migrated-legacy-ids.json
+data/manifest.json
+data/index.html

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,69 @@
+# Agent Map
+
+This file is the entry point for coding agents. Keep it short. Put durable details
+in `docs/` and link to them from here.
+
+## Current State
+
+`main` is still the legacy MRTDown data API repository:
+
+- `src/api/` contains Hono routes and response schemas.
+- `src/db/` generates and reads the DuckDB database.
+- `src/schema/`, `src/model/`, and `src/helpers/` contain shared runtime types and
+  calculations.
+- `src/util/ingestContent/` and `src/scripts/` handle ingestion and maintenance
+  utilities.
+- `data/source/` is the legacy source-data layout.
+
+The data-overhaul work is being split into smaller PRs. Follow
+`docs/DATA_OVERHAUL_SPLIT.md` before moving package, data, workflow, or deploy
+surface between branches.
+
+## Target Layout
+
+The target architecture is a package/data repository:
+
+- `packages/core`: schemas, shared period helpers, and state helpers.
+- `packages/fs`: file-backed repositories and writers. It depends on `core`.
+- `packages/triage`: LLM-assisted evidence triage and replay utilities. It may
+  depend on `core` and `fs`.
+- `packages/cli`: command-line entry point that wires packages together.
+- `data/{station,line,service,operator,town,landmark}`: canonical static
+  entities.
+- `data/issue/YYYY/MM/<issue_id>/`: append-only issue records with
+  `issue.json`, `evidence.ndjson`, and `impact.ndjson`.
+- `fixtures/data`: small deterministic data set for tests and examples.
+
+## Commands
+
+For the current legacy app:
+
+- `npm ci`: install dependencies from the lockfile.
+- `npm run build`: compile TypeScript and run the legacy postbuild pipeline.
+- `npm test`: run deterministic tests.
+- `npm run check`: run harness checks that should stay fast and deterministic.
+- `npm run check:boundaries`: enforce package import boundaries when packages
+  exist.
+- `npm run check:docs`: verify repo-relative documentation links.
+
+For the target package architecture, each split PR should keep these commands
+truthful in its own branch and update this file only when the branch changes
+the repository shape.
+
+## Review Rules
+
+- Prefer small PRs that isolate one concern: harness, package scaffold, core
+  schemas, file-backed repositories, CLI, triage, data migration, workflows, or
+  deploy cleanup.
+- Keep generated data and hand-authored code in separate PRs whenever practical.
+- If documentation and code disagree, fix the documentation or narrow the PR
+  before adding more implementation.
+- Do not merge temporary branch names, one-off deploy triggers, or local
+  generated artifacts.
+
+## Deeper Docs
+
+- `README.md`: current legacy app overview and commands.
+- `docs/DATA_OVERHAUL_SPLIT.md`: planned split sequence for the data overhaul.
+- `CLAUDE.md`: Claude-specific compatibility entry point.
+- `.github/copilot-instructions.md`: Copilot compatibility entry point.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,10 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+Start with `AGENTS.md`. It is the maintained short map for agents. This file is
+kept only as a Claude-compatible entry point and should not grow into a second
+source of truth.
+
 ## Project Overview
 
 This is **mrtdown-data**, a data repository and API system that tracks Singapore's MRT (Mass Rapid Transit) service disruptions, maintenance, and infrastructure issues. It functions as a comprehensive status monitoring system for Singapore's public transportation.
@@ -11,6 +15,9 @@ This is **mrtdown-data**, a data repository and API system that tracks Singapore
 ## Development Commands
 
 ```bash
+# Harness checks
+npm run check              # Fast deterministic agent-harness checks
+
 # Database and build
 npm run build              # Compile TypeScript (auto-runs db:generate)
 npm run db:generate        # Generate DuckDB database from source data

--- a/README.md
+++ b/README.md
@@ -31,6 +31,16 @@ npx biome check
 
 ## Development Commands
 
+### Agent Harness
+```bash
+npm run check              # Fast deterministic harness checks
+npm run check:docs         # Verify repo-relative documentation links
+npm run check:boundaries   # Enforce package import boundaries when packages exist
+```
+
+See `AGENTS.md` for the short agent map and `docs/DATA_OVERHAUL_SPLIT.md` for
+the planned data-overhaul split.
+
 ### Database Operations
 ```bash
 npm run build              # Compile TypeScript (auto-runs db:generate)

--- a/biome.json
+++ b/biome.json
@@ -1,14 +1,21 @@
 {
   "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
   "vcs": {
-    "enabled": false,
+    "enabled": true,
     "clientKind": "git",
-    "useIgnoreFile": false
+    "useIgnoreFile": true
   },
   "files": {
-    "ignoreUnknown": false,
+    "ignoreUnknown": true,
     "includes": [
-      "**"
+      "**",
+      "!**/.turbo",
+      "!**/dist",
+      "!**/node_modules",
+      "!**/*.duckdb",
+      "!data/manifest.json",
+      "!data/index.html",
+      "!migrated-legacy-ids.json"
     ]
   },
   "formatter": {

--- a/docs/DATA_OVERHAUL_SPLIT.md
+++ b/docs/DATA_OVERHAUL_SPLIT.md
@@ -1,0 +1,81 @@
+# Data Overhaul Split Plan
+
+PR #177 is the backup/source branch for this migration. Do not keep expanding
+that branch. Split it into small PRs that can be reviewed and validated
+independently.
+
+## Goals
+
+- Make `mrtdown-data` the canonical reviewed data repository for MRTDown.
+- Move runtime serving and Postgres import concerns to `mrtdown-site`.
+- Keep agent instructions short and make repository feedback mechanical.
+- Keep generated/migrated data separate from package and workflow changes.
+
+## PR Sequence
+
+1. Harness foundation
+   - Add `AGENTS.md`, this split plan, doc-link checks, package-boundary checks,
+     generated-file ignores, and validation workflow wiring.
+   - Do not move runtime code or migrate data in this PR.
+
+2. Package scaffold and core schemas
+   - Add workspaces and `packages/core`.
+   - Move shared schemas and period/state helpers.
+   - Keep tests focused on pure deterministic behavior.
+
+3. File-backed repository and CLI
+   - Add `packages/fs` and `packages/cli`.
+   - Add fixtures and commands for validate, list, show, create, id, manifest,
+     and pages-index.
+
+4. Triage package
+   - Add `packages/triage` with deterministic tests.
+   - Document `test:eval`, required environment variables, model dependency,
+     and expected cost before running paid/model-dependent evals.
+
+5. Static canonical data
+   - Migrate `station`, `line`, `service`, `operator`, `town`, and `landmark`
+     data into the target `data/` layout.
+   - Validate with CLI tooling from earlier PRs.
+
+6. Issue dataset migration
+   - Migrate `data/issue/YYYY/MM/<issue_id>/`.
+   - Keep replay/repair reports with the PR so reviewers can inspect the
+     generator behavior instead of reading every generated file.
+
+7. Runtime removal and deploy cleanup
+   - Remove old Hono/API/DuckDB runtime files from this repo.
+   - Remove or move `Dockerfile`, `fly.toml`, and Fly deploy workflow surfaces
+     once the serving target exists in `mrtdown-site`.
+
+8. Pages and package publishing
+   - Add GitHub Pages static data artifact generation.
+   - Add Changesets/npm publishing only after package APIs and branch triggers
+     are reviewed.
+
+## Mechanical Checks
+
+Every PR should run the fastest applicable subset:
+
+- `npm run check`
+- `npm run build`
+- `npm test`
+- target CLI validation once the CLI exists
+
+When packages exist, `npm run check:boundaries` enforces the intended dependency
+direction:
+
+- `core` must not import `fs`, `triage`, or `cli`.
+- `fs` may import `core`, but not `triage` or `cli`.
+- `triage` may import `core` and `fs`, but not `cli`.
+- `cli` may wire all packages together.
+
+## Review Notes
+
+- Keep branch names, workflow triggers, and deploy targets production-safe before
+  merge.
+- Do not commit generated `data/manifest.json`, generated `data/index.html`,
+  `.turbo/`, `dist/`, DuckDB files, or migration scratch files unless a PR
+  explicitly changes artifact policy.
+- If a split PR depends on an earlier split PR, target the earlier branch rather
+  than hiding the dependency in a large diff.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "check": "npm run lint && npm run check:boundaries && npm run check:docs",
     "check:boundaries": "node scripts/check-package-boundaries.mjs",
     "check:docs": "node scripts/check-docs-links.mjs",
-    "lint": "biome check AGENTS.md CLAUDE.md README.md biome.json package.json scripts",
+    "lint": "biome check AGENTS.md CLAUDE.md README.md docs .github/copilot-instructions.md biome.json package.json scripts",
     "typecheck": "tsc --noEmit",
     "test": "vitest",
     "ingest:webhook": "tsx src/scripts/ingestViaWebhook.ts",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,11 @@
   "scripts": {
     "build": "tsc",
     "postbuild": "npm run db:generate && npm run sentry:sourcemaps",
+    "check": "npm run lint && npm run check:boundaries && npm run check:docs",
+    "check:boundaries": "node scripts/check-package-boundaries.mjs",
+    "check:docs": "node scripts/check-docs-links.mjs",
+    "lint": "biome check AGENTS.md CLAUDE.md README.md biome.json package.json scripts",
+    "typecheck": "tsc --noEmit",
     "test": "vitest",
     "ingest:webhook": "tsx src/scripts/ingestViaWebhook.ts",
     "check-rss-feeds": "tsx src/scripts/checkRssFeeds.ts",

--- a/scripts/check-docs-links.mjs
+++ b/scripts/check-docs-links.mjs
@@ -1,0 +1,64 @@
+import { existsSync, statSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+
+const repoRoot = resolve(import.meta.dirname, '..');
+const docs = [
+  'AGENTS.md',
+  'README.md',
+  'CLAUDE.md',
+  '.github/copilot-instructions.md',
+  'docs/DATA_OVERHAUL_SPLIT.md',
+];
+
+const linkPattern = /\[[^\]]+\]\(([^)]+)\)/g;
+const errors = [];
+
+function isExternal(target) {
+  return /^[a-z][a-z0-9+.-]*:/i.test(target) || target.startsWith('#');
+}
+
+for (const doc of docs) {
+  const path = resolve(repoRoot, doc);
+  if (!existsSync(path)) {
+    errors.push(`${doc}: expected documentation file is missing`);
+    continue;
+  }
+
+  const text = await import('node:fs').then(({ readFileSync }) =>
+    readFileSync(path, 'utf8'),
+  );
+
+  for (const match of text.matchAll(linkPattern)) {
+    const rawTarget = match[1];
+    if (!rawTarget || isExternal(rawTarget)) {
+      continue;
+    }
+
+    const target = rawTarget.split('#')[0];
+    if (!target || target.includes('*') || target.includes('{')) {
+      continue;
+    }
+
+    const resolved = resolve(dirname(path), target);
+    if (!resolved.startsWith(repoRoot) || !existsSync(resolved)) {
+      errors.push(`${doc}: missing linked path ${rawTarget}`);
+      continue;
+    }
+
+    if (!statSync(resolved).isFile() && !statSync(resolved).isDirectory()) {
+      errors.push(
+        `${doc}: linked path is not a file or directory ${rawTarget}`,
+      );
+    }
+  }
+}
+
+if (errors.length > 0) {
+  console.error('Documentation link check failed:');
+  for (const error of errors) {
+    console.error(`- ${error}`);
+  }
+  process.exit(1);
+}
+
+console.log('Documentation links are valid.');

--- a/scripts/check-package-boundaries.mjs
+++ b/scripts/check-package-boundaries.mjs
@@ -1,0 +1,67 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = resolve(fileURLToPath(new URL('..', import.meta.url)));
+const packagesRoot = join(repoRoot, 'packages');
+
+const allowed = {
+  core: new Set([]),
+  fs: new Set(['core']),
+  triage: new Set(['core', 'fs']),
+  cli: new Set(['core', 'fs', 'triage']),
+};
+
+if (!existsSync(packagesRoot)) {
+  console.log('No packages directory found; package boundary check skipped.');
+  process.exit(0);
+}
+
+const files = execFileSync(
+  'git',
+  ['ls-files', 'packages/*/src/**/*.ts', 'packages/*/src/*.ts'],
+  {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  },
+)
+  .split('\n')
+  .filter(Boolean);
+
+const importPattern =
+  /(?:import|export)\s+(?:type\s+)?(?:[^'"]*?\s+from\s+)?['"]([^'"]+)['"]/g;
+const errors = [];
+
+for (const file of files) {
+  const [, packageName] = file.split('/');
+  const packageRules = allowed[packageName];
+  if (!packageRules) {
+    continue;
+  }
+
+  const text = readFileSync(join(repoRoot, file), 'utf8');
+  for (const match of text.matchAll(importPattern)) {
+    const specifier = match[1];
+    const dependency = specifier.match(/^@mrtdown\/([^/]+)/)?.[1];
+    if (!dependency || dependency === packageName) {
+      continue;
+    }
+
+    if (!packageRules.has(dependency)) {
+      errors.push(
+        `${file}: @mrtdown/${packageName} must not import @mrtdown/${dependency}`,
+      );
+    }
+  }
+}
+
+if (errors.length > 0) {
+  console.error('Package boundary check failed:');
+  for (const error of errors) {
+    console.error(`- ${error}`);
+  }
+  process.exit(1);
+}
+
+console.log('Package boundaries are valid.');


### PR DESCRIPTION
## Summary

- add a short root AGENTS.md as the agent entry point
- document the data-overhaul split sequence in docs/DATA_OVERHAUL_SPLIT.md
- add fast docs and package-boundary harness checks
- add a validate workflow that runs checks, typecheck, DB generation, and tests
- tune Biome and git ignores so generated/cache files do not pollute feedback

## Validation

- npm run check
- npm run typecheck
- npm test -- --run
- DUCKDB_DATABASE_PATH=/private/tmp/mrtdown-data-validate.duckdb npm run db:generate

## Notes

This PR deliberately does not move runtime code or migrate data. The existing duncanleo/data-overhaul branch remains the backup/source branch for follow-up split PRs.