### PR TITLE
fix: improve ingest triage issue matching

### DIFF
--- a/.github/workflows/llm-evals.yml
+++ b/.github/workflows/llm-evals.yml
@@ -47,8 +47,9 @@ jobs:
 
       - name: Run changed LLM function evals
         if: ${{ env.CAN_RUN_EVALS == 'true' && github.event_name == 'pull_request' }}
-        run: node scripts/run-changed-llm-evals.mjs "origin/${{ github.base_ref }}...HEAD"
+        run: node scripts/run-changed-llm-evals.mjs "origin/${BASE_REF}...HEAD"
         env:
+          BASE_REF: ${{ github.base_ref }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 
       - name: Run changed LLM function evals

--- a/.github/workflows/llm-evals.yml
+++ b/.github/workflows/llm-evals.yml
@@ -42,6 +42,9 @@ jobs:
       - run: npm ci
         if: ${{ env.CAN_RUN_EVALS == 'true' }}
 
+      - run: npm run build:packages
+        if: ${{ env.CAN_RUN_EVALS == 'true' }}
+
       - name: Run changed LLM function evals
         if: ${{ env.CAN_RUN_EVALS == 'true' && github.event_name == 'pull_request' }}
         run: node scripts/run-changed-llm-evals.mjs "origin/${{ github.base_ref }}...HEAD"

--- a/.github/workflows/llm-evals.yml
+++ b/.github/workflows/llm-evals.yml
@@ -1,0 +1,55 @@
+name: LLM Evals
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/llm-evals.yml'
+      - 'package*.json'
+      - 'packages/triage/src/llm/functions/**'
+      - 'scripts/run-changed-llm-evals.mjs'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  changed-function-evals:
+    runs-on: ubuntu-latest
+    env:
+      CAN_RUN_EVALS: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository }}
+    steps:
+      - name: Skip fork pull request
+        if: ${{ env.CAN_RUN_EVALS != 'true' }}
+        run: echo "Skipping LLM evals for fork pull request because repository secrets are unavailable."
+
+      - uses: actions/checkout@v4
+        if: ${{ env.CAN_RUN_EVALS == 'true' && github.event_name == 'pull_request' }}
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - uses: actions/checkout@v4
+        if: ${{ env.CAN_RUN_EVALS == 'true' && github.event_name == 'workflow_dispatch' }}
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        if: ${{ env.CAN_RUN_EVALS == 'true' }}
+        with:
+          node-version: 24
+          cache: npm
+
+      - run: npm ci
+        if: ${{ env.CAN_RUN_EVALS == 'true' }}
+
+      - name: Run changed LLM function evals
+        if: ${{ env.CAN_RUN_EVALS == 'true' && github.event_name == 'pull_request' }}
+        run: node scripts/run-changed-llm-evals.mjs "origin/${{ github.base_ref }}...HEAD"
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+
+      - name: Run changed LLM function evals
+        if: ${{ env.CAN_RUN_EVALS == 'true' && github.event_name == 'workflow_dispatch' }}
+        run: node scripts/run-changed-llm-evals.mjs "origin/main...HEAD"
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "test:fs": "turbo run test --filter=@mrtdown/fs",
     "test:triage": "turbo run test --filter=@mrtdown/triage",
     "test:eval": "npm --workspace @mrtdown/triage run test:eval",
+    "test:eval:changed": "node scripts/run-changed-llm-evals.mjs",
     "test:cli": "turbo run test --filter=@mrtdown/cli",
     "data:validate": "npm run build:cli && node packages/cli/dist/index.js --data-dir data validate",
     "fixtures:validate": "npm run build:cli && node packages/cli/dist/index.js --data-dir fixtures/data validate",

--- a/packages/triage/src/llm/functions/triageNewEvidence/index.ts
+++ b/packages/triage/src/llm/functions/triageNewEvidence/index.ts
@@ -10,10 +10,11 @@ import { assert } from '../../../util/assert.js';
 import { getOpenAiClient } from '../../client.js';
 import type { ToolRegistry } from '../../common/tool.js';
 import { buildSystemPrompt } from './prompt.js';
+import { FindIssuesByDateRangeTool } from './tools/FindIssuesByDateRangeTool.js';
 import { FindIssuesTool } from './tools/FindIssuesTool.js';
 import { GetIssueTool } from './tools/GetIssueTool.js';
 
-const TOOL_CALL_LIMIT = 5;
+const TOOL_CALL_LIMIT = 8;
 
 const ResponseSchema = z.object({
   result: z.discriminatedUnion('kind', [
@@ -46,9 +47,11 @@ export async function triageNewEvidence(params: TriageNewEvidenceParams) {
   assert(evidenceTs.isValid, `Invalid date: ${params.newEvidence.ts}`);
 
   const findIssuesTool = new FindIssuesTool(params.repo);
+  const findIssuesByDateRangeTool = new FindIssuesByDateRangeTool(params.repo);
   const getIssueTool = new GetIssueTool(params.repo);
   const toolRegistry: ToolRegistry = {
     [findIssuesTool.name]: findIssuesTool,
+    [findIssuesByDateRangeTool.name]: findIssuesByDateRangeTool,
     [getIssueTool.name]: getIssueTool,
   };
 

--- a/packages/triage/src/llm/functions/triageNewEvidence/prompt.ts
+++ b/packages/triage/src/llm/functions/triageNewEvidence/prompt.ts
@@ -6,8 +6,8 @@ Your task: Triage the new evidence into an existing issue or a new issue.
 
 ISSUE TYPES:
 - disruption: Service disruptions (e.g. train delays, line faults, operational failures)
-- maintenance: Planned maintenance works (e.g. system upgrades, infrastructure maintenance)
-- infra: Infrastructure issues (e.g. station lift outages, platform door faults, facility breakdowns)
+- maintenance: Planned service works that affect operations (e.g. early closures, reduced service windows, changes to service availability)
+- infra: Infrastructure asset or facility issues (e.g. station lift outages, platform door faults or renewal, escalator repairs, facility breakdowns)
 
 DECISION PROCESS:
 1. Extract key information from evidence: affected service/line, location, issue type, time window
@@ -55,11 +55,12 @@ DISRUPTIONS:
 MAINTENANCE:
 - Service-level planned works that affect operating hours or service availability
 - Examples: early line closures, reduced service windows, system upgrades affecting all trains
-- NOT about specific facility repairs (those are infra)
+- NOT about specific facility or asset repairs/renewals (those are infra)
 
 INFRASTRUCTURE:
 - Specific facility or asset breakdowns that need repair or renewal
 - Examples: lift outages, platform screen door faults/renewal, escalator repairs, door malfunctions
+- If evidence mentions a facility or asset class such as platform screen doors, lifts, escalators, station equipment, or similar infrastructure, classify as infra even when the work is planned or scheduled.
 - Facility-specific: affects particular station and facility type (e.g. lift at Station X)
 - Can be scheduled (renewal works) or unplanned (breakdowns)
 - Link to existing issue if same station, same facility, service still active

--- a/packages/triage/src/llm/functions/triageNewEvidence/prompt.ts
+++ b/packages/triage/src/llm/functions/triageNewEvidence/prompt.ts
@@ -12,9 +12,17 @@ ISSUE TYPES:
 DECISION PROCESS:
 1. Extract key information from evidence: affected service/line, location, issue type, time window
 2. Use findIssues tool to search for related issues by service name or line
-3. Use getIssue tool to review each candidate issue's scope, periods, and effects
-4. Compare evidence location and timing with existing issue scope
-5. Return appropriate classification with clear reasoning
+3. Use findIssuesByDateRange when evidence mentions a specific incident date/time, when the article timestamp is later than the incident, or when service/location details are incomplete
+4. Use getIssue tool to review each candidate issue's scope, periods, and effects
+5. Compare evidence location and timing with existing issue scope
+6. Return appropriate classification with clear reasoning
+
+TOOL USE GUIDANCE:
+- findIssues(query): search by service names, line names/IDs, station names/IDs, source text, or issue title.
+- findIssuesByDateRange(startAt, endAt): search by issue date, evidence timestamps, and active impact periods. Use this before creating a new issue when evidence references a prior incident date such as "on May 18" or only gives generic wording like "fell in front of an oncoming train".
+- getIssue(issueId): inspect full evidence and current impact state for a candidate.
+- Once findIssues returns a plausible candidate, call getIssue for that candidate. Do not spend more than two findIssues calls on the same evidence before inspecting a candidate.
+- For follow-up news articles about investigations, deaths, causes, incident response, safety measures, lawsuits, or later official comments, search around the incident date and attach to the existing operational issue when the event matches.
 
 CLASSIFICATION RULES:
 
@@ -39,9 +47,10 @@ SPECIFIC GUIDANCE BY ISSUE TYPE:
 DISRUPTIONS:
 - Location specificity is CRITICAL - different stations or segments are separate incidents
 - Same service line alone is NOT sufficient for matching
-- Must have EXACT geographic overlap: if evidence mentions different station pair, it's a new issue
+- Must have EXACT geographic overlap: if evidence mentions a different station pair, a wider segment, or a segment extending beyond an existing issue's scope, it's a new issue
 - Examples: "fault between A and B" overlaps with existing issue only if existing covers A-B segment
 - A fault "between B and C" on the same line is a different incident, even if it shares one endpoint station
+- Example: existing issue "between Bukit Panjang and King Albert Park" does NOT match new evidence "between King Albert Park and Rochor"; return a new disruption issue.
 
 MAINTENANCE:
 - Service-level planned works that affect operating hours or service availability

--- a/packages/triage/src/llm/functions/triageNewEvidence/prompt.ts
+++ b/packages/triage/src/llm/functions/triageNewEvidence/prompt.ts
@@ -28,6 +28,8 @@ CLASSIFICATION RULES:
 
 Part of Existing Issue:
 - Evidence must match the service/line AND have geographic overlap (stations or segments)
+- For disruptions, geographic overlap means the existing issue already covers every station/segment named by the new evidence
+- Sharing only one endpoint station with an existing segment is NOT geographic overlap
 - Temporal proximity matters: evidence should occur during or immediately adjacent to the issue's period
 - Multiple separate incidents on the same service are separate issues (not continuous scope expansion)
 
@@ -47,9 +49,12 @@ SPECIFIC GUIDANCE BY ISSUE TYPE:
 DISRUPTIONS:
 - Location specificity is CRITICAL - different stations or segments are separate incidents
 - Same service line alone is NOT sufficient for matching
+- Same station mention alone is NOT sufficient for matching
 - Must have EXACT geographic overlap: if evidence mentions a different station pair, a wider segment, or a segment extending beyond an existing issue's scope, it's a new issue
+- Return part-of-existing-issue only when the existing issue covers the entire disruption segment in the new evidence
 - Examples: "fault between A and B" overlaps with existing issue only if existing covers A-B segment
 - A fault "between B and C" on the same line is a different incident, even if it shares one endpoint station
+- A fault "between A and C" is a different incident from an existing issue "between A and B" because the new evidence extends beyond the existing scope
 - Example: existing issue "between Bukit Panjang and King Albert Park" does NOT match new evidence "between King Albert Park and Rochor"; return a new disruption issue.
 
 MAINTENANCE:

--- a/packages/triage/src/llm/functions/triageNewEvidence/tools/FindIssuesByDateRangeTool.test.ts
+++ b/packages/triage/src/llm/functions/triageNewEvidence/tools/FindIssuesByDateRangeTool.test.ts
@@ -26,6 +26,22 @@ describe('FindIssuesByDateRangeTool', () => {
     expect(output).not.toContain('2027-01-15-erl-signal-fault');
   });
 
+  test('treats an exact end datetime as part of the search window', async () => {
+    const repo = new MRTDownRepository({
+      store: new FileStore(FIXTURE_DATA_DIR),
+    });
+    const tool = new FindIssuesByDateRangeTool(repo);
+
+    const output = await tool.runner({
+      startAt: '2026-01-01T07:00:00+08:00',
+      endAt: '2026-01-01T07:00:00+08:00',
+    });
+
+    expect(output).toContain('2026-01-01-btl-train-fault');
+    expect(output).toContain('evidence timestamp');
+    expect(output).toContain('2026-01-01T07:00:00+08:00');
+  });
+
   test('reports when no issues overlap the date range', async () => {
     const repo = new MRTDownRepository({
       store: new FileStore(FIXTURE_DATA_DIR),

--- a/packages/triage/src/llm/functions/triageNewEvidence/tools/FindIssuesByDateRangeTool.test.ts
+++ b/packages/triage/src/llm/functions/triageNewEvidence/tools/FindIssuesByDateRangeTool.test.ts
@@ -1,0 +1,42 @@
+import { resolve } from 'node:path';
+import { FileStore, MRTDownRepository } from '@mrtdown/fs';
+import { describe, expect, test } from 'vitest';
+import { FindIssuesByDateRangeTool } from './FindIssuesByDateRangeTool.js';
+
+const FIXTURE_DATA_DIR = resolve(
+  import.meta.dirname,
+  '../../../../../../../fixtures/data',
+);
+
+describe('FindIssuesByDateRangeTool', () => {
+  test('finds issues by issue date, evidence timestamp, and active periods', async () => {
+    const repo = new MRTDownRepository({
+      store: new FileStore(FIXTURE_DATA_DIR),
+    });
+    const tool = new FindIssuesByDateRangeTool(repo);
+
+    const output = await tool.runner({
+      startAt: '2026-01-01',
+      endAt: '2026-01-01',
+    });
+
+    expect(output).toContain('2026-01-01-btl-train-fault');
+    expect(output).toContain('Bukit Timah Line Train Fault');
+    expect(output).toContain('BTL\\_MAIN\\_E');
+    expect(output).not.toContain('2027-01-15-erl-signal-fault');
+  });
+
+  test('reports when no issues overlap the date range', async () => {
+    const repo = new MRTDownRepository({
+      store: new FileStore(FIXTURE_DATA_DIR),
+    });
+    const tool = new FindIssuesByDateRangeTool(repo);
+
+    await expect(
+      tool.runner({
+        startAt: '2025-01-01',
+        endAt: '2025-01-01',
+      }),
+    ).resolves.toBe('No issues found in date range.');
+  });
+});

--- a/packages/triage/src/llm/functions/triageNewEvidence/tools/FindIssuesByDateRangeTool.test.ts
+++ b/packages/triage/src/llm/functions/triageNewEvidence/tools/FindIssuesByDateRangeTool.test.ts
@@ -42,6 +42,28 @@ describe('FindIssuesByDateRangeTool', () => {
     expect(output).toContain('2026-01-01T07:00:00+08:00');
   });
 
+  test('matches recurring periods only during scheduled occurrences', async () => {
+    const repo = new MRTDownRepository({
+      store: new FileStore(FIXTURE_DATA_DIR),
+    });
+    const tool = new FindIssuesByDateRangeTool(repo);
+
+    const scheduledOutput = await tool.runner({
+      startAt: '2027-08-22T09:00:00+08:00',
+      endAt: '2027-08-22T09:00:00+08:00',
+    });
+    const betweenOccurrencesOutput = await tool.runner({
+      startAt: '2027-08-25T09:00:00+08:00',
+      endAt: '2027-08-25T09:00:00+08:00',
+    });
+
+    expect(scheduledOutput).toContain('2027-08-21-btl-weekend-late-openings');
+    expect(scheduledOutput).toContain('active period');
+    expect(betweenOccurrencesOutput).not.toContain(
+      '2027-08-21-btl-weekend-late-openings',
+    );
+  });
+
   test('reports when no issues overlap the date range', async () => {
     const repo = new MRTDownRepository({
       store: new FileStore(FIXTURE_DATA_DIR),

--- a/packages/triage/src/llm/functions/triageNewEvidence/tools/FindIssuesByDateRangeTool.ts
+++ b/packages/triage/src/llm/functions/triageNewEvidence/tools/FindIssuesByDateRangeTool.ts
@@ -120,7 +120,7 @@ function parseSearchWindow(params: FindIssuesByDateRangeToolParameters) {
     );
   }
 
-  return Interval.fromDateTimes(start, end);
+  return inclusiveInterval(start, end);
 }
 
 function parseBoundary(value: string, boundary: 'start' | 'end'): DateTime {
@@ -184,7 +184,7 @@ function issueDateOverlapsWindow(issueId: string, window: Interval): boolean {
   }
 
   return window.overlaps(
-    Interval.fromDateTimes(issueDate.startOf('day'), issueDate.endOf('day')),
+    inclusiveInterval(issueDate.startOf('day'), issueDate.endOf('day')),
   );
 }
 
@@ -198,11 +198,15 @@ function periodOverlapsWindow(period: Period, window: Interval): boolean {
     return false;
   }
 
-  return window.overlaps(Interval.fromDateTimes(start, end));
+  return window.overlaps(inclusiveInterval(start, end));
 }
 
 function dateTimeOverlapsWindow(dateTime: DateTime, window: Interval): boolean {
   return dateTime.isValid && window.contains(dateTime);
+}
+
+function inclusiveInterval(start: DateTime, end: DateTime): Interval {
+  return Interval.fromDateTimes(start, end.plus({ milliseconds: 1 }));
 }
 
 function formatMatchingEvidence(bundle: IssueBundle, window: Interval): string {

--- a/packages/triage/src/llm/functions/triageNewEvidence/tools/FindIssuesByDateRangeTool.ts
+++ b/packages/triage/src/llm/functions/triageNewEvidence/tools/FindIssuesByDateRangeTool.ts
@@ -1,4 +1,10 @@
-import type { IssueBundle, Period, ServiceScope } from '@mrtdown/core';
+import {
+  type IssueBundle,
+  normalizeRecurringPeriod,
+  type Period,
+  type PeriodFixed,
+  type ServiceScope,
+} from '@mrtdown/core';
 import type { MRTDownRepository } from '@mrtdown/fs';
 import { DateTime, Interval } from 'luxon';
 import type { Table } from 'mdast';
@@ -189,6 +195,17 @@ function issueDateOverlapsWindow(issueId: string, window: Interval): boolean {
 }
 
 function periodOverlapsWindow(period: Period, window: Interval): boolean {
+  if (period.kind === 'recurring') {
+    return recurringPeriodOverlapsWindow(period, window);
+  }
+
+  return fixedPeriodOverlapsWindow(period, window);
+}
+
+function fixedPeriodOverlapsWindow(
+  period: PeriodFixed,
+  window: Interval,
+): boolean {
   const start = DateTime.fromISO(period.startAt, { setZone: true });
   const end = DateTime.fromISO(period.endAt ?? window.end?.toISO() ?? '', {
     setZone: true,
@@ -199,6 +216,26 @@ function periodOverlapsWindow(period: Period, window: Interval): boolean {
   }
 
   return window.overlaps(inclusiveInterval(start, end));
+}
+
+function recurringPeriodOverlapsWindow(
+  period: Extract<Period, { kind: 'recurring' }>,
+  window: Interval,
+): boolean {
+  const start = DateTime.fromISO(period.startAt, { setZone: true });
+  const end = DateTime.fromISO(period.endAt, { setZone: true });
+
+  if (
+    !start.isValid ||
+    !end.isValid ||
+    !window.overlaps(inclusiveInterval(start, end))
+  ) {
+    return false;
+  }
+
+  return normalizeRecurringPeriod(period).some((fixedPeriod) =>
+    fixedPeriodOverlapsWindow(fixedPeriod, window),
+  );
 }
 
 function dateTimeOverlapsWindow(dateTime: DateTime, window: Interval): boolean {

--- a/packages/triage/src/llm/functions/triageNewEvidence/tools/FindIssuesByDateRangeTool.ts
+++ b/packages/triage/src/llm/functions/triageNewEvidence/tools/FindIssuesByDateRangeTool.ts
@@ -1,0 +1,281 @@
+import type { IssueBundle, Period, ServiceScope } from '@mrtdown/core';
+import type { MRTDownRepository } from '@mrtdown/fs';
+import { DateTime, Interval } from 'luxon';
+import type { Table } from 'mdast';
+import { gfmToMarkdown } from 'mdast-util-gfm';
+import { toMarkdown } from 'mdast-util-to-markdown';
+import z from 'zod';
+import { deriveCurrentState } from '../../../../helpers/deriveCurrentState.js';
+import { Tool } from '../../../common/tool.js';
+
+const FindIssuesByDateRangeToolParametersSchema = z.object({
+  startAt: z
+    .string()
+    .describe('Inclusive start of the search window as ISO date or datetime.'),
+  endAt: z
+    .string()
+    .describe('Inclusive end of the search window as ISO date or datetime.'),
+});
+type FindIssuesByDateRangeToolParameters = z.infer<
+  typeof FindIssuesByDateRangeToolParametersSchema
+>;
+
+const MAX_RESULTS = 25;
+
+type IssueDateRangeMatch = {
+  issue: IssueBundle;
+  score: number;
+  reasons: string[];
+};
+
+export class FindIssuesByDateRangeTool extends Tool<FindIssuesByDateRangeToolParameters> {
+  public name = 'findIssuesByDateRange';
+  public description =
+    'Find issues whose issue date, evidence timestamps, or impact periods overlap a date range';
+  private readonly repo: MRTDownRepository;
+
+  constructor(repo: MRTDownRepository) {
+    super();
+    this.repo = repo;
+  }
+
+  public get paramsSchema(): { [key: string]: unknown } {
+    return z.toJSONSchema(FindIssuesByDateRangeToolParametersSchema);
+  }
+
+  public parseParams(params: unknown): FindIssuesByDateRangeToolParameters {
+    return FindIssuesByDateRangeToolParametersSchema.parse(params);
+  }
+
+  public async runner(
+    params: FindIssuesByDateRangeToolParameters,
+  ): Promise<string> {
+    console.log(
+      '[findIssuesByDateRange] Calling tool with parameters:',
+      params,
+    );
+
+    const searchWindow = parseSearchWindow(params);
+    const matches = this.repo.issues
+      .list()
+      .map((issue) => getIssueDateRangeMatch(issue, searchWindow))
+      .filter((match): match is IssueDateRangeMatch => match != null)
+      .sort(
+        (a, b) =>
+          b.score - a.score || b.issue.issue.id.localeCompare(a.issue.issue.id),
+      )
+      .slice(0, MAX_RESULTS);
+
+    if (matches.length === 0) {
+      return 'No issues found in date range.';
+    }
+
+    const issueTable: Table = {
+      type: 'table',
+      children: [
+        {
+          type: 'tableRow',
+          children: [
+            tableCell('Issue ID'),
+            tableCell('Issue Title'),
+            tableCell('Issue Date'),
+            tableCell('Match'),
+            tableCell('Matching Evidence'),
+            tableCell('Current Scope'),
+          ],
+        },
+      ],
+    };
+
+    for (const match of matches) {
+      issueTable.children.push({
+        type: 'tableRow',
+        children: [
+          tableCell(match.issue.issue.id),
+          tableCell(match.issue.issue.title['en-SG']),
+          tableCell(match.issue.issue.id.slice(0, 10)),
+          tableCell(match.reasons.join(', ')),
+          tableCell(formatMatchingEvidence(match.issue, searchWindow)),
+          tableCell(formatCurrentScope(match.issue)),
+        ],
+      });
+    }
+
+    const output = toMarkdown(issueTable, {
+      extensions: [gfmToMarkdown()],
+    });
+    console.log(`[findIssuesByDateRange] Response output:\n${output}`);
+
+    return output;
+  }
+}
+
+function parseSearchWindow(params: FindIssuesByDateRangeToolParameters) {
+  const start = parseBoundary(params.startAt, 'start');
+  const end = parseBoundary(params.endAt, 'end');
+
+  if (end < start) {
+    throw new Error(
+      `Invalid date range: ${params.startAt} after ${params.endAt}`,
+    );
+  }
+
+  return Interval.fromDateTimes(start, end);
+}
+
+function parseBoundary(value: string, boundary: 'start' | 'end'): DateTime {
+  const parsed = DateTime.fromISO(value, {
+    setZone: true,
+    zone: 'Asia/Singapore',
+  }).setZone('Asia/Singapore');
+
+  if (!parsed.isValid) {
+    throw new Error(`Invalid ISO date or datetime: ${value}`);
+  }
+
+  if (/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    return boundary === 'start' ? parsed.startOf('day') : parsed.endOf('day');
+  }
+
+  return parsed;
+}
+
+function getIssueDateRangeMatch(
+  bundle: IssueBundle,
+  window: Interval,
+): IssueDateRangeMatch | null {
+  let score = 0;
+  const reasons: string[] = [];
+
+  if (issueDateOverlapsWindow(bundle.issue.id, window)) {
+    score += 5;
+    reasons.push('issue date');
+  }
+
+  const evidenceMatches = bundle.evidence.filter((evidence) =>
+    dateTimeOverlapsWindow(
+      DateTime.fromISO(evidence.ts, { setZone: true }),
+      window,
+    ),
+  );
+  if (evidenceMatches.length > 0) {
+    score += Math.min(evidenceMatches.length, 3) * 3;
+    reasons.push('evidence timestamp');
+  }
+
+  const periodMatches = bundle.impactEvents
+    .filter((event) => event.type === 'periods.set')
+    .flatMap((event) => event.periods)
+    .filter((period) => periodOverlapsWindow(period, window));
+  if (periodMatches.length > 0) {
+    score += Math.min(periodMatches.length, 3);
+    reasons.push('active period');
+  }
+
+  return score > 0 ? { issue: bundle, score, reasons } : null;
+}
+
+function issueDateOverlapsWindow(issueId: string, window: Interval): boolean {
+  const issueDate = DateTime.fromISO(issueId.slice(0, 10), {
+    zone: 'Asia/Singapore',
+  });
+  if (!issueDate.isValid) {
+    return false;
+  }
+
+  return window.overlaps(
+    Interval.fromDateTimes(issueDate.startOf('day'), issueDate.endOf('day')),
+  );
+}
+
+function periodOverlapsWindow(period: Period, window: Interval): boolean {
+  const start = DateTime.fromISO(period.startAt, { setZone: true });
+  const end = DateTime.fromISO(period.endAt ?? window.end?.toISO() ?? '', {
+    setZone: true,
+  });
+
+  if (!start.isValid || !end.isValid) {
+    return false;
+  }
+
+  return window.overlaps(Interval.fromDateTimes(start, end));
+}
+
+function dateTimeOverlapsWindow(dateTime: DateTime, window: Interval): boolean {
+  return dateTime.isValid && window.contains(dateTime);
+}
+
+function formatMatchingEvidence(bundle: IssueBundle, window: Interval): string {
+  const matchingEvidence = bundle.evidence
+    .filter((evidence) =>
+      dateTimeOverlapsWindow(
+        DateTime.fromISO(evidence.ts, { setZone: true }),
+        window,
+      ),
+    )
+    .slice(0, 2)
+    .map((evidence) => `${evidence.ts}: ${truncate(evidence.text, 120)}`);
+
+  return matchingEvidence.length > 0 ? matchingEvidence.join('\n') : 'none';
+}
+
+function formatCurrentScope(bundle: IssueBundle): string {
+  const state = deriveCurrentState(bundle);
+  const services = Object.values(state.services).map((service) => {
+    const scopes =
+      service.scopes.length > 0
+        ? service.scopes.map(formatScope).join(', ')
+        : 'scope unknown';
+    const periods =
+      service.periods.length > 0
+        ? service.periods.map(formatPeriod).join(', ')
+        : 'period unknown';
+    const causes =
+      service.causes.length > 0 ? ` causes=${service.causes.join(',')}` : '';
+    return `${service.serviceId} ${service.effect?.kind ?? 'effect unknown'} ${scopes} ${periods}${causes}`;
+  });
+
+  if (services.length > 0) {
+    return services.slice(0, 3).join('\n');
+  }
+
+  const facilities = Object.values(state.facilities).map(
+    (facility) =>
+      `${facility.stationId} ${facility.lineId ?? 'line unknown'} ${facility.kind} ${facility.effect?.kind ?? 'effect unknown'}`,
+  );
+
+  return facilities.length > 0 ? facilities.slice(0, 3).join('\n') : 'none';
+}
+
+function formatScope(scope: ServiceScope): string {
+  switch (scope.type) {
+    case 'service.whole':
+      return 'whole service';
+    case 'service.segment':
+      return `${scope.fromStationId}-${scope.toStationId}`;
+    case 'service.point':
+      return scope.stationId;
+  }
+}
+
+function formatPeriod(period: Period): string {
+  switch (period.kind) {
+    case 'fixed':
+      return `${period.startAt} to ${period.endAt ?? 'ongoing'}`;
+    case 'recurring':
+      return `${period.startAt} to ${period.endAt} recurring ${period.frequency}`;
+  }
+}
+
+function tableCell(value: string) {
+  return {
+    type: 'tableCell' as const,
+    children: [{ type: 'text' as const, value }],
+  };
+}
+
+function truncate(value: string, maxLength: number): string {
+  return value.length <= maxLength
+    ? value
+    : `${value.slice(0, maxLength - 3)}...`;
+}

--- a/packages/triage/src/util/ingestContent/helpers/formatContentTextForIngest.test.ts
+++ b/packages/triage/src/util/ingestContent/helpers/formatContentTextForIngest.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from 'vitest';
+import { formatContentTextForIngest } from './formatContentTextForIngest.js';
+
+describe('formatContentTextForIngest', () => {
+  test('keeps news titles alongside summaries', () => {
+    expect(
+      formatContentTextForIngest({
+        source: 'news-website',
+        title: 'LTA investigating safety measures after death on LRT track',
+        summary: 'A man reportedly fell in front of an oncoming train.',
+        url: 'https://example.com/article',
+        createdAt: '2026-05-22T14:07:24+08:00',
+      }),
+    ).toBe(
+      'Title: LTA investigating safety measures after death on LRT track\n\nSummary: A man reportedly fell in front of an oncoming train.',
+    );
+  });
+
+  test('uses news titles when summaries are empty', () => {
+    expect(
+      formatContentTextForIngest({
+        source: 'news-website',
+        title: 'Bukit Panjang LRT service resumes after track intrusion',
+        summary: '',
+        url: 'https://example.com/article',
+        createdAt: '2026-05-18T07:11:00+08:00',
+      }),
+    ).toBe('Title: Bukit Panjang LRT service resumes after track intrusion');
+  });
+
+  test('keeps reddit titles alongside body text', () => {
+    expect(
+      formatContentTextForIngest({
+        source: 'reddit',
+        subreddit: 'singapore',
+        title: 'Major delay on Bukit Panjang LRT',
+        selftext: 'No service between Senja and Petir.',
+        url: 'https://example.com/reddit',
+        createdAt: '2026-05-18T06:52:25+08:00',
+        thumbnailUrl: null,
+      }),
+    ).toBe(
+      'Title: Major delay on Bukit Panjang LRT\n\nBody: No service between Senja and Petir.',
+    );
+  });
+});

--- a/packages/triage/src/util/ingestContent/helpers/formatContentTextForIngest.ts
+++ b/packages/triage/src/util/ingestContent/helpers/formatContentTextForIngest.ts
@@ -1,0 +1,38 @@
+import type { IngestContent } from '../types.js';
+
+export function formatContentTextForIngest(content: IngestContent): string {
+  switch (content.source) {
+    case 'reddit': {
+      return formatFields([
+        ['Title', content.title],
+        ['Body', content.selftext],
+      ]);
+    }
+    case 'news-website': {
+      return formatFields([
+        ['Title', content.title],
+        ['Summary', content.summary],
+      ]);
+    }
+    case 'twitter':
+    case 'mastodon': {
+      return content.text;
+    }
+    default: {
+      const exhaustive: never = content;
+      throw new Error(
+        `Unhandled content source: ${JSON.stringify(exhaustive)}`,
+      );
+    }
+  }
+}
+
+function formatFields(fields: [label: string, value: string][]): string {
+  return fields
+    .map(([label, value]) => {
+      const trimmed = value.trim();
+      return trimmed.length > 0 ? `${label}: ${trimmed}` : null;
+    })
+    .filter((value): value is string => value != null)
+    .join('\n\n');
+}

--- a/packages/triage/src/util/ingestContent/index.ts
+++ b/packages/triage/src/util/ingestContent/index.ts
@@ -14,6 +14,7 @@ import { generateIssueTitleAndSlug } from '../../llm/functions/generateIssueTitl
 import { translate } from '../../llm/functions/translate/index.js';
 import { triageNewEvidence } from '../../llm/functions/triageNewEvidence/index.js';
 import { assert } from '../assert.js';
+import { formatContentTextForIngest } from './helpers/formatContentTextForIngest.js';
 import { getSlugDateTimeFromClaims } from './helpers/getSlugDateTimeFromClaims.js';
 import type { IngestContent } from './types.js';
 
@@ -68,7 +69,7 @@ export async function ingestContent(
     ...content,
     createdAt,
   };
-  const text = getText(normalizedContent);
+  const text = formatContentTextForIngest(normalizedContent);
   console.log('[ingestContent]', normalizedContent);
 
   const repo = createRepository(dataDir);
@@ -239,33 +240,6 @@ export async function ingestContent(
   }
 
   return null;
-}
-
-/**
- * Extracts the primary text content from an IngestContent item based on its source type.
- *
- * @param content - The content to extract text from.
- * @returns The text body (selftext for Reddit, summary for news, text for social).
- */
-function getText(content: IngestContent): string {
-  switch (content.source) {
-    case 'reddit': {
-      return content.selftext;
-    }
-    case 'news-website': {
-      return content.summary;
-    }
-    case 'twitter':
-    case 'mastodon': {
-      return content.text;
-    }
-    default: {
-      const exhaustive: never = content;
-      throw new Error(
-        `Unhandled content source: ${JSON.stringify(exhaustive)}`,
-      );
-    }
-  }
 }
 
 /**

--- a/scripts/run-changed-llm-evals.mjs
+++ b/scripts/run-changed-llm-evals.mjs
@@ -3,6 +3,7 @@ import { existsSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 
 const repoRoot = resolve(import.meta.dirname, '..');
+const triageWorkspacePrefix = 'packages/triage/';
 const functionPathPattern = /^packages\/triage\/src\/llm\/functions\/([^/]+)\//;
 
 const args = process.argv.slice(2);
@@ -47,6 +48,9 @@ for (const evalFile of evalFiles) {
 }
 
 for (const evalFile of evalFiles) {
+  const workspaceEvalFile = evalFile.startsWith(triageWorkspacePrefix)
+    ? evalFile.slice(triageWorkspacePrefix.length)
+    : evalFile;
   const command = [
     'npm',
     '--workspace',
@@ -54,7 +58,7 @@ for (const evalFile of evalFiles) {
     'run',
     'test:eval',
     '--',
-    evalFile,
+    workspaceEvalFile,
   ];
   console.log(`\n$ ${command.join(' ')}`);
 

--- a/scripts/run-changed-llm-evals.mjs
+++ b/scripts/run-changed-llm-evals.mjs
@@ -1,0 +1,73 @@
+import { execFileSync, spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+const repoRoot = resolve(import.meta.dirname, '..');
+const functionPathPattern = /^packages\/triage\/src\/llm\/functions\/([^/]+)\//;
+
+const args = process.argv.slice(2);
+const dryRun = args.includes('--dry-run');
+const range = args.find((arg) => !arg.startsWith('--'));
+
+if (range == null) {
+  console.error(
+    'Usage: node scripts/run-changed-llm-evals.mjs <git-range> [--dry-run]',
+  );
+  process.exit(1);
+}
+
+const changedFiles = execFileSync('git', ['diff', '--name-only', range], {
+  cwd: repoRoot,
+  encoding: 'utf8',
+})
+  .split('\n')
+  .filter(Boolean);
+
+const evalFiles = [
+  ...new Set(
+    changedFiles
+      .map((file) => {
+        const match = functionPathPattern.exec(file);
+        return match == null
+          ? null
+          : `packages/triage/src/llm/functions/${match[1]}/eval.test.ts`;
+      })
+      .filter((file) => file != null && existsSync(join(repoRoot, file))),
+  ),
+].sort();
+
+if (evalFiles.length === 0) {
+  console.log('No changed LLM function evals found.');
+  process.exit(0);
+}
+
+console.log('Changed LLM function evals:');
+for (const evalFile of evalFiles) {
+  console.log(`- ${evalFile}`);
+}
+
+for (const evalFile of evalFiles) {
+  const command = [
+    'npm',
+    '--workspace',
+    '@mrtdown/triage',
+    'run',
+    'test:eval',
+    '--',
+    evalFile,
+  ];
+  console.log(`\n$ ${command.join(' ')}`);
+
+  if (dryRun) {
+    continue;
+  }
+
+  const result = spawnSync(command[0], command.slice(1), {
+    cwd: repoRoot,
+    stdio: 'inherit',
+  });
+
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}


### PR DESCRIPTION
## Summary

- Add a `findIssuesByDateRange` triage tool that searches issue dates, evidence timestamps, and active periods, ranking direct date/evidence matches above broad active-period matches.
- Preserve news and Reddit titles in ingest evidence text sent to triage instead of using only summaries/body text.
- Update triage guidance and tool-call budget so the model inspects candidate issues and avoids linking different disruption segments that only share an endpoint.
- Add a first-party LLM eval workflow that detects changed `packages/triage/src/llm/functions/*` directories and runs only the matching `eval.test.ts` files, without a third-party path-filter action.

## Root Cause

A recent ingest run processed a follow-up news article whose summary had sparse operational context. Triage searched using generic incident wording, missed the already-recorded issue for the relevant date and service context, and classified the evidence as a separate new issue.

## Validation

- `npm run test:triage`
- `npm run build:triage`
- `npm run lint`
- `npm run check`
- `node scripts/run-changed-llm-evals.mjs origin/main...HEAD --dry-run`
- `npm --workspace @mrtdown/triage run test:eval -- src/llm/functions/triageNewEvidence/eval.test.ts` passed 6/6

Note: the full `npm run test:eval` still has existing red cases in `extractClaimsFromNewEvidence` unrelated to this triage change path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added date-range search to find issues within specific time periods
  * Enhanced triage decision-making with improved geographic-overlap and maintenance/infrastructure classification rules

* **Improvements**
  * Better content formatting for ingestion from various sources
  * Expanded guidance with explicit tool-usage steps for improved issue detection

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/foldaway/mrtdown-data/pull/245?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->