### PR TITLE
feat(fixtures): add unopened line fixture data

### DIFF
--- a/fixtures/data/line/UPL.json
+++ b/fixtures/data/line/UPL.json
@@ -1,0 +1,32 @@
+{
+  "id": "UPL",
+  "name": {
+    "en-SG": "Upperline",
+    "zh-Hans": "上环线",
+    "ms": "Laluan Upperline",
+    "ta": "அப்பர்லைன் வழி"
+  },
+  "type": "mrt.high",
+  "color": "#6f2dbd",
+  "startedAt": "2027-06-01",
+  "serviceIds": [
+    "UPL_MAIN"
+  ],
+  "operators": [
+    {
+      "operatorId": "SMRT_TRAINS",
+      "startedAt": "2027-06-01",
+      "endedAt": null
+    }
+  ],
+  "operatingHours": {
+    "weekdays": {
+      "start": "05:30",
+      "end": "00:00"
+    },
+    "weekends": {
+      "start": "05:30",
+      "end": "00:00"
+    }
+  }
+}

--- a/fixtures/data/service/UPL_MAIN.json
+++ b/fixtures/data/service/UPL_MAIN.json
@@ -1,0 +1,35 @@
+{
+  "id": "UPL_MAIN",
+  "name": {
+    "en-SG": "Upperline",
+    "zh-Hans": "上环线",
+    "ms": "Laluan Upperline",
+    "ta": "அப்பர்லைன் வழி"
+  },
+  "lineId": "UPL",
+  "revisions": [
+    {
+      "id": "r_initial",
+      "startAt": "2027-06-01",
+      "endAt": null,
+      "path": {
+        "stations": [
+          {
+            "stationId": "UPN",
+            "displayCode": "UP1"
+          }
+        ]
+      },
+      "operatingHours": {
+        "weekdays": {
+          "start": "05:30",
+          "end": "00:00"
+        },
+        "weekends": {
+          "start": "05:30",
+          "end": "00:00"
+        }
+      }
+    }
+  ]
+}

--- a/fixtures/data/station/UPN.json
+++ b/fixtures/data/station/UPN.json
@@ -1,0 +1,26 @@
+{
+  "id": "UPN",
+  "name": {
+    "en-SG": "Upper Novena",
+    "zh-Hans": "上诺维娜",
+    "ms": "Upper Novena",
+    "ta": "அப்பர் நோவேனா"
+  },
+  "geo": {
+    "latitude": 1.3501,
+    "longitude": 103.8452
+  },
+  "stationCodes": [
+    {
+      "lineId": "UPL",
+      "code": "UP1",
+      "startedAt": "2027-06-01T00:00:00Z",
+      "endedAt": null,
+      "structureType": "underground"
+    }
+  ],
+  "landmarkIds": [
+    "thomson-nature-park"
+  ],
+  "townId": "novena"
+}

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -32,7 +32,7 @@ describe('@mrtdown/cli', () => {
     expect(stderr).toEqual([]);
     expect(JSON.parse(stdout[0] as string)).toMatchObject({
       issue: 2,
-      station: 17,
+      station: 18,
     });
   });
 

--- a/packages/fs/src/index.test.ts
+++ b/packages/fs/src/index.test.ts
@@ -126,6 +126,7 @@ describe('@mrtdown/fs', () => {
     await expect(listEntityIds(fixtureDataDir, 'line')).resolves.toEqual([
       'SLL',
       'TGL',
+      'UPL',
     ]);
 
     const bundle = await readIssueBundle(
@@ -145,10 +146,10 @@ describe('@mrtdown/fs', () => {
       checked: {
         issue: 2,
         landmark: 36,
-        line: 2,
+        line: 3,
         operator: 2,
-        service: 5,
-        station: 17,
+        service: 6,
+        station: 18,
         town: 14,
       },
     });


### PR DESCRIPTION
### Motivation
- Provide a deterministic fixture for an unopened/future line so code that reasons about future `startedAt` periods and unopened services can be tested.
- Keep the fixture set representative of both active and not-yet-open lines for `@mrtdown/fs` validation and manifest generation scenarios.

### Description
- Added new fixture files `fixtures/data/line/UPL.json`, `fixtures/data/service/UPL_MAIN.json`, and `fixtures/data/station/UPN.json` describing the unopened "Upperline" with `startedAt` set to `2027-06-01` and operator `SMRT_TRAINS`.
- The `UPL_MAIN` service revision references a single-station path using station `UPN` and the station includes a station code with `startedAt` `2027-06-01T00:00:00Z`.
- Updated `packages/fs/src/index.test.ts` to include `UPL` in the `listEntityIds` expectation and to bump validated entity counts for `line`, `service`, and `station` to reflect the new fixtures.

### Testing
- Attempted `npm run test:fs -- --runInBand` failed due to `turbo run` treating `--runInBand` as an unexpected argument.
- Ran `npm run test:fs` which built `@mrtdown/core` and executed the `@mrtdown/fs` test suite, and the `@mrtdown/fs` tests completed successfully with all tests passing (34 tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ef22042a08320a88d85691c64f3e8)