### PR TITLE
feat: add crowd report ingest contract

### DIFF
--- a/.changeset/calm-crowds-report.md
+++ b/.changeset/calm-crowds-report.md
@@ -1,0 +1,7 @@
+---
+"@mrtdown/ingest-contracts": minor
+"@mrtdown/triage": patch
+---
+
+Add the crowd-report ingest content contract and map accepted crowd reports to
+public report evidence during triage ingestion.

--- a/docs/plans/active/crowdsourced-reports.md
+++ b/docs/plans/active/crowdsourced-reports.md
@@ -198,6 +198,8 @@ Exit criteria:
 ## Progress Log
 
 - 2026-05-24: Drafted paired canonical ingest plan for crowdsourced reports.
+- 2026-05-24: Added the `crowd-report` ingest contract, deterministic contract
+  tests, triage text formatting, and public-report evidence type mapping.
 
 ## Decision Log
 

--- a/packages/ingest-contracts/README.md
+++ b/packages/ingest-contracts/README.md
@@ -24,3 +24,43 @@ const payload: IngestPayload = IngestPayloadSchema.parse({
   ],
 });
 ```
+
+## Crowd Reports
+
+Accepted and moderated public commuter reports use the `crowd-report` content
+source. These payloads are intended for reports that are already safe to become
+canonical evidence.
+
+```ts
+const payload: IngestPayload = IngestPayloadSchema.parse({
+  content: [
+    {
+      source: 'crowd-report',
+      reportId: 'accepted-20260523-0903-btl-001',
+      text: 'Several commuters report 15 minute delays on the BTL.',
+      createdAt: '2026-05-23T09:04:00+08:00',
+      observedAt: '2026-05-23T09:03:00+08:00',
+      lineIds: ['BTL'],
+      stationIds: ['BCL'],
+      directionText: 'towards Expo',
+      effect: 'delay',
+      delayMinutes: 15,
+      reportCount: 4,
+      url: 'https://example.com/crowd-reports/accepted-20260523-0903-btl-001',
+    },
+  ],
+});
+```
+
+Contract rules:
+
+- `reportId` must be stable and non-PII.
+- `createdAt` is when the producer accepted the report or cluster for
+  dispatch.
+- `observedAt` is when the condition was observed.
+- `text` is the natural-language evidence passed to triage.
+- At least one `lineIds` or `stationIds` entry is required.
+- `url` is required because canonical evidence stores a public `sourceUrl`.
+- Site-local metadata is rejected. Keep submitter identities, IP addresses,
+  user-agent strings, contact fields, moderation notes, abuse scores, and
+  challenge tokens out of this payload.

--- a/packages/ingest-contracts/src/index.test.ts
+++ b/packages/ingest-contracts/src/index.test.ts
@@ -29,9 +29,79 @@ describe('IngestPayloadSchema', () => {
             url: 'https://example.com/news/1',
             createdAt: '2026-05-23T09:02:00+08:00',
           },
+          {
+            source: 'crowd-report',
+            reportId: 'accepted-20260523-0903-btl-001',
+            text: 'Trains are skipping Bencoolen after a station announcement.',
+            createdAt: '2026-05-23T09:04:00+08:00',
+            observedAt: '2026-05-23T09:03:00+08:00',
+            lineIds: ['BTL'],
+            stationIds: ['BCL'],
+            directionText: 'towards Expo',
+            effect: 'skipped-stop',
+            reportCount: 2,
+            url: 'https://example.com/crowd-reports/accepted-20260523-0903-btl-001',
+          },
         ],
       }),
     ).not.toThrow();
+  });
+
+  test('accepts crowd reports with optional cluster fields', () => {
+    expect(() =>
+      IngestPayloadSchema.parse({
+        content: [
+          {
+            source: 'crowd-report',
+            reportId: 'accepted-20260523-0903-btl-001',
+            text: 'Several commuters report 15 minute delays on the BTL.',
+            createdAt: '2026-05-23T09:04:00+08:00',
+            observedAt: '2026-05-23T09:03:00+08:00',
+            lineIds: ['BTL'],
+            effect: 'delay',
+            delayMinutes: 15,
+            reportCount: 4,
+            url: 'https://example.com/crowd-reports/accepted-20260523-0903-btl-001',
+          },
+        ],
+      }),
+    ).not.toThrow();
+  });
+
+  test('rejects crowd reports without affected lines or stations', () => {
+    expect(() =>
+      IngestPayloadSchema.parse({
+        content: [
+          {
+            source: 'crowd-report',
+            reportId: 'accepted-20260523-0903-btl-001',
+            text: 'Several commuters report delays.',
+            createdAt: '2026-05-23T09:04:00+08:00',
+            observedAt: '2026-05-23T09:03:00+08:00',
+            url: 'https://example.com/crowd-reports/accepted-20260523-0903-btl-001',
+          },
+        ],
+      }),
+    ).toThrow();
+  });
+
+  test('rejects site-local crowd report metadata', () => {
+    expect(() =>
+      IngestPayloadSchema.parse({
+        content: [
+          {
+            source: 'crowd-report',
+            reportId: 'accepted-20260523-0903-btl-001',
+            text: 'Several commuters report delays.',
+            createdAt: '2026-05-23T09:04:00+08:00',
+            observedAt: '2026-05-23T09:03:00+08:00',
+            lineIds: ['BTL'],
+            url: 'https://example.com/crowd-reports/accepted-20260523-0903-btl-001',
+            submitterEmail: 'commuter@example.com',
+          },
+        ],
+      }),
+    ).toThrow();
   });
 
   test('rejects unknown content sources', () => {

--- a/packages/ingest-contracts/src/index.ts
+++ b/packages/ingest-contracts/src/index.ts
@@ -34,10 +34,43 @@ export type IngestContentNewsArticle = z.infer<
   typeof IngestContentNewsArticleSchema
 >;
 
+export const IngestContentCrowdReportSchema = z
+  .object({
+    source: z.literal('crowd-report'),
+    reportId: z.string().min(1),
+    text: z.string().min(1),
+    createdAt: z.string(),
+    observedAt: z.string(),
+    lineIds: z.array(z.string().min(1)).optional(),
+    stationIds: z.array(z.string().min(1)).optional(),
+    directionText: z.string().optional(),
+    effect: z
+      .enum(['delay', 'no-service', 'crowding', 'skipped-stop', 'unknown'])
+      .optional(),
+    delayMinutes: z.number().int().nonnegative().optional(),
+    reportCount: z.number().int().positive().optional(),
+    url: z.string().min(1),
+  })
+  .strict()
+  .refine(
+    (content) =>
+      (content.lineIds != null && content.lineIds.length > 0) ||
+      (content.stationIds != null && content.stationIds.length > 0),
+    {
+      message: 'Expected at least one lineIds or stationIds entry',
+      path: ['lineIds'],
+    },
+  );
+
+export type IngestContentCrowdReport = z.infer<
+  typeof IngestContentCrowdReportSchema
+>;
+
 export const IngestContentSchema = z.union([
   IngestContentTwitterSchema,
   IngestContentRedditSchema,
   IngestContentNewsArticleSchema,
+  IngestContentCrowdReportSchema,
 ]);
 
 export type IngestContent = z.infer<typeof IngestContentSchema>;

--- a/packages/triage/src/util/ingestContent/helpers/formatContentTextForIngest.test.ts
+++ b/packages/triage/src/util/ingestContent/helpers/formatContentTextForIngest.test.ts
@@ -43,4 +43,35 @@ describe('formatContentTextForIngest', () => {
       'Title: Major delay on Bukit Panjang LRT\n\nBody: No service between Senja and Petir.',
     );
   });
+
+  test('formats accepted crowd reports as structured evidence', () => {
+    expect(
+      formatContentTextForIngest({
+        source: 'crowd-report',
+        reportId: 'accepted-20260523-0903-btl-001',
+        text: 'Several commuters report 15 minute delays on the BTL.',
+        createdAt: '2026-05-23T09:04:00+08:00',
+        observedAt: '2026-05-23T09:03:00+08:00',
+        lineIds: ['BTL'],
+        stationIds: ['BCL'],
+        directionText: 'towards Expo',
+        effect: 'delay',
+        delayMinutes: 15,
+        reportCount: 4,
+        url: 'https://example.com/crowd-reports/accepted-20260523-0903-btl-001',
+      }),
+    ).toBe(
+      [
+        'Report: Several commuters report 15 minute delays on the BTL.',
+        'Observed at: 2026-05-23T09:03:00+08:00',
+        'Accepted at: 2026-05-23T09:04:00+08:00',
+        'Lines: BTL',
+        'Stations: BCL',
+        'Direction: towards Expo',
+        'Effect: delay',
+        'Delay minutes: 15',
+        'Report count: 4',
+      ].join('\n\n'),
+    );
+  });
 });

--- a/packages/triage/src/util/ingestContent/helpers/formatContentTextForIngest.ts
+++ b/packages/triage/src/util/ingestContent/helpers/formatContentTextForIngest.ts
@@ -14,6 +14,27 @@ export function formatContentTextForIngest(content: IngestContent): string {
         ['Summary', content.summary],
       ]);
     }
+    case 'crowd-report': {
+      return formatFields([
+        ['Report', content.text],
+        ['Observed at', content.observedAt],
+        ['Accepted at', content.createdAt],
+        ['Lines', content.lineIds?.join(', ')],
+        ['Stations', content.stationIds?.join(', ')],
+        ['Direction', content.directionText],
+        ['Effect', content.effect],
+        [
+          'Delay minutes',
+          content.delayMinutes == null
+            ? undefined
+            : String(content.delayMinutes),
+        ],
+        [
+          'Report count',
+          content.reportCount == null ? undefined : String(content.reportCount),
+        ],
+      ]);
+    }
     case 'twitter':
     case 'mastodon': {
       return content.text;
@@ -27,10 +48,12 @@ export function formatContentTextForIngest(content: IngestContent): string {
   }
 }
 
-function formatFields(fields: [label: string, value: string][]): string {
+function formatFields(
+  fields: [label: string, value: string | undefined][],
+): string {
   return fields
     .map(([label, value]) => {
-      const trimmed = value.trim();
+      const trimmed = value?.trim() ?? '';
       return trimmed.length > 0 ? `${label}: ${trimmed}` : null;
     })
     .filter((value): value is string => value != null)

--- a/packages/triage/src/util/ingestContent/helpers/getEvidenceProvenanceForIngestContent.test.ts
+++ b/packages/triage/src/util/ingestContent/helpers/getEvidenceProvenanceForIngestContent.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from 'vitest';
+import { getEvidenceProvenanceForIngestContent } from './getEvidenceProvenanceForIngestContent.js';
+
+describe('getEvidenceProvenanceForIngestContent', () => {
+  test('maps crowd reports to public report evidence and keeps the source URL', () => {
+    expect(
+      getEvidenceProvenanceForIngestContent({
+        source: 'crowd-report',
+        reportId: 'accepted-20260523-0903-btl-001',
+        text: 'Several commuters report 15 minute delays on the BTL.',
+        createdAt: '2026-05-23T09:04:00+08:00',
+        observedAt: '2026-05-23T09:03:00+08:00',
+        lineIds: ['BTL'],
+        url: 'https://example.com/crowd-reports/accepted-20260523-0903-btl-001',
+      }),
+    ).toEqual({
+      type: 'report.public',
+      sourceUrl:
+        'https://example.com/crowd-reports/accepted-20260523-0903-btl-001',
+    });
+  });
+
+  test('keeps news website content as media report evidence', () => {
+    expect(
+      getEvidenceProvenanceForIngestContent({
+        source: 'news-website',
+        title: 'Train service delayed',
+        summary: 'Services are delayed due to a track fault.',
+        url: 'https://example.com/news/1',
+        createdAt: '2026-05-23T09:02:00+08:00',
+      }),
+    ).toEqual({
+      type: 'report.media',
+      sourceUrl: 'https://example.com/news/1',
+    });
+  });
+});

--- a/packages/triage/src/util/ingestContent/helpers/getEvidenceProvenanceForIngestContent.ts
+++ b/packages/triage/src/util/ingestContent/helpers/getEvidenceProvenanceForIngestContent.ts
@@ -1,0 +1,36 @@
+import { type EvidenceType, EvidenceTypeSchema } from '@mrtdown/core';
+import type { IngestContent } from '../types.js';
+
+export interface IngestContentEvidenceProvenance {
+  type: EvidenceType;
+  sourceUrl: string;
+}
+
+export function getEvidenceProvenanceForIngestContent(
+  content: IngestContent,
+): IngestContentEvidenceProvenance {
+  return {
+    type: getEvidenceTypeForIngestContent(content),
+    sourceUrl: content.url,
+  };
+}
+
+function getEvidenceTypeForIngestContent(content: IngestContent): EvidenceType {
+  switch (content.source) {
+    case 'reddit':
+    case 'twitter':
+    case 'mastodon':
+    case 'crowd-report': {
+      return EvidenceTypeSchema.enum['report.public'];
+    }
+    case 'news-website': {
+      return EvidenceTypeSchema.enum['report.media'];
+    }
+    default: {
+      const exhaustive: never = content;
+      throw new Error(
+        `Unhandled content source: ${JSON.stringify(exhaustive)}`,
+      );
+    }
+  }
+}

--- a/packages/triage/src/util/ingestContent/index.ts
+++ b/packages/triage/src/util/ingestContent/index.ts
@@ -1,5 +1,5 @@
 import { resolve } from 'node:path';
-import type { Evidence, EvidenceType, Issue, IssueBundle } from '@mrtdown/core';
+import type { Evidence, Issue, IssueBundle } from '@mrtdown/core';
 import {
   FileStore,
   FileWriteStore,
@@ -15,6 +15,7 @@ import { translate } from '../../llm/functions/translate/index.js';
 import { triageNewEvidence } from '../../llm/functions/triageNewEvidence/index.js';
 import { assert } from '../assert.js';
 import { formatContentTextForIngest } from './helpers/formatContentTextForIngest.js';
+import { getEvidenceProvenanceForIngestContent } from './helpers/getEvidenceProvenanceForIngestContent.js';
 import { getSlugDateTimeFromClaims } from './helpers/getSlugDateTimeFromClaims.js';
 import type { IngestContent } from './types.js';
 
@@ -187,13 +188,15 @@ export async function ingestContent(
   if (translatedEvidenceText == null) {
     return null;
   }
+  const evidenceProvenance =
+    getEvidenceProvenanceForIngestContent(normalizedContent);
 
   const evidence: Evidence = {
     id: IdGenerator.evidenceId(contentDateTime),
     ts: contentDateTime.toISO({ includeOffset: true }),
-    type: getEvidenceType(normalizedContent),
+    type: evidenceProvenance.type,
     text,
-    sourceUrl: normalizedContent.url,
+    sourceUrl: evidenceProvenance.sourceUrl,
     render: {
       text: translatedEvidenceText,
       source: '@openai/gpt-5-nano',
@@ -240,31 +243,4 @@ export async function ingestContent(
   }
 
   return null;
-}
-
-/**
- * Maps IngestContent source type to the corresponding Evidence type for provenance tracking.
- *
- * @param content - The content to classify.
- * @returns The evidence type: report.public for social sources, or report.media for news.
- */
-function getEvidenceType(content: IngestContent): EvidenceType {
-  switch (content.source) {
-    case 'reddit': {
-      return 'report.public';
-    }
-    case 'news-website': {
-      return 'report.media';
-    }
-    case 'twitter':
-    case 'mastodon': {
-      return 'report.public';
-    }
-    default: {
-      const exhaustive: never = content;
-      throw new Error(
-        `Unhandled content source: ${JSON.stringify(exhaustive)}`,
-      );
-    }
-  }
 }


### PR DESCRIPTION
## Summary

- Add the `crowd-report` ingest content contract to `@mrtdown/ingest-contracts`.
- Document producer payloads and the privacy boundary for accepted crowd reports.
- Format accepted crowd reports for triage and map them to canonical `report.public` evidence while preserving the report URL as `sourceUrl`.
- Add deterministic schema, formatting, and provenance tests plus a changeset.

## Validation

- `npm run test:ingest-contracts`
- `npm run test:triage`
- `npm run build:ingest-contracts`
- `npm run build:triage`
- `npm run data:validate`
- `npm run check`

Note: npm printed the existing unknown `min-release-age` config warning, and Turbo printed a sandbox cache IO warning, but all validation commands exited successfully.