### PR TITLE
fix: use trusted publishing for packages

### DIFF
--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -58,6 +58,4 @@ jobs:
           title: 'chore: version packages'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
## Summary

- Remove `NPM_TOKEN` and `NODE_AUTH_TOKEN` from the Changesets publish step.
- Let npm publish use GitHub Actions OIDC/trusted publishing, matching the package publishing approach from the data-overhaul branch.
- Leave the branch without a changeset so `changesets/action@v1` takes its no-changesets path and publishes the already-versioned, unpublished `@mrtdown/core` and `@mrtdown/fs` packages.

## Root Cause

The merged package publish run reached `changeset publish`, but npm returned `E404 Not Found ... or you do not have permission` for both `@mrtdown/core@2.0.0-alpha.23` and `@mrtdown/fs@2.0.0-alpha.23`. The workflow was passing `secrets.NPM_TOKEN`, so npm attempted token-based publish with a token that does not have publish rights for the `@mrtdown` scope. The repository already has `id-token: write`, so the workflow should use npm trusted publishing instead.

## Validation

- `npm run check`
- `npm run changeset -- status --since origin/main`