### PR TITLE
feat: update CCL data for stage 6 opening

### DIFF
--- a/data/station/CTM.json
+++ b/data/station/CTM.json
@@ -14,7 +14,7 @@
     {
       "lineId": "CCL",
       "code": "CC31",
-      "startedAt": "2026-12-31T00:00:00Z",
+      "startedAt": "2026-07-12T00:00:00Z",
       "endedAt": null,
       "structureType": "underground"
     }

--- a/data/station/KPL.json
+++ b/data/station/KPL.json
@@ -14,7 +14,7 @@
     {
       "lineId": "CCL",
       "code": "CC30",
-      "startedAt": "2026-12-31T00:00:00Z",
+      "startedAt": "2026-07-12T00:00:00Z",
       "endedAt": null,
       "structureType": "underground"
     }

--- a/data/station/PER.json
+++ b/data/station/PER.json
@@ -14,7 +14,7 @@
     {
       "lineId": "CCL",
       "code": "CC32",
-      "startedAt": "2026-12-31T00:00:00Z",
+      "startedAt": "2026-07-12T00:00:00Z",
       "endedAt": null,
       "structureType": "underground"
     }


### PR DESCRIPTION
## Summary

Updates the canonical station data for the Circle Line Stage 6 opening on 12 July 2026.

- Sets Keppel station code CC30 active from 2026-07-12.
- Sets Cantonment station code CC31 active from 2026-07-12.
- Sets Prince Edward Road station code CC32 active from 2026-07-12.

## Notes

The opening date is based on LTA's May 2026 CCL6 opening announcement and current public CCL6 project details. This PR intentionally leaves CCL service revisions and service patterns unchanged until there is an official post confirming post-opening operations.

## Validation

- `npm run data:validate`
- `npm run check`