### PR TITLE
ci: trigger site pull after Pages deploy

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -62,6 +62,7 @@ jobs:
         uses: actions/deploy-pages@v4
 
   trigger-site-pull:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: deploy
     steps:

--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -60,3 +60,28 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+
+  trigger-site-pull:
+    runs-on: ubuntu-latest
+    needs: deploy
+    steps:
+      - name: Trigger mrtdown-site pull workflow
+        env:
+          MRTDOWN_SITE_PULL_URL: ${{ secrets.MRTDOWN_SITE_PULL_URL }}
+          MRTDOWN_SITE_INTERNAL_API_TOKEN: ${{ secrets.MRTDOWN_SITE_INTERNAL_API_TOKEN }}
+        run: |
+          if [[ -z "$MRTDOWN_SITE_PULL_URL" ]]; then
+            echo "::error::MRTDOWN_SITE_PULL_URL secret is required"
+            exit 1
+          fi
+
+          if [[ -z "$MRTDOWN_SITE_INTERNAL_API_TOKEN" ]]; then
+            echo "::error::MRTDOWN_SITE_INTERNAL_API_TOKEN secret is required"
+            exit 1
+          fi
+
+          curl --fail-with-body --show-error --silent \
+            --request POST \
+            --header "Accept: application/json" \
+            --header "Authorization: Bearer ${MRTDOWN_SITE_INTERNAL_API_TOKEN}" \
+            "$MRTDOWN_SITE_PULL_URL"

--- a/README.md
+++ b/README.md
@@ -79,6 +79,15 @@ available under `fixtures/` for tests and examples.
 Preview branches and pull requests build the same bundle in CI and upload it as
 a one-day artifact. Only `main` deploys the bundle to GitHub Pages.
 
+After a successful `main` Pages deployment, CI triggers the `mrtdown-site`
+internal pull endpoint so the site can import the newly published archive. The
+deploy workflow expects these repository secrets:
+
+- `MRTDOWN_SITE_PULL_URL`: the full `mrtdown-site`
+  `/internal/api/tasks/pull` URL.
+- `MRTDOWN_SITE_INTERNAL_API_TOKEN`: a bearer token present in the site's
+  `INTERNAL_API_TOKENS`.
+
 The artifact publishes the canonical export at the root:
 
 - `index.html`


### PR DESCRIPTION
## Summary

- Add a post-deploy GitHub Actions job that calls the `mrtdown-site` internal pull endpoint after GitHub Pages deployment succeeds.
- Document the required `MRTDOWN_SITE_PULL_URL` and `MRTDOWN_SITE_INTERNAL_API_TOKEN` repository secrets.

## Validation

- `npm run check:docs`
- Parsed `.github/workflows/pages-deploy.yml` with Ruby YAML

`npm run lint` was attempted, but this worktree does not have `biome` installed in `node_modules`.