### PR TITLE
feat(fixtures): add defunct service edge case

### DIFF
--- a/fixtures/data/line/SLL.json
+++ b/fixtures/data/line/SLL.json
@@ -11,7 +11,8 @@
   "startedAt": "2025-12-31",
   "serviceIds": [
     "SLL_MAIN_N",
-    "SLL_MAIN_S"
+    "SLL_MAIN_S",
+    "SLL_BRANCH_C"
   ],
   "operators": [
     {

--- a/fixtures/data/service/SLL_BRANCH_C.json
+++ b/fixtures/data/service/SLL_BRANCH_C.json
@@ -1,0 +1,43 @@
+{
+  "id": "SLL_BRANCH_C",
+  "name": {
+    "en-SG": "Seletar Line (Service C, Defunct)",
+    "zh-Hans": "新柔线（C线，已停运）",
+    "ms": "Laluan Seletar (Perkhidmatan C, Ditamatkan)",
+    "ta": "செலெட்டா வழி (சேவை C, நிறுத்தப்பட்டது)"
+  },
+  "lineId": "SLL",
+  "revisions": [
+    {
+      "id": "r_initial_and_final",
+      "startAt": "2025-12-31",
+      "endAt": "2026-03-31",
+      "path": {
+        "stations": [
+          {
+            "stationId": "SER",
+            "displayCode": "SL5"
+          },
+          {
+            "stationId": "SKG",
+            "displayCode": "SL4"
+          },
+          {
+            "stationId": "FNV",
+            "displayCode": "SL3"
+          }
+        ]
+      },
+      "operatingHours": {
+        "weekdays": {
+          "start": "06:00",
+          "end": "23:00"
+        },
+        "weekends": {
+          "start": "06:30",
+          "end": "23:00"
+        }
+      }
+    }
+  ]
+}

--- a/packages/fs/src/index.test.ts
+++ b/packages/fs/src/index.test.ts
@@ -147,7 +147,7 @@ describe('@mrtdown/fs', () => {
         landmark: 36,
         line: 2,
         operator: 2,
-        service: 4,
+        service: 5,
         station: 17,
         town: 14,
       },


### PR DESCRIPTION
### Motivation

- Improve fixture coverage for lifecycle edge cases by adding a retired/defunct service pattern (analogous to real-world Service C examples) so validation and downstream tests exercise closed revisions.

### Description

- Add `fixtures/data/service/SLL_BRANCH_C.json` containing a service with a `revisions` entry that has a non-null `endAt` to model a defunct service. 
- Update `fixtures/data/line/SLL.json` to include `SLL_BRANCH_C` in `serviceIds` so the defunct service is part of the normal fixture graph.
- The new service includes a short station `path` and explicit `operatingHours` to exercise schedule and path validation logic.

### Testing

- Ran `npm run fixtures:validate` which builds the CLI and validates fixtures and completed successfully. 
- The validation run enumerated fixture counts and returned no errors for the updated fixtures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e98f97ab88320850adc5d39013863)