### PR TITLE
feat: add Pages artifact publishing foundation

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -1,0 +1,61 @@
+# Publish static data to GitHub Pages.
+# In repository Settings > Pages, set Source to "GitHub Actions".
+
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/pages-deploy.yml'
+      - 'fixtures/data/**'
+      - 'package*.json'
+      - 'packages/**'
+      - 'scripts/build-pages-artifact.mjs'
+      - 'turbo.json'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build Pages artifact
+        run: npm run pages:build
+
+      - uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: pages-dist
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/pages-preview.yml
+++ b/.github/workflows/pages-preview.yml
@@ -1,0 +1,56 @@
+# Build the static Pages bundle for preview branches without deploying it.
+
+name: Build Pages Preview
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/pages-preview.yml'
+      - 'fixtures/data/**'
+      - 'package*.json'
+      - 'packages/**'
+      - 'scripts/build-pages-artifact.mjs'
+      - 'turbo.json'
+  push:
+    branches-ignore:
+      - main
+    paths:
+      - '.github/workflows/pages-preview.yml'
+      - 'fixtures/data/**'
+      - 'package*.json'
+      - 'packages/**'
+      - 'scripts/build-pages-artifact.mjs'
+      - 'turbo.json'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pages-preview-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build Pages artifact
+        run: npm run pages:build
+
+      - name: Upload preview artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: pages-preview-${{ github.run_id }}
+          path: pages-dist
+          if-no-files-found: error
+          retention-days: 1

--- a/.gitignore
+++ b/.gitignore
@@ -153,3 +153,4 @@ dist
 migrated-legacy-ids.json
 data/manifest.json
 data/index.html
+pages-dist

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,8 @@ the repository shape.
 - Keep generated data and hand-authored code in separate PRs whenever practical.
 - If documentation and code disagree, fix the documentation or narrow the PR
   before adding more implementation.
+- Use Conventional Commits style for commit messages and PR titles, for example
+  `feat: add Pages artifact publishing foundation`.
 - Do not merge temporary branch names, one-off deploy triggers, or local
   generated artifacts.
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ the planned data-overhaul split.
 split export uses `fixtures/data` so downstream consumers can integrate against
 the static contract before the canonical `data/` migration lands.
 
+Preview branches and pull requests build the same bundle in CI and upload it as
+a one-day artifact. Only `main` deploys the bundle to GitHub Pages.
+
 The artifact publishes:
 
 - `manifest.json`

--- a/README.md
+++ b/README.md
@@ -45,10 +45,25 @@ npm run test:core          # Run @mrtdown/core deterministic tests
 npm run test:fs            # Run @mrtdown/fs deterministic tests
 npm run test:cli           # Run @mrtdown/cli deterministic tests
 npm run data:validate      # Validate fixtures/data with @mrtdown/cli
+npm run pages:build        # Build the GitHub Pages static data artifact
 ```
 
 See `AGENTS.md` for the short agent map and `docs/DATA_OVERHAUL_SPLIT.md` for
 the planned data-overhaul split.
+
+### Static Pages Export
+
+`npm run pages:build` writes a GitHub Pages artifact to `pages-dist/`. The early
+split export uses `fixtures/data` so downstream consumers can integrate against
+the static contract before the canonical `data/` migration lands.
+
+The artifact publishes:
+
+- `manifest.json`
+- `index.html`
+- `archive.tar.gz`
+- `archive.zip`
+- the target-layout data files used to build the manifest
 
 ### Database Operations
 ```bash

--- a/README.md
+++ b/README.md
@@ -53,20 +53,21 @@ the planned data-overhaul split.
 
 ### Static Pages Export
 
-`npm run pages:build` writes a GitHub Pages artifact to `pages-dist/`. The early
-split export uses `fixtures/data` so downstream consumers can integrate against
-the static contract before the canonical `data/` migration lands.
+`npm run pages:build` writes a GitHub Pages artifact to `pages-dist/`. This
+split branch publishes only `fixtures/data` under `fixtures/` so downstream
+consumers can integrate against the static contract before the canonical `data/`
+migration lands.
 
 Preview branches and pull requests build the same bundle in CI and upload it as
 a one-day artifact. Only `main` deploys the bundle to GitHub Pages.
 
-The artifact publishes:
+The artifact publishes a root `index.html` that links to the fixture export:
 
-- `manifest.json`
-- `index.html`
-- `archive.tar.gz`
-- `archive.zip`
-- the target-layout data files used to build the manifest
+- `fixtures/index.html`
+- `fixtures/manifest.json`
+- `fixtures/archive.tar.gz`
+- `fixtures/archive.zip`
+- the fixture target-layout data files used to build the fixture manifest
 
 ### Database Operations
 ```bash

--- a/docs/DATA_OVERHAUL_SPLIT.md
+++ b/docs/DATA_OVERHAUL_SPLIT.md
@@ -36,28 +36,36 @@ Step 3.5: Turborepo package task harness
 - Preserve the existing root command names so production stabilization patches
   continue to run the same entry points.
 
-4. Triage package
+4. GitHub Pages publishing foundation
+   - Add GitHub Pages static data artifact generation and deployment before
+     triage so `mrtdown-site` can begin consuming published data.
+   - Use the existing target CLI manifest and pages-index behavior as the
+     publication boundary.
+   - Keep this PR limited to Pages workflow wiring, artifact generation, and
+     docs for the published contract.
+   - Do not add Changesets/npm package publishing in this PR.
+
+5. Triage package
    - Add `packages/triage` with deterministic tests.
    - Document `test:eval`, required environment variables, model dependency,
      and expected cost before running paid/model-dependent evals.
 
-5. Static canonical data
+6. Static canonical data
    - Migrate `station`, `line`, `service`, `operator`, `town`, and `landmark`
      data into the target `data/` layout.
    - Validate with CLI tooling from earlier PRs.
 
-6. Issue dataset migration
+7. Issue dataset migration
    - Migrate `data/issue/YYYY/MM/<issue_id>/`.
    - Keep replay/repair reports with the PR so reviewers can inspect the
      generator behavior instead of reading every generated file.
 
-7. Runtime removal and deploy cleanup
+8. Runtime removal and deploy cleanup
    - Remove old Hono/API/DuckDB runtime files from this repo.
    - Remove or move `Dockerfile`, `fly.toml`, and Fly deploy workflow surfaces
      once the serving target exists in `mrtdown-site`.
 
-8. Pages and package publishing
-   - Add GitHub Pages static data artifact generation.
+9. Package publishing
    - Add Changesets/npm publishing only after package APIs and branch triggers
      are reviewed.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "fuse.js": "^7.1.0",
         "generic-pool": "^3.9.0",
         "hast-util-from-html": "^2.0.3",
+        "hast-util-to-html": "^9.0.5",
         "hast-util-to-mdast": "^10.1.2",
         "hono": "^4.11.4",
         "hono-openapi": "^0.5.0-rc.3",
@@ -5028,7 +5029,8 @@
       "version": "2.0.0-alpha.22",
       "license": "UNLICENSED",
       "dependencies": {
-        "@mrtdown/core": "2.0.0-alpha.22"
+        "@mrtdown/core": "2.0.0-alpha.22",
+        "hast-util-to-html": "^9.0.5"
       },
       "devDependencies": {
         "@biomejs/biome": "2.3.14",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
         "fuse.js": "^7.1.0",
         "generic-pool": "^3.9.0",
         "hast-util-from-html": "^2.0.3",
-        "hast-util-to-html": "^9.0.5",
         "hast-util-to-mdast": "^10.1.2",
         "hono": "^4.11.4",
         "hono-openapi": "^0.5.0-rc.3",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "fuse.js": "^7.1.0",
     "generic-pool": "^3.9.0",
     "hast-util-from-html": "^2.0.3",
+    "hast-util-to-html": "^9.0.5",
     "hast-util-to-mdast": "^10.1.2",
     "hono": "^4.11.4",
     "hono-openapi": "^0.5.0-rc.3",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "test:fs": "turbo run test --filter=@mrtdown/fs",
     "test:cli": "turbo run test --filter=@mrtdown/cli",
     "data:validate": "npm run build:cli && node packages/cli/dist/index.js --data-dir fixtures/data validate",
+    "pages:build": "npm run build:fs && node scripts/build-pages-artifact.mjs",
     "test": "vitest",
     "ingest:webhook": "tsx src/scripts/ingestViaWebhook.ts",
     "check-rss-feeds": "tsx src/scripts/checkRssFeeds.ts",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "fuse.js": "^7.1.0",
     "generic-pool": "^3.9.0",
     "hast-util-from-html": "^2.0.3",
-    "hast-util-to-html": "^9.0.5",
     "hast-util-to-mdast": "^10.1.2",
     "hono": "^4.11.4",
     "hono-openapi": "^0.5.0-rc.3",

--- a/packages/fs/package.json
+++ b/packages/fs/package.json
@@ -29,7 +29,8 @@
     "test": "npm --workspace @mrtdown/core run build && vitest --run"
   },
   "dependencies": {
-    "@mrtdown/core": "2.0.0-alpha.22"
+    "@mrtdown/core": "2.0.0-alpha.22",
+    "hast-util-to-html": "^9.0.5"
   },
   "devDependencies": {
     "@biomejs/biome": "2.3.14",

--- a/packages/fs/src/index.test.ts
+++ b/packages/fs/src/index.test.ts
@@ -62,7 +62,7 @@ describe('@mrtdown/fs', () => {
     expect(manifest.lines).toMatchObject({
       TGL: 'line/TGL.json',
     });
-    expect(renderPagesIndex(manifest)).toContain('MRTDown data');
+    expect(renderPagesIndex(manifest)).toContain('mrtdown-data');
     expect(renderPagesIndex(manifest)).not.toContain('archive.tar.gz');
     expect(renderPagesIndex(manifest, { includeArchiveLinks: true })).toContain(
       'archive.tar.gz',

--- a/packages/fs/src/index.test.ts
+++ b/packages/fs/src/index.test.ts
@@ -63,6 +63,10 @@ describe('@mrtdown/fs', () => {
       TGL: 'line/TGL.json',
     });
     expect(renderPagesIndex(manifest)).toContain('MRTDown data');
+    expect(renderPagesIndex(manifest)).not.toContain('archive.tar.gz');
+    expect(renderPagesIndex(manifest, { includeArchiveLinks: true })).toContain(
+      'archive.tar.gz',
+    );
   });
 
   it('rejects fixture line references that are missing from fixture lines', async () => {

--- a/packages/fs/src/pagesIndex.ts
+++ b/packages/fs/src/pagesIndex.ts
@@ -6,6 +6,10 @@ export type PagesIndexOptions = {
   includeArchiveLinks?: boolean;
 };
 
+export type PagesRootIndexOptions = {
+  generatedAt?: Date;
+};
+
 type Child = Element['children'][number];
 
 function text(value: string): Child {
@@ -33,6 +37,51 @@ function code(value: string): Element {
   return element('pre', [text(value)]);
 }
 
+function buildDocument(
+  bodyChildren: Child[],
+  options: { includeCodeStyle?: boolean } = {},
+): Root {
+  const codeStyle = options.includeCodeStyle
+    ? 'pre { word-break: break-word; white-space: pre-wrap; display: inline; background-color: #f0f0f0; padding: 0.125rem 0.25rem; border-radius: 0.25rem; }'
+    : '';
+
+  return {
+    type: 'root',
+    children: [
+      { type: 'doctype' },
+      element(
+        'html',
+        [
+          element('head', [
+            element('meta', [], { charset: 'utf-8' }),
+            element('meta', [], {
+              name: 'viewport',
+              content: 'width=device-width, initial-scale=1',
+            }),
+            element('title', [text('mrtdown-data')]),
+            element('style', [
+              text(
+                `
+:root { font-family: system-ui, sans-serif; line-height: 1.5; }
+body { max-width: 40rem; margin: 2rem auto; padding: 0 1rem; color: #111; }
+h1 { font-size: 1.5rem; }
+table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+th, td { text-align: left; padding: 0.35rem 0.5rem; border-bottom: 1px solid #ddd; }
+th { font-weight: 600; width: 40%; }
+${codeStyle}
+footer { margin-top: 2rem; font-size: 0.875rem; color: #555; }
+a { color: #0b57d0; }`.trim(),
+              ),
+            ]),
+          ]),
+          element('body', bodyChildren),
+        ],
+        { lang: 'en' },
+      ),
+    ],
+  };
+}
+
 function buildExportLinks(options: PagesIndexOptions): Element {
   const children: Child[] = [
     text(
@@ -56,6 +105,19 @@ function buildExportLinks(options: PagesIndexOptions): Element {
   return element('p', children);
 }
 
+function buildFooter(
+  generatedAt: Date,
+  datetime = generatedAt.toISOString(),
+): Element {
+  return element('footer', [
+    text('Generated at '),
+    element('time', [text(generatedAt.toUTCString())], {
+      datetime,
+    }),
+    text(` (UTC) on ${process.platform}/${process.arch}`),
+  ]);
+}
+
 function buildTable(title: string, records: Record<string, string>): Element[] {
   const rows = Object.entries(records).map(([id, path]) =>
     element('tr', [element('td', [code(id)]), element('td', [link(path)])]),
@@ -75,6 +137,62 @@ function buildTable(title: string, records: Record<string, string>): Element[] {
   ];
 }
 
+function buildFileRow(href: string, description: string): Element {
+  return element('tr', [
+    element('td', [link(href)]),
+    element('td', [text(description)]),
+  ]);
+}
+
+export function renderPagesRootIndex(
+  options: PagesRootIndexOptions = {},
+): string {
+  const generatedAt = options.generatedAt ?? new Date();
+
+  return toHtml(
+    buildDocument([
+      element('h1', [text('mrtdown-data')]),
+      element('p', [
+        text(
+          'This split branch publishes only the deterministic fixture export. The canonical data export will be added after the target-layout data migration lands.',
+        ),
+      ]),
+      element('p', [
+        text('The fixture data index is available as '),
+        link('fixtures/'),
+        text('. Its machine-readable manifest is published as '),
+        link('fixtures/manifest.json'),
+        text('. The fixture directory is also available as '),
+        link('fixtures/archive.tar.gz'),
+        text(' (gzipped tarball) or '),
+        link('fixtures/archive.zip'),
+        text('.'),
+      ]),
+      link('https://github.com/foldaway/mrtdown-data', 'GitHub repository'),
+      element('h2', [text('Developer files')]),
+      element('table', [
+        element('tbody', [
+          element('tr', [
+            element('th', [text('File')]),
+            element('th', [text('Description')]),
+          ]),
+          buildFileRow('fixtures/', 'Fixture data index.'),
+          buildFileRow('fixtures/manifest.json', 'Fixture export manifest.'),
+          buildFileRow(
+            'fixtures/archive.tar.gz',
+            'Fixture export as a gzipped tarball.',
+          ),
+          buildFileRow(
+            'fixtures/archive.zip',
+            'Fixture export as a ZIP archive.',
+          ),
+        ]),
+      ]),
+      buildFooter(generatedAt),
+    ]),
+  );
+}
+
 export function renderPagesIndex(
   manifest: Manifest,
   options: PagesIndexOptions = {},
@@ -92,56 +210,17 @@ export function renderPagesIndex(
     buildTable(title, records),
   );
   const generatedAt = new Date(manifest.generatedAt);
-  const root: Root = {
-    type: 'root',
-    children: [
-      { type: 'doctype' },
-      element(
-        'html',
-        [
-          element('head', [
-            element('meta', [], { charset: 'utf-8' }),
-            element('meta', [], {
-              name: 'viewport',
-              content: 'width=device-width, initial-scale=1',
-            }),
-            element('title', [text('mrtdown-data')]),
-            element('style', [
-              text(
-                `
-:root { font-family: system-ui, sans-serif; line-height: 1.5; }
-body { max-width: 40rem; margin: 2rem auto; padding: 0 1rem; color: #111; }
-h1 { font-size: 1.5rem; }
-table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
-th, td { text-align: left; padding: 0.35rem 0.5rem; border-bottom: 1px solid #ddd; }
-th { font-weight: 600; width: 40%; }
-pre { word-break: break-word; white-space: pre-wrap; display: inline; background-color: #f0f0f0; padding: 0.125rem 0.25rem; border-radius: 0.25rem; }
-footer { margin-top: 2rem; font-size: 0.875rem; color: #555; }
-a { color: #0b57d0; }`.trim(),
-              ),
-            ]),
-          ]),
-          element('body', [
-            element('h1', [text('mrtdown-data')]),
-            buildExportLinks(options),
-            link(
-              'https://github.com/foldaway/mrtdown-data',
-              'GitHub repository',
-            ),
-            ...tables,
-            element('footer', [
-              text('Generated at '),
-              element('time', [text(generatedAt.toUTCString())], {
-                datetime: manifest.generatedAt,
-              }),
-              text(` (UTC) on ${process.platform}/${process.arch}`),
-            ]),
-          ]),
-        ],
-        { lang: 'en' },
-      ),
-    ],
-  };
 
-  return toHtml(root);
+  return toHtml(
+    buildDocument(
+      [
+        element('h1', [text('mrtdown-data')]),
+        buildExportLinks(options),
+        link('https://github.com/foldaway/mrtdown-data', 'GitHub repository'),
+        ...tables,
+        buildFooter(generatedAt, manifest.generatedAt),
+      ],
+      { includeCodeStyle: true },
+    ),
+  );
 }

--- a/packages/fs/src/pagesIndex.ts
+++ b/packages/fs/src/pagesIndex.ts
@@ -1,5 +1,9 @@
 import type { Manifest } from '@mrtdown/core';
 
+export type PagesIndexOptions = {
+  includeArchiveLinks?: boolean;
+};
+
 const escapeHtml = (value: string): string =>
   value
     .replace(/&/g, '&amp;')
@@ -7,7 +11,10 @@ const escapeHtml = (value: string): string =>
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;');
 
-export function renderPagesIndex(manifest: Manifest): string {
+export function renderPagesIndex(
+  manifest: Manifest,
+  options: PagesIndexOptions = {},
+): string {
   const counts = [
     ['Lines', Object.keys(manifest.lines).length],
     ['Stations', Object.keys(manifest.stations).length],
@@ -24,6 +31,11 @@ export function renderPagesIndex(manifest: Manifest): string {
         `<tr><th scope="row">${escapeHtml(String(label))}</th><td>${count}</td></tr>`,
     )
     .join('');
+  const archiveLinks = options.includeArchiveLinks
+    ? `
+        <li><a href="archive.tar.gz">archive.tar.gz</a></li>
+        <li><a href="archive.zip">archive.zip</a></li>`
+    : '';
 
   return `<!doctype html>
 <html lang="en">
@@ -39,8 +51,7 @@ export function renderPagesIndex(manifest: Manifest): string {
       <p>Generated at <time datetime="${escapeHtml(manifest.generatedAt)}">${escapeHtml(manifest.generatedAt)}</time>.</p>
       <ul>
         <li><a href="manifest.json">manifest.json</a></li>
-        <li><a href="archive.tar.gz">archive.tar.gz</a></li>
-        <li><a href="archive.zip">archive.zip</a></li>
+        ${archiveLinks}
       </ul>
       <table>
         <tbody>

--- a/packages/fs/src/pagesIndex.ts
+++ b/packages/fs/src/pagesIndex.ts
@@ -1,48 +1,78 @@
 import type { Manifest } from '@mrtdown/core';
+import type { Element, Root } from 'hast';
+import { toHtml } from 'hast-util-to-html';
 
 export type PagesIndexOptions = {
   includeArchiveLinks?: boolean;
 };
 
-const escapeHtml = (value: string): string =>
-  value
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;');
+type Child = Element['children'][number];
 
-function renderCode(value: string): string {
-  return `<pre>${escapeHtml(value)}</pre>`;
+function text(value: string): Child {
+  return { type: 'text', value };
 }
 
-function renderExportLinks(options: PagesIndexOptions): string {
-  const archiveLinks = options.includeArchiveLinks
-    ? ` The full data directory is also available as <a href="archive.tar.gz">archive.tar.gz</a> (gzipped tarball) or <a href="archive.zip">archive.zip</a>.`
-    : '';
-
-  return `<p>Static data index for Singapore MRT/LRT status and history. The machine-readable manifest is published as <a href="manifest.json">manifest.json</a>.${archiveLinks} Records are listed in alphabetical order by ID.</p>`;
+function element(
+  tagName: string,
+  children: Child[] = [],
+  properties: Element['properties'] = {},
+): Element {
+  return {
+    type: 'element',
+    tagName,
+    properties,
+    children,
+  };
 }
 
-function renderTable(title: string, records: Record<string, string>): string {
-  const rows = Object.entries(records)
-    .map(
-      ([id, path]) => `<tr>
-          <td>${renderCode(id)}</td>
-          <td><a href="${escapeHtml(path)}">${escapeHtml(path)}</a></td>
-        </tr>`,
-    )
-    .join('');
+function link(href: string, label = href): Element {
+  return element('a', [text(label)], { href });
+}
 
-  return `<h2>${escapeHtml(title)}</h2>
-      <table>
-        <tbody>
-          <tr>
-            <th>ID</th>
-            <th>Link</th>
-          </tr>
-          ${rows}
-        </tbody>
-      </table>`;
+function code(value: string): Element {
+  return element('pre', [text(value)]);
+}
+
+function buildExportLinks(options: PagesIndexOptions): Element {
+  const children: Child[] = [
+    text(
+      'Static data index for Singapore MRT/LRT status and history. The machine-readable manifest is published as ',
+    ),
+    link('manifest.json'),
+    text('.'),
+  ];
+
+  if (options.includeArchiveLinks) {
+    children.push(
+      text(' The full data directory is also available as '),
+      link('archive.tar.gz'),
+      text(' (gzipped tarball) or '),
+      link('archive.zip'),
+      text('.'),
+    );
+  }
+
+  children.push(text(' Records are listed in alphabetical order by ID.'));
+  return element('p', children);
+}
+
+function buildTable(title: string, records: Record<string, string>): Element[] {
+  const rows = Object.entries(records).map(([id, path]) =>
+    element('tr', [element('td', [code(id)]), element('td', [link(path)])]),
+  );
+
+  return [
+    element('h2', [text(title)]),
+    element('table', [
+      element('tbody', [
+        element('tr', [
+          element('th', [text('ID')]),
+          element('th', [text('Link')]),
+        ]),
+        ...rows,
+      ]),
+    ]),
+  ];
 }
 
 export function renderPagesIndex(
@@ -58,18 +88,27 @@ export function renderPagesIndex(
     ['Stations', manifest.stations],
     ['Issues', manifest.issues],
   ] satisfies Array<[string, Record<string, string>]>;
-  const tables = sections
-    .map(([title, records]) => renderTable(title, records))
-    .join('');
+  const tables = sections.flatMap(([title, records]) =>
+    buildTable(title, records),
+  );
   const generatedAt = new Date(manifest.generatedAt);
-
-  return `<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>mrtdown-data</title>
-    <style>
+  const root: Root = {
+    type: 'root',
+    children: [
+      { type: 'doctype' },
+      element(
+        'html',
+        [
+          element('head', [
+            element('meta', [], { charset: 'utf-8' }),
+            element('meta', [], {
+              name: 'viewport',
+              content: 'width=device-width, initial-scale=1',
+            }),
+            element('title', [text('mrtdown-data')]),
+            element('style', [
+              text(
+                `
 :root { font-family: system-ui, sans-serif; line-height: 1.5; }
 body { max-width: 40rem; margin: 2rem auto; padding: 0 1rem; color: #111; }
 h1 { font-size: 1.5rem; }
@@ -78,18 +117,31 @@ th, td { text-align: left; padding: 0.35rem 0.5rem; border-bottom: 1px solid #dd
 th { font-weight: 600; width: 40%; }
 pre { word-break: break-word; white-space: pre-wrap; display: inline; background-color: #f0f0f0; padding: 0.125rem 0.25rem; border-radius: 0.25rem; }
 footer { margin-top: 2rem; font-size: 0.875rem; color: #555; }
-a { color: #0b57d0; }
-    </style>
-  </head>
-  <body>
-    <h1>mrtdown-data</h1>
-    ${renderExportLinks(options)}
-    <a href="https://github.com/foldaway/mrtdown-data">GitHub repository</a>
-    ${tables}
-    <footer>
-      Generated at <time datetime="${escapeHtml(manifest.generatedAt)}">${escapeHtml(generatedAt.toUTCString())}</time> (UTC) on ${escapeHtml(process.platform)}/${escapeHtml(process.arch)}
-    </footer>
-  </body>
-</html>
-`;
+a { color: #0b57d0; }`.trim(),
+              ),
+            ]),
+          ]),
+          element('body', [
+            element('h1', [text('mrtdown-data')]),
+            buildExportLinks(options),
+            link(
+              'https://github.com/foldaway/mrtdown-data',
+              'GitHub repository',
+            ),
+            ...tables,
+            element('footer', [
+              text('Generated at '),
+              element('time', [text(generatedAt.toUTCString())], {
+                datetime: manifest.generatedAt,
+              }),
+              text(` (UTC) on ${process.platform}/${process.arch}`),
+            ]),
+          ]),
+        ],
+        { lang: 'en' },
+      ),
+    ],
+  };
+
+  return toHtml(root);
 }

--- a/packages/fs/src/pagesIndex.ts
+++ b/packages/fs/src/pagesIndex.ts
@@ -12,29 +12,13 @@ export type PagesRootIndexOptions = {
 
 type Child = Element['children'][number];
 
-function text(value: string): Child {
-  return { type: 'text', value };
-}
-
-function element(
-  tagName: string,
-  children: Child[] = [],
-  properties: Element['properties'] = {},
-): Element {
+function linkElement(href: string, label = href): Element {
   return {
     type: 'element',
-    tagName,
-    properties,
-    children,
+    tagName: 'a',
+    properties: { href },
+    children: [{ type: 'text', value: label }],
   };
-}
-
-function link(href: string, label = href): Element {
-  return element('a', [text(label)], { href });
-}
-
-function code(value: string): Element {
-  return element('pre', [text(value)]);
 }
 
 function buildDocument(
@@ -49,19 +33,45 @@ function buildDocument(
     type: 'root',
     children: [
       { type: 'doctype' },
-      element(
-        'html',
-        [
-          element('head', [
-            element('meta', [], { charset: 'utf-8' }),
-            element('meta', [], {
-              name: 'viewport',
-              content: 'width=device-width, initial-scale=1',
-            }),
-            element('title', [text('mrtdown-data')]),
-            element('style', [
-              text(
-                `
+      {
+        type: 'element',
+        tagName: 'html',
+        properties: { lang: 'en' },
+        children: [
+          {
+            type: 'element',
+            tagName: 'head',
+            properties: {},
+            children: [
+              {
+                type: 'element',
+                tagName: 'meta',
+                properties: { charset: 'utf-8' },
+                children: [],
+              },
+              {
+                type: 'element',
+                tagName: 'meta',
+                properties: {
+                  name: 'viewport',
+                  content: 'width=device-width, initial-scale=1',
+                },
+                children: [],
+              },
+              {
+                type: 'element',
+                tagName: 'title',
+                properties: {},
+                children: [{ type: 'text', value: 'mrtdown-data' }],
+              },
+              {
+                type: 'element',
+                tagName: 'style',
+                properties: {},
+                children: [
+                  {
+                    type: 'text',
+                    value: `
 :root { font-family: system-ui, sans-serif; line-height: 1.5; }
 body { max-width: 40rem; margin: 2rem auto; padding: 0 1rem; color: #111; }
 h1 { font-size: 1.5rem; }
@@ -71,77 +81,175 @@ th { font-weight: 600; width: 40%; }
 ${codeStyle}
 footer { margin-top: 2rem; font-size: 0.875rem; color: #555; }
 a { color: #0b57d0; }`.trim(),
-              ),
-            ]),
-          ]),
-          element('body', bodyChildren),
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            type: 'element',
+            tagName: 'body',
+            properties: {},
+            children: bodyChildren,
+          },
         ],
-        { lang: 'en' },
-      ),
+      },
     ],
   };
 }
 
 function buildExportLinks(options: PagesIndexOptions): Element {
   const children: Child[] = [
-    text(
-      'Static data index for Singapore MRT/LRT status and history. The machine-readable manifest is published as ',
-    ),
-    link('manifest.json'),
-    text('.'),
+    {
+      type: 'text',
+      value:
+        'Static data index for Singapore MRT/LRT status and history. The machine-readable manifest is published as ',
+    },
+    linkElement('manifest.json'),
+    { type: 'text', value: '.' },
   ];
 
   if (options.includeArchiveLinks) {
     children.push(
-      text(' The full data directory is also available as '),
-      link('archive.tar.gz'),
-      text(' (gzipped tarball) or '),
-      link('archive.zip'),
-      text('.'),
+      { type: 'text', value: ' The full data directory is also available as ' },
+      linkElement('archive.tar.gz'),
+      { type: 'text', value: ' (gzipped tarball) or ' },
+      linkElement('archive.zip'),
+      { type: 'text', value: '.' },
     );
   }
 
-  children.push(text(' Records are listed in alphabetical order by ID.'));
-  return element('p', children);
+  children.push({
+    type: 'text',
+    value: ' Records are listed in alphabetical order by ID.',
+  });
+
+  return {
+    type: 'element',
+    tagName: 'p',
+    properties: {},
+    children,
+  };
 }
 
 function buildFooter(
   generatedAt: Date,
   datetime = generatedAt.toISOString(),
 ): Element {
-  return element('footer', [
-    text('Generated at '),
-    element('time', [text(generatedAt.toUTCString())], {
-      datetime,
-    }),
-    text(` (UTC) on ${process.platform}/${process.arch}`),
-  ]);
+  return {
+    type: 'element',
+    tagName: 'footer',
+    properties: {},
+    children: [
+      { type: 'text', value: 'Generated at ' },
+      {
+        type: 'element',
+        tagName: 'time',
+        properties: { datetime },
+        children: [{ type: 'text', value: generatedAt.toUTCString() }],
+      },
+      {
+        type: 'text',
+        value: ` (UTC) on ${process.platform}/${process.arch}`,
+      },
+    ],
+  };
 }
 
 function buildTable(title: string, records: Record<string, string>): Element[] {
-  const rows = Object.entries(records).map(([id, path]) =>
-    element('tr', [element('td', [code(id)]), element('td', [link(path)])]),
-  );
+  const rows = Object.entries(records).map(([id, path]) => {
+    return {
+      type: 'element',
+      tagName: 'tr',
+      properties: {},
+      children: [
+        {
+          type: 'element',
+          tagName: 'td',
+          properties: {},
+          children: [
+            {
+              type: 'element',
+              tagName: 'pre',
+              properties: {},
+              children: [{ type: 'text', value: id }],
+            },
+          ],
+        },
+        {
+          type: 'element',
+          tagName: 'td',
+          properties: {},
+          children: [linkElement(path)],
+        },
+      ],
+    } satisfies Element;
+  });
 
   return [
-    element('h2', [text(title)]),
-    element('table', [
-      element('tbody', [
-        element('tr', [
-          element('th', [text('ID')]),
-          element('th', [text('Link')]),
-        ]),
-        ...rows,
-      ]),
-    ]),
+    {
+      type: 'element',
+      tagName: 'h2',
+      properties: {},
+      children: [{ type: 'text', value: title }],
+    },
+    {
+      type: 'element',
+      tagName: 'table',
+      properties: {},
+      children: [
+        {
+          type: 'element',
+          tagName: 'tbody',
+          properties: {},
+          children: [
+            {
+              type: 'element',
+              tagName: 'tr',
+              properties: {},
+              children: [
+                {
+                  type: 'element',
+                  tagName: 'th',
+                  properties: {},
+                  children: [{ type: 'text', value: 'ID' }],
+                },
+                {
+                  type: 'element',
+                  tagName: 'th',
+                  properties: {},
+                  children: [{ type: 'text', value: 'Link' }],
+                },
+              ],
+            },
+            ...rows,
+          ],
+        },
+      ],
+    },
   ];
 }
 
 function buildFileRow(href: string, description: string): Element {
-  return element('tr', [
-    element('td', [link(href)]),
-    element('td', [text(description)]),
-  ]);
+  return {
+    type: 'element',
+    tagName: 'tr',
+    properties: {},
+    children: [
+      {
+        type: 'element',
+        tagName: 'td',
+        properties: {},
+        children: [linkElement(href)],
+      },
+      {
+        type: 'element',
+        tagName: 'td',
+        properties: {},
+        children: [{ type: 'text', value: description }],
+      },
+    ],
+  };
 }
 
 export function renderPagesRootIndex(
@@ -151,43 +259,102 @@ export function renderPagesRootIndex(
 
   return toHtml(
     buildDocument([
-      element('h1', [text('mrtdown-data')]),
-      element('p', [
-        text(
-          'This split branch publishes only the deterministic fixture export. The canonical data export will be added after the target-layout data migration lands.',
-        ),
-      ]),
-      element('p', [
-        text('The fixture data index is available as '),
-        link('fixtures/'),
-        text('. Its machine-readable manifest is published as '),
-        link('fixtures/manifest.json'),
-        text('. The fixture directory is also available as '),
-        link('fixtures/archive.tar.gz'),
-        text(' (gzipped tarball) or '),
-        link('fixtures/archive.zip'),
-        text('.'),
-      ]),
-      link('https://github.com/foldaway/mrtdown-data', 'GitHub repository'),
-      element('h2', [text('Developer files')]),
-      element('table', [
-        element('tbody', [
-          element('tr', [
-            element('th', [text('File')]),
-            element('th', [text('Description')]),
-          ]),
-          buildFileRow('fixtures/', 'Fixture data index.'),
-          buildFileRow('fixtures/manifest.json', 'Fixture export manifest.'),
-          buildFileRow(
-            'fixtures/archive.tar.gz',
-            'Fixture export as a gzipped tarball.',
-          ),
-          buildFileRow(
-            'fixtures/archive.zip',
-            'Fixture export as a ZIP archive.',
-          ),
-        ]),
-      ]),
+      {
+        type: 'element',
+        tagName: 'h1',
+        properties: {},
+        children: [{ type: 'text', value: 'mrtdown-data' }],
+      },
+      {
+        type: 'element',
+        tagName: 'p',
+        properties: {},
+        children: [
+          {
+            type: 'text',
+            value:
+              'This split branch publishes only the deterministic fixture export. The canonical data export will be added after the target-layout data migration lands.',
+          },
+        ],
+      },
+      {
+        type: 'element',
+        tagName: 'p',
+        properties: {},
+        children: [
+          { type: 'text', value: 'The fixture data index is available as ' },
+          linkElement('fixtures/'),
+          {
+            type: 'text',
+            value: '. Its machine-readable manifest is published as ',
+          },
+          linkElement('fixtures/manifest.json'),
+          {
+            type: 'text',
+            value: '. The fixture directory is also available as ',
+          },
+          linkElement('fixtures/archive.tar.gz'),
+          { type: 'text', value: ' (gzipped tarball) or ' },
+          linkElement('fixtures/archive.zip'),
+          { type: 'text', value: '.' },
+        ],
+      },
+      linkElement(
+        'https://github.com/foldaway/mrtdown-data',
+        'GitHub repository',
+      ),
+      {
+        type: 'element',
+        tagName: 'h2',
+        properties: {},
+        children: [{ type: 'text', value: 'Developer files' }],
+      },
+      {
+        type: 'element',
+        tagName: 'table',
+        properties: {},
+        children: [
+          {
+            type: 'element',
+            tagName: 'tbody',
+            properties: {},
+            children: [
+              {
+                type: 'element',
+                tagName: 'tr',
+                properties: {},
+                children: [
+                  {
+                    type: 'element',
+                    tagName: 'th',
+                    properties: {},
+                    children: [{ type: 'text', value: 'File' }],
+                  },
+                  {
+                    type: 'element',
+                    tagName: 'th',
+                    properties: {},
+                    children: [{ type: 'text', value: 'Description' }],
+                  },
+                ],
+              },
+              buildFileRow('fixtures/', 'Fixture data index.'),
+              buildFileRow(
+                'fixtures/manifest.json',
+                'Fixture export manifest.',
+              ),
+              buildFileRow(
+                'fixtures/archive.tar.gz',
+                'Fixture export as a gzipped tarball.',
+              ),
+              buildFileRow(
+                'fixtures/archive.zip',
+                'Fixture export as a ZIP archive.',
+              ),
+            ],
+          },
+        ],
+      },
       buildFooter(generatedAt),
     ]),
   );
@@ -214,9 +381,17 @@ export function renderPagesIndex(
   return toHtml(
     buildDocument(
       [
-        element('h1', [text('mrtdown-data')]),
+        {
+          type: 'element',
+          tagName: 'h1',
+          properties: {},
+          children: [{ type: 'text', value: 'mrtdown-data' }],
+        },
         buildExportLinks(options),
-        link('https://github.com/foldaway/mrtdown-data', 'GitHub repository'),
+        linkElement(
+          'https://github.com/foldaway/mrtdown-data',
+          'GitHub repository',
+        ),
         ...tables,
         buildFooter(generatedAt, manifest.generatedAt),
       ],

--- a/packages/fs/src/pagesIndex.ts
+++ b/packages/fs/src/pagesIndex.ts
@@ -35,8 +35,13 @@ export function renderPagesIndex(manifest: Manifest): string {
   <body>
     <main>
       <h1>MRTDown data</h1>
+      <p>Static data export for MRTDown. During the split migration this early Pages export uses the deterministic fixture data set; the same manifest and archive contract will be used for canonical data after migration.</p>
       <p>Generated at <time datetime="${escapeHtml(manifest.generatedAt)}">${escapeHtml(manifest.generatedAt)}</time>.</p>
-      <p><a href="manifest.json">manifest.json</a></p>
+      <ul>
+        <li><a href="manifest.json">manifest.json</a></li>
+        <li><a href="archive.tar.gz">archive.tar.gz</a></li>
+        <li><a href="archive.zip">archive.zip</a></li>
+      </ul>
       <table>
         <tbody>
           ${rows}

--- a/packages/fs/src/pagesIndex.ts
+++ b/packages/fs/src/pagesIndex.ts
@@ -35,7 +35,7 @@ export function renderPagesIndex(manifest: Manifest): string {
   <body>
     <main>
       <h1>MRTDown data</h1>
-      <p>Static data export for MRTDown. During the split migration this early Pages export uses the deterministic fixture data set; the same manifest and archive contract will be used for canonical data after migration.</p>
+      <p>Static data export for MRTDown.</p>
       <p>Generated at <time datetime="${escapeHtml(manifest.generatedAt)}">${escapeHtml(manifest.generatedAt)}</time>.</p>
       <ul>
         <li><a href="manifest.json">manifest.json</a></li>

--- a/packages/fs/src/pagesIndex.ts
+++ b/packages/fs/src/pagesIndex.ts
@@ -11,54 +11,84 @@ const escapeHtml = (value: string): string =>
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;');
 
+function renderCode(value: string): string {
+  return `<pre>${escapeHtml(value)}</pre>`;
+}
+
+function renderExportLinks(options: PagesIndexOptions): string {
+  const archiveLinks = options.includeArchiveLinks
+    ? ` The full data directory is also available as <a href="archive.tar.gz">archive.tar.gz</a> (gzipped tarball) or <a href="archive.zip">archive.zip</a>.`
+    : '';
+
+  return `<p>Static data index for Singapore MRT/LRT status and history. The machine-readable manifest is published as <a href="manifest.json">manifest.json</a>.${archiveLinks} Records are listed in alphabetical order by ID.</p>`;
+}
+
+function renderTable(title: string, records: Record<string, string>): string {
+  const rows = Object.entries(records)
+    .map(
+      ([id, path]) => `<tr>
+          <td>${renderCode(id)}</td>
+          <td><a href="${escapeHtml(path)}">${escapeHtml(path)}</a></td>
+        </tr>`,
+    )
+    .join('');
+
+  return `<h2>${escapeHtml(title)}</h2>
+      <table>
+        <tbody>
+          <tr>
+            <th>ID</th>
+            <th>Link</th>
+          </tr>
+          ${rows}
+        </tbody>
+      </table>`;
+}
+
 export function renderPagesIndex(
   manifest: Manifest,
   options: PagesIndexOptions = {},
 ): string {
-  const counts = [
-    ['Lines', Object.keys(manifest.lines).length],
-    ['Stations', Object.keys(manifest.stations).length],
-    ['Services', Object.keys(manifest.services).length],
-    ['Operators', Object.keys(manifest.operators).length],
-    ['Towns', Object.keys(manifest.towns).length],
-    ['Landmarks', Object.keys(manifest.landmarks).length],
-    ['Issues', Object.keys(manifest.issues).length],
-  ];
-
-  const rows = counts
-    .map(
-      ([label, count]) =>
-        `<tr><th scope="row">${escapeHtml(String(label))}</th><td>${count}</td></tr>`,
-    )
+  const sections = [
+    ['Lines', manifest.lines],
+    ['Towns', manifest.towns],
+    ['Landmarks', manifest.landmarks],
+    ['Operators', manifest.operators],
+    ['Services', manifest.services],
+    ['Stations', manifest.stations],
+    ['Issues', manifest.issues],
+  ] satisfies Array<[string, Record<string, string>]>;
+  const tables = sections
+    .map(([title, records]) => renderTable(title, records))
     .join('');
-  const archiveLinks = options.includeArchiveLinks
-    ? `
-        <li><a href="archive.tar.gz">archive.tar.gz</a></li>
-        <li><a href="archive.zip">archive.zip</a></li>`
-    : '';
+  const generatedAt = new Date(manifest.generatedAt);
 
   return `<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>MRTDown data</title>
+    <title>mrtdown-data</title>
+    <style>
+:root { font-family: system-ui, sans-serif; line-height: 1.5; }
+body { max-width: 40rem; margin: 2rem auto; padding: 0 1rem; color: #111; }
+h1 { font-size: 1.5rem; }
+table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+th, td { text-align: left; padding: 0.35rem 0.5rem; border-bottom: 1px solid #ddd; }
+th { font-weight: 600; width: 40%; }
+pre { word-break: break-word; white-space: pre-wrap; display: inline; background-color: #f0f0f0; padding: 0.125rem 0.25rem; border-radius: 0.25rem; }
+footer { margin-top: 2rem; font-size: 0.875rem; color: #555; }
+a { color: #0b57d0; }
+    </style>
   </head>
   <body>
-    <main>
-      <h1>MRTDown data</h1>
-      <p>Static data export for MRTDown.</p>
-      <p>Generated at <time datetime="${escapeHtml(manifest.generatedAt)}">${escapeHtml(manifest.generatedAt)}</time>.</p>
-      <ul>
-        <li><a href="manifest.json">manifest.json</a></li>
-        ${archiveLinks}
-      </ul>
-      <table>
-        <tbody>
-          ${rows}
-        </tbody>
-      </table>
-    </main>
+    <h1>mrtdown-data</h1>
+    ${renderExportLinks(options)}
+    <a href="https://github.com/foldaway/mrtdown-data">GitHub repository</a>
+    ${tables}
+    <footer>
+      Generated at <time datetime="${escapeHtml(manifest.generatedAt)}">${escapeHtml(generatedAt.toUTCString())}</time> (UTC) on ${escapeHtml(process.platform)}/${escapeHtml(process.arch)}
+    </footer>
   </body>
 </html>
 `;

--- a/scripts/build-pages-artifact.mjs
+++ b/scripts/build-pages-artifact.mjs
@@ -1,11 +1,13 @@
 import { execFile } from 'node:child_process';
 import { cp, mkdir, rm, writeFile } from 'node:fs/promises';
-import { dirname, resolve } from 'node:path';
+import { dirname, isAbsolute, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const execFileAsync = promisify(execFile);
+const generatedArchivePattern = /[\\/]archive\.(?:tar\.gz|zip)$/;
+const generatedIndexPattern = /[\\/](?:manifest\.json|index\.html)$/;
 
 function usage() {
   return `Usage:
@@ -65,7 +67,7 @@ async function createArchives(outDir) {
   await mkdir(archiveRoot, { recursive: true });
   await cp(outDir, resolve(archiveRoot, 'data'), {
     recursive: true,
-    filter: (source) => !/\/archive\.(?:tar\.gz|zip)$/.test(source),
+    filter: (source) => !generatedArchivePattern.test(source),
   });
 
   await execFileAsync('tar', [
@@ -81,11 +83,16 @@ async function createArchives(outDir) {
   await rm(archiveRoot, { recursive: true, force: true });
 }
 
+function isSubpath(parent, candidate) {
+  const path = relative(parent, candidate);
+  return path !== '' && !path.startsWith('..') && !isAbsolute(path);
+}
+
 function assertOutputPath(dataDir, outDir) {
   if (
     outDir === dataDir ||
-    dataDir.startsWith(`${outDir}/`) ||
-    outDir.startsWith(`${dataDir}/`)
+    isSubpath(outDir, dataDir) ||
+    isSubpath(dataDir, outDir)
   ) {
     throw new Error('--out-dir must not overlap the data root');
   }
@@ -107,7 +114,7 @@ async function buildDataExport(sourceDataDir, exportDir, fsPackage) {
   await mkdir(exportDir, { recursive: true });
   await cp(sourceDataDir, exportDir, {
     recursive: true,
-    filter: (source) => !/\/(?:manifest\.json|index\.html)$/.test(source),
+    filter: (source) => !generatedIndexPattern.test(source),
   });
 
   const manifest = await fsPackage.buildManifest(exportDir);

--- a/scripts/build-pages-artifact.mjs
+++ b/scripts/build-pages-artifact.mjs
@@ -3,7 +3,6 @@ import { cp, mkdir, rm, writeFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
-import { toHtml } from 'hast-util-to-html';
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const execFileAsync = promisify(execFile);
@@ -92,106 +91,6 @@ function assertOutputPath(dataDir, outDir) {
   }
 }
 
-function renderRootIndex() {
-  const generatedAt = new Date();
-  const text = (value) => ({ type: 'text', value });
-  const element = (tagName, children = [], properties = {}) => ({
-    type: 'element',
-    tagName,
-    properties,
-    children,
-  });
-  const link = (href, label = href) => element('a', [text(label)], { href });
-  const fileRow = (href, description) =>
-    element('tr', [
-      element('td', [link(href)]),
-      element('td', [text(description)]),
-    ]);
-
-  return toHtml({
-    type: 'root',
-    children: [
-      { type: 'doctype' },
-      element(
-        'html',
-        [
-          element('head', [
-            element('meta', [], { charset: 'utf-8' }),
-            element('meta', [], {
-              name: 'viewport',
-              content: 'width=device-width, initial-scale=1',
-            }),
-            element('title', [text('mrtdown-data')]),
-            element('style', [
-              text(
-                `
-:root { font-family: system-ui, sans-serif; line-height: 1.5; }
-body { max-width: 40rem; margin: 2rem auto; padding: 0 1rem; color: #111; }
-h1 { font-size: 1.5rem; }
-table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
-th, td { text-align: left; padding: 0.35rem 0.5rem; border-bottom: 1px solid #ddd; }
-th { font-weight: 600; width: 40%; }
-footer { margin-top: 2rem; font-size: 0.875rem; color: #555; }
-a { color: #0b57d0; }`.trim(),
-              ),
-            ]),
-          ]),
-          element('body', [
-            element('h1', [text('mrtdown-data')]),
-            element('p', [
-              text(
-                'This split branch publishes only the deterministic fixture export. The canonical data export will be added after the target-layout data migration lands.',
-              ),
-            ]),
-            element('p', [
-              text('The fixture data index is available as '),
-              link('fixtures/'),
-              text('. Its machine-readable manifest is published as '),
-              link('fixtures/manifest.json'),
-              text('. The fixture directory is also available as '),
-              link('fixtures/archive.tar.gz'),
-              text(' (gzipped tarball) or '),
-              link('fixtures/archive.zip'),
-              text('.'),
-            ]),
-            link(
-              'https://github.com/foldaway/mrtdown-data',
-              'GitHub repository',
-            ),
-            element('h2', [text('Developer files')]),
-            element('table', [
-              element('tbody', [
-                element('tr', [
-                  element('th', [text('File')]),
-                  element('th', [text('Description')]),
-                ]),
-                fileRow('fixtures/', 'Fixture data index.'),
-                fileRow('fixtures/manifest.json', 'Fixture export manifest.'),
-                fileRow(
-                  'fixtures/archive.tar.gz',
-                  'Fixture export as a gzipped tarball.',
-                ),
-                fileRow(
-                  'fixtures/archive.zip',
-                  'Fixture export as a ZIP archive.',
-                ),
-              ]),
-            ]),
-            element('footer', [
-              text('Generated at '),
-              element('time', [text(generatedAt.toUTCString())], {
-                datetime: generatedAt.toISOString(),
-              }),
-              text(` (UTC) on ${process.platform}/${process.arch}`),
-            ]),
-          ]),
-        ],
-        { lang: 'en' },
-      ),
-    ],
-  });
-}
-
 async function buildDataExport(sourceDataDir, exportDir, fsPackage) {
   assertOutputPath(sourceDataDir, exportDir);
 
@@ -230,7 +129,10 @@ async function main() {
   await rm(options.outDir, { recursive: true, force: true });
   await mkdir(options.outDir, { recursive: true });
   await writeFile(resolve(options.outDir, '.nojekyll'), '');
-  await writeFile(resolve(options.outDir, 'index.html'), renderRootIndex());
+  await writeFile(
+    resolve(options.outDir, 'index.html'),
+    fsPackage.renderPagesRootIndex(),
+  );
   await buildDataExport(
     options.dataDir,
     resolve(options.outDir, 'fixtures'),

--- a/scripts/build-pages-artifact.mjs
+++ b/scripts/build-pages-artifact.mjs
@@ -92,24 +92,58 @@ function assertOutputPath(dataDir, outDir) {
 }
 
 function renderRootIndex() {
+  const generatedAt = new Date();
+
   return `<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>MRTDown data</title>
+    <title>mrtdown-data</title>
+    <style>
+:root { font-family: system-ui, sans-serif; line-height: 1.5; }
+body { max-width: 40rem; margin: 2rem auto; padding: 0 1rem; color: #111; }
+h1 { font-size: 1.5rem; }
+table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+th, td { text-align: left; padding: 0.35rem 0.5rem; border-bottom: 1px solid #ddd; }
+th { font-weight: 600; width: 40%; }
+footer { margin-top: 2rem; font-size: 0.875rem; color: #555; }
+a { color: #0b57d0; }
+    </style>
   </head>
   <body>
-    <main>
-      <h1>MRTDown data</h1>
-      <p>This split branch publishes only the deterministic fixture export. The canonical data export will be added after the target-layout data migration lands.</p>
-      <ul>
-        <li><a href="fixtures/">fixtures/</a></li>
-        <li><a href="fixtures/manifest.json">fixtures/manifest.json</a></li>
-        <li><a href="fixtures/archive.tar.gz">fixtures/archive.tar.gz</a></li>
-        <li><a href="fixtures/archive.zip">fixtures/archive.zip</a></li>
-      </ul>
-    </main>
+    <h1>mrtdown-data</h1>
+    <p>This split branch publishes only the deterministic fixture export. The canonical data export will be added after the target-layout data migration lands.</p>
+    <p>The fixture data index is available as <a href="fixtures/">fixtures/</a>. Its machine-readable manifest is published as <a href="fixtures/manifest.json">fixtures/manifest.json</a>. The fixture directory is also available as <a href="fixtures/archive.tar.gz">fixtures/archive.tar.gz</a> (gzipped tarball) or <a href="fixtures/archive.zip">fixtures/archive.zip</a>.</p>
+    <a href="https://github.com/foldaway/mrtdown-data">GitHub repository</a>
+    <h2>Developer files</h2>
+    <table>
+      <tbody>
+        <tr>
+          <th>File</th>
+          <th>Description</th>
+        </tr>
+        <tr>
+          <td><a href="fixtures/">fixtures/</a></td>
+          <td>Fixture data index.</td>
+        </tr>
+        <tr>
+          <td><a href="fixtures/manifest.json">fixtures/manifest.json</a></td>
+          <td>Fixture export manifest.</td>
+        </tr>
+        <tr>
+          <td><a href="fixtures/archive.tar.gz">fixtures/archive.tar.gz</a></td>
+          <td>Fixture export as a gzipped tarball.</td>
+        </tr>
+        <tr>
+          <td><a href="fixtures/archive.zip">fixtures/archive.zip</a></td>
+          <td>Fixture export as a ZIP archive.</td>
+        </tr>
+      </tbody>
+    </table>
+    <footer>
+      Generated at <time datetime="${generatedAt.toISOString()}">${generatedAt.toUTCString()}</time> (UTC) on ${process.platform}/${process.arch}
+    </footer>
   </body>
 </html>
 `;

--- a/scripts/build-pages-artifact.mjs
+++ b/scripts/build-pages-artifact.mjs
@@ -3,6 +3,7 @@ import { cp, mkdir, rm, writeFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
+import { toHtml } from 'hast-util-to-html';
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const execFileAsync = promisify(execFile);
@@ -93,14 +94,37 @@ function assertOutputPath(dataDir, outDir) {
 
 function renderRootIndex() {
   const generatedAt = new Date();
+  const text = (value) => ({ type: 'text', value });
+  const element = (tagName, children = [], properties = {}) => ({
+    type: 'element',
+    tagName,
+    properties,
+    children,
+  });
+  const link = (href, label = href) => element('a', [text(label)], { href });
+  const fileRow = (href, description) =>
+    element('tr', [
+      element('td', [link(href)]),
+      element('td', [text(description)]),
+    ]);
 
-  return `<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>mrtdown-data</title>
-    <style>
+  return toHtml({
+    type: 'root',
+    children: [
+      { type: 'doctype' },
+      element(
+        'html',
+        [
+          element('head', [
+            element('meta', [], { charset: 'utf-8' }),
+            element('meta', [], {
+              name: 'viewport',
+              content: 'width=device-width, initial-scale=1',
+            }),
+            element('title', [text('mrtdown-data')]),
+            element('style', [
+              text(
+                `
 :root { font-family: system-ui, sans-serif; line-height: 1.5; }
 body { max-width: 40rem; margin: 2rem auto; padding: 0 1rem; color: #111; }
 h1 { font-size: 1.5rem; }
@@ -108,45 +132,64 @@ table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
 th, td { text-align: left; padding: 0.35rem 0.5rem; border-bottom: 1px solid #ddd; }
 th { font-weight: 600; width: 40%; }
 footer { margin-top: 2rem; font-size: 0.875rem; color: #555; }
-a { color: #0b57d0; }
-    </style>
-  </head>
-  <body>
-    <h1>mrtdown-data</h1>
-    <p>This split branch publishes only the deterministic fixture export. The canonical data export will be added after the target-layout data migration lands.</p>
-    <p>The fixture data index is available as <a href="fixtures/">fixtures/</a>. Its machine-readable manifest is published as <a href="fixtures/manifest.json">fixtures/manifest.json</a>. The fixture directory is also available as <a href="fixtures/archive.tar.gz">fixtures/archive.tar.gz</a> (gzipped tarball) or <a href="fixtures/archive.zip">fixtures/archive.zip</a>.</p>
-    <a href="https://github.com/foldaway/mrtdown-data">GitHub repository</a>
-    <h2>Developer files</h2>
-    <table>
-      <tbody>
-        <tr>
-          <th>File</th>
-          <th>Description</th>
-        </tr>
-        <tr>
-          <td><a href="fixtures/">fixtures/</a></td>
-          <td>Fixture data index.</td>
-        </tr>
-        <tr>
-          <td><a href="fixtures/manifest.json">fixtures/manifest.json</a></td>
-          <td>Fixture export manifest.</td>
-        </tr>
-        <tr>
-          <td><a href="fixtures/archive.tar.gz">fixtures/archive.tar.gz</a></td>
-          <td>Fixture export as a gzipped tarball.</td>
-        </tr>
-        <tr>
-          <td><a href="fixtures/archive.zip">fixtures/archive.zip</a></td>
-          <td>Fixture export as a ZIP archive.</td>
-        </tr>
-      </tbody>
-    </table>
-    <footer>
-      Generated at <time datetime="${generatedAt.toISOString()}">${generatedAt.toUTCString()}</time> (UTC) on ${process.platform}/${process.arch}
-    </footer>
-  </body>
-</html>
-`;
+a { color: #0b57d0; }`.trim(),
+              ),
+            ]),
+          ]),
+          element('body', [
+            element('h1', [text('mrtdown-data')]),
+            element('p', [
+              text(
+                'This split branch publishes only the deterministic fixture export. The canonical data export will be added after the target-layout data migration lands.',
+              ),
+            ]),
+            element('p', [
+              text('The fixture data index is available as '),
+              link('fixtures/'),
+              text('. Its machine-readable manifest is published as '),
+              link('fixtures/manifest.json'),
+              text('. The fixture directory is also available as '),
+              link('fixtures/archive.tar.gz'),
+              text(' (gzipped tarball) or '),
+              link('fixtures/archive.zip'),
+              text('.'),
+            ]),
+            link(
+              'https://github.com/foldaway/mrtdown-data',
+              'GitHub repository',
+            ),
+            element('h2', [text('Developer files')]),
+            element('table', [
+              element('tbody', [
+                element('tr', [
+                  element('th', [text('File')]),
+                  element('th', [text('Description')]),
+                ]),
+                fileRow('fixtures/', 'Fixture data index.'),
+                fileRow('fixtures/manifest.json', 'Fixture export manifest.'),
+                fileRow(
+                  'fixtures/archive.tar.gz',
+                  'Fixture export as a gzipped tarball.',
+                ),
+                fileRow(
+                  'fixtures/archive.zip',
+                  'Fixture export as a ZIP archive.',
+                ),
+              ]),
+            ]),
+            element('footer', [
+              text('Generated at '),
+              element('time', [text(generatedAt.toUTCString())], {
+                datetime: generatedAt.toISOString(),
+              }),
+              text(` (UTC) on ${process.platform}/${process.arch}`),
+            ]),
+          ]),
+        ],
+        { lang: 'en' },
+      ),
+    ],
+  });
 }
 
 async function buildDataExport(sourceDataDir, exportDir, fsPackage) {

--- a/scripts/build-pages-artifact.mjs
+++ b/scripts/build-pages-artifact.mjs
@@ -91,6 +91,56 @@ function assertOutputPath(dataDir, outDir) {
   }
 }
 
+function renderRootIndex() {
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>MRTDown data</title>
+  </head>
+  <body>
+    <main>
+      <h1>MRTDown data</h1>
+      <p>This split branch publishes only the deterministic fixture export. The canonical data export will be added after the target-layout data migration lands.</p>
+      <ul>
+        <li><a href="fixtures/">fixtures/</a></li>
+        <li><a href="fixtures/manifest.json">fixtures/manifest.json</a></li>
+        <li><a href="fixtures/archive.tar.gz">fixtures/archive.tar.gz</a></li>
+        <li><a href="fixtures/archive.zip">fixtures/archive.zip</a></li>
+      </ul>
+    </main>
+  </body>
+</html>
+`;
+}
+
+async function buildDataExport(sourceDataDir, exportDir, fsPackage) {
+  assertOutputPath(sourceDataDir, exportDir);
+
+  const validation = await fsPackage.validateDataRoot(sourceDataDir);
+  if (!validation.ok) {
+    throw new Error(validation.errors.join('\n'));
+  }
+
+  await mkdir(exportDir, { recursive: true });
+  await cp(sourceDataDir, exportDir, {
+    recursive: true,
+    filter: (source) => !/\/(?:manifest\.json|index\.html)$/.test(source),
+  });
+
+  const manifest = await fsPackage.buildManifest(exportDir);
+  await writeFile(
+    resolve(exportDir, 'manifest.json'),
+    `${JSON.stringify(manifest, null, 2)}\n`,
+  );
+  await writeFile(
+    resolve(exportDir, 'index.html'),
+    fsPackage.renderPagesIndex(manifest),
+  );
+  await createArchives(exportDir);
+}
+
 async function main() {
   const options = parseArgs(process.argv.slice(2));
   if (options.help) {
@@ -98,33 +148,17 @@ async function main() {
     return;
   }
 
-  assertOutputPath(options.dataDir, options.outDir);
-
-  const { buildManifest, renderPagesIndex, validateDataRoot } =
-    await loadFsPackage();
-  const validation = await validateDataRoot(options.dataDir);
-  if (!validation.ok) {
-    throw new Error(validation.errors.join('\n'));
-  }
+  const fsPackage = await loadFsPackage();
 
   await rm(options.outDir, { recursive: true, force: true });
   await mkdir(options.outDir, { recursive: true });
-  await cp(options.dataDir, options.outDir, {
-    recursive: true,
-    filter: (source) => !/\/(?:manifest\.json|index\.html)$/.test(source),
-  });
-
-  const manifest = await buildManifest(options.outDir);
-  await writeFile(
-    resolve(options.outDir, 'manifest.json'),
-    `${JSON.stringify(manifest, null, 2)}\n`,
-  );
-  await writeFile(
-    resolve(options.outDir, 'index.html'),
-    renderPagesIndex(manifest),
-  );
   await writeFile(resolve(options.outDir, '.nojekyll'), '');
-  await createArchives(options.outDir);
+  await writeFile(resolve(options.outDir, 'index.html'), renderRootIndex());
+  await buildDataExport(
+    options.dataDir,
+    resolve(options.outDir, 'fixtures'),
+    fsPackage,
+  );
 
   console.log(`Built Pages artifact at ${options.outDir}`);
 }

--- a/scripts/build-pages-artifact.mjs
+++ b/scripts/build-pages-artifact.mjs
@@ -136,7 +136,7 @@ async function buildDataExport(sourceDataDir, exportDir, fsPackage) {
   );
   await writeFile(
     resolve(exportDir, 'index.html'),
-    fsPackage.renderPagesIndex(manifest),
+    fsPackage.renderPagesIndex(manifest, { includeArchiveLinks: true }),
   );
   await createArchives(exportDir);
 }

--- a/scripts/build-pages-artifact.mjs
+++ b/scripts/build-pages-artifact.mjs
@@ -91,6 +91,11 @@ function assertOutputPath(dataDir, outDir) {
   }
 }
 
+function assertArtifactPaths(options) {
+  assertOutputPath(options.dataDir, options.outDir);
+  assertOutputPath(options.dataDir, resolve(options.outDir, 'fixtures'));
+}
+
 async function buildDataExport(sourceDataDir, exportDir, fsPackage) {
   assertOutputPath(sourceDataDir, exportDir);
 
@@ -123,6 +128,7 @@ async function main() {
     console.log(usage().trimEnd());
     return;
   }
+  assertArtifactPaths(options);
 
   const fsPackage = await loadFsPackage();
 

--- a/scripts/build-pages-artifact.mjs
+++ b/scripts/build-pages-artifact.mjs
@@ -1,0 +1,135 @@
+import { execFile } from 'node:child_process';
+import { cp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const execFileAsync = promisify(execFile);
+
+function usage() {
+  return `Usage:
+  node scripts/build-pages-artifact.mjs [--data-dir <path>] [--out-dir <path>]
+
+Defaults:
+  --data-dir fixtures/data
+  --out-dir pages-dist
+`;
+}
+
+function parseArgs(argv) {
+  const options = {
+    dataDir: resolve(repoRoot, 'fixtures/data'),
+    outDir: resolve(repoRoot, 'pages-dist'),
+  };
+  const args = [...argv];
+
+  while (args.length > 0) {
+    const arg = args.shift();
+    if (arg === '--help' || arg === '-h') {
+      return { ...options, help: true };
+    }
+
+    if (arg !== '--data-dir' && arg !== '--out-dir') {
+      throw new Error(`Unknown option: ${arg}`);
+    }
+
+    const value = args.shift();
+    if (!value || value.startsWith('--')) {
+      throw new Error(`${arg} requires a value`);
+    }
+
+    if (arg === '--data-dir') {
+      options.dataDir = resolve(repoRoot, value);
+    } else {
+      options.outDir = resolve(repoRoot, value);
+    }
+  }
+
+  return options;
+}
+
+async function loadFsPackage() {
+  try {
+    return await import('../packages/fs/dist/index.js');
+  } catch (error) {
+    throw new Error(
+      `Unable to load built @mrtdown/fs package. Run "npm run build:fs" first. ${error}`,
+    );
+  }
+}
+
+async function createArchives(outDir) {
+  const archiveRoot = resolve(outDir, '..', 'pages-archive-root');
+  await rm(archiveRoot, { recursive: true, force: true });
+  await mkdir(archiveRoot, { recursive: true });
+  await cp(outDir, resolve(archiveRoot, 'data'), {
+    recursive: true,
+    filter: (source) => !/\/archive\.(?:tar\.gz|zip)$/.test(source),
+  });
+
+  await execFileAsync('tar', [
+    '-czf',
+    resolve(outDir, 'archive.tar.gz'),
+    '-C',
+    archiveRoot,
+    'data',
+  ]);
+  await execFileAsync('zip', ['-rq', resolve(outDir, 'archive.zip'), 'data'], {
+    cwd: archiveRoot,
+  });
+  await rm(archiveRoot, { recursive: true, force: true });
+}
+
+function assertOutputPath(dataDir, outDir) {
+  if (
+    outDir === dataDir ||
+    dataDir.startsWith(`${outDir}/`) ||
+    outDir.startsWith(`${dataDir}/`)
+  ) {
+    throw new Error('--out-dir must not overlap the data root');
+  }
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    console.log(usage().trimEnd());
+    return;
+  }
+
+  assertOutputPath(options.dataDir, options.outDir);
+
+  const { buildManifest, renderPagesIndex, validateDataRoot } =
+    await loadFsPackage();
+  const validation = await validateDataRoot(options.dataDir);
+  if (!validation.ok) {
+    throw new Error(validation.errors.join('\n'));
+  }
+
+  await rm(options.outDir, { recursive: true, force: true });
+  await mkdir(options.outDir, { recursive: true });
+  await cp(options.dataDir, options.outDir, {
+    recursive: true,
+    filter: (source) => !/\/(?:manifest\.json|index\.html)$/.test(source),
+  });
+
+  const manifest = await buildManifest(options.outDir);
+  await writeFile(
+    resolve(options.outDir, 'manifest.json'),
+    `${JSON.stringify(manifest, null, 2)}\n`,
+  );
+  await writeFile(
+    resolve(options.outDir, 'index.html'),
+    renderPagesIndex(manifest),
+  );
+  await writeFile(resolve(options.outDir, '.nojekyll'), '');
+  await createArchives(options.outDir);
+
+  console.log(`Built Pages artifact at ${options.outDir}`);
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary

- Moves the data-overhaul split plan so GitHub Pages publishing is the next step before triage.
- Adds a `pages:build` command that builds a Pages artifact from `fixtures/data` during this early split step.
- Adds the GitHub Pages deployment workflow, generated artifact ignore rule, README contract notes, and index links for `manifest.json` plus archive downloads.

## Notes

This intentionally keeps npm package publishing out of scope. Until canonical target-layout `data/` lands in a later split PR, the Pages artifact publishes the deterministic fixture data set while preserving the same static contract expected by downstream consumers.

## Validation

- `npm run check`
- `npm run pages:build`
- `npm run test:fs`
- `npm run test:cli`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automated GitHub Pages deployment on main branch updates and pull request previews

* **Documentation**
  * Documented static pages export workflow and artifact handling
  * Added Conventional Commits requirement for contribution guidelines

* **Chores**
  * Added GitHub Actions workflows for Pages deployment and preview builds
  * Added build scripts for static pages artifact generation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/foldaway/mrtdown-data/pull/226?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->