### PR TITLE
feat(workflows): support JSON workflow_dispatch payload for ingest

### DIFF
--- a/.github/workflows/ingest.yml
+++ b/.github/workflows/ingest.yml
@@ -3,12 +3,19 @@ name: Ingest Content via Webhook
 on:
   repository_dispatch:
     types: [ingest]
+  workflow_dispatch:
+    inputs:
+      payload:
+        description: "JSON payload forwarded to ingest:webhook as MESSAGE"
+        required: false
+        type: string
+        default: "{}"
 
 concurrency:
   group: ingestion
 
 jobs:
-  checkRss:
+  ingestWebhook:
     runs-on: "ubuntu-latest"
     steps:
       - uses: actions/checkout@v4
@@ -31,10 +38,28 @@ jobs:
           node-version: 24
           cache: npm
       - run: npm ci
+      - name: Build ingest payload
+        id: ingest-payload
+        env:
+          DISPATCH_PAYLOAD: ${{ toJSON(github.event.client_payload) }}
+          MANUAL_PAYLOAD: ${{ inputs.payload }}
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            PAYLOAD="$MANUAL_PAYLOAD"
+          else
+            PAYLOAD="$DISPATCH_PAYLOAD"
+          fi
+
+          echo "$PAYLOAD" | jq -e . >/dev/null
+          {
+            echo 'message<<EOF'
+            echo "$PAYLOAD"
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
       - run: npm run ingest:webhook
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          MESSAGE: ${{ toJSON(github.event.client_payload) }}
+          MESSAGE: ${{ steps.ingest-payload.outputs.message }}
       - run: npm run data:validate
       - name: Check for changes
         id: make-changes

--- a/.github/workflows/ingest.yml
+++ b/.github/workflows/ingest.yml
@@ -7,9 +7,8 @@ on:
     inputs:
       payload:
         description: "JSON payload forwarded to ingest:webhook as MESSAGE"
-        required: false
+        required: true
         type: string
-        default: "{}"
 
 concurrency:
   group: ingestion


### PR DESCRIPTION
### Motivation
- Allow maintainers to manually trigger the ingest workflow from the Actions UI with an explicit JSON payload. 
- Preserve existing `repository_dispatch` behavior while making the job name more accurate and removing an obsolete `checkRss` identifier.

### Description
- Add `workflow_dispatch` trigger with a `payload` string input (default `{}`) to `.github/workflows/ingest.yml` so manual runs can supply JSON.
- Rename the job id from `checkRss` to `ingestWebhook` to reflect current behavior.
- Add a `Build ingest payload` step that selects `inputs.payload` for `workflow_dispatch` and `github.event.client_payload` for `repository_dispatch`, validates the JSON with `jq`, and emits it as a `message` output.
- Update the `MESSAGE` environment variable for `npm run ingest:webhook` to use the prepared `steps.ingest-payload.outputs.message` value.

### Testing
- Ran repository searches with `rg --files .github/workflows` and `rg -n "checkRss|workflow_dispatch|ingest|rss" .github/workflows` to locate and confirm affected workflow files, which succeeded.
- Inspected the updated workflow with `sed -n '1,220p' .github/workflows/ingest.yml` and `nl -ba .github/workflows/ingest.yml` to verify the new `workflow_dispatch` input and payload-building step, which succeeded.
- Verified the workflow diff for the intended additions and job rename with `git diff -- .github/workflows/ingest.yml`, which showed the expected changes.
- Created PR metadata via the repository helper to capture this change, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ff6901c2883209440af29e83d108d)