### PR TITLE
feat: extend news article ingest schema

### DIFF
--- a/.changeset/soft-articles-reflect.md
+++ b/.changeset/soft-articles-reflect.md
@@ -1,0 +1,7 @@
+---
+"@mrtdown/ingest-contracts": minor
+"@mrtdown/triage": patch
+---
+
+Add optional enriched news article text fields to the ingest contract and use
+them during triage formatting.

--- a/packages/ingest-contracts/README.md
+++ b/packages/ingest-contracts/README.md
@@ -20,10 +20,23 @@ const payload: IngestPayload = IngestPayloadSchema.parse({
       summary: 'Trains are delayed due to a track fault.',
       url: 'https://example.com/report',
       createdAt: '2026-05-23T09:00:00+08:00',
+      articleText:
+        'The operator said commuters should expect an additional 20 minutes of travel time.',
+      articleTextSource: 'publisher',
+      articleTextFetchedAt: '2026-05-23T09:01:00.000Z',
     },
   ],
 });
 ```
+
+## News Articles
+
+News website payloads may include optional article enrichment fields from
+crawler-side extraction:
+
+- `articleText` is extracted article body text, or a compact metadata fallback.
+- `articleTextSource` is `publisher`, `archive`, or `metadata`.
+- `articleTextFetchedAt` is when the article text was fetched or derived.
 
 ## Crowd Reports
 

--- a/packages/ingest-contracts/src/index.test.ts
+++ b/packages/ingest-contracts/src/index.test.ts
@@ -3,6 +3,8 @@ import {
   IngestContentCrowdReportEffectSchema,
   IngestContentCrowdReportEffects,
   IngestContentCrowdReportSource,
+  IngestContentNewsArticleTextSourceSchema,
+  IngestContentNewsArticleTextSources,
   IngestPayloadSchema,
 } from './index.js';
 
@@ -14,6 +16,15 @@ describe('IngestPayloadSchema', () => {
     ]);
     expect(IngestContentCrowdReportEffectSchema.parse('crowding')).toBe(
       'crowding',
+    );
+  });
+
+  test('exports news article text source constants', () => {
+    expect(IngestContentNewsArticleTextSourceSchema.options).toEqual([
+      ...IngestContentNewsArticleTextSources,
+    ]);
+    expect(IngestContentNewsArticleTextSourceSchema.parse('publisher')).toBe(
+      'publisher',
     );
   });
 
@@ -43,6 +54,10 @@ describe('IngestPayloadSchema', () => {
             summary: 'Services are delayed due to a track fault.',
             url: 'https://example.com/news/1',
             createdAt: '2026-05-23T09:02:00+08:00',
+            articleText:
+              'Services are delayed due to a track fault. The operator said commuters should add 20 minutes of travel time.',
+            articleTextSource: 'publisher',
+            articleTextFetchedAt: '2026-05-23T09:03:00.000Z',
           },
           {
             source: 'crowd-report',
@@ -60,6 +75,26 @@ describe('IngestPayloadSchema', () => {
         ],
       }),
     ).not.toThrow();
+  });
+
+  test('rejects unknown news article text sources', () => {
+    expect(() =>
+      IngestPayloadSchema.parse({
+        content: [
+          {
+            source: 'news-website',
+            title: 'Train service delayed',
+            summary: 'Services are delayed due to a track fault.',
+            url: 'https://example.com/news/1',
+            createdAt: '2026-05-23T09:02:00+08:00',
+            articleText:
+              'Services are delayed due to a track fault. The operator said commuters should add 20 minutes of travel time.',
+            articleTextSource: 'scraper',
+            articleTextFetchedAt: '2026-05-23T09:03:00.000Z',
+          },
+        ],
+      }),
+    ).toThrow();
   });
 
   test('accepts crowd reports with optional cluster fields', () => {

--- a/packages/ingest-contracts/src/index.ts
+++ b/packages/ingest-contracts/src/index.ts
@@ -22,12 +22,29 @@ export const IngestContentRedditSchema = z.object({
 
 export type IngestContentReddit = z.infer<typeof IngestContentRedditSchema>;
 
+export const IngestContentNewsArticleTextSources = [
+  'publisher',
+  'archive',
+  'metadata',
+] as const;
+
+export const IngestContentNewsArticleTextSourceSchema = z.enum(
+  IngestContentNewsArticleTextSources,
+);
+
+export type IngestContentNewsArticleTextSource = z.infer<
+  typeof IngestContentNewsArticleTextSourceSchema
+>;
+
 export const IngestContentNewsArticleSchema = z.object({
   source: z.literal('news-website'),
   title: z.string(),
   summary: z.string(),
   url: z.string(),
   createdAt: z.string(),
+  articleText: z.string().min(1).optional(),
+  articleTextSource: IngestContentNewsArticleTextSourceSchema.optional(),
+  articleTextFetchedAt: z.string().optional(),
 });
 
 export type IngestContentNewsArticle = z.infer<

--- a/packages/triage/src/util/ingestContent/helpers/formatContentTextForIngest.test.ts
+++ b/packages/triage/src/util/ingestContent/helpers/formatContentTextForIngest.test.ts
@@ -28,6 +28,29 @@ describe('formatContentTextForIngest', () => {
     ).toBe('Title: Bukit Panjang LRT service resumes after track intrusion');
   });
 
+  test('includes enriched news article text when present', () => {
+    expect(
+      formatContentTextForIngest({
+        source: 'news-website',
+        title: 'Train service delayed',
+        summary: 'Services are delayed due to a track fault.',
+        url: 'https://example.com/article',
+        createdAt: '2026-05-22T14:07:24+08:00',
+        articleText:
+          'Services are delayed due to a track fault. The operator said commuters should add 20 minutes of travel time.',
+        articleTextSource: 'publisher',
+        articleTextFetchedAt: '2026-05-22T06:08:00.000Z',
+      }),
+    ).toBe(
+      [
+        'Title: Train service delayed',
+        'Summary: Services are delayed due to a track fault.',
+        'Article text: Services are delayed due to a track fault. The operator said commuters should add 20 minutes of travel time.',
+        'Article text source: publisher',
+      ].join('\n\n'),
+    );
+  });
+
   test('keeps reddit titles alongside body text', () => {
     expect(
       formatContentTextForIngest({

--- a/packages/triage/src/util/ingestContent/helpers/formatContentTextForIngest.ts
+++ b/packages/triage/src/util/ingestContent/helpers/formatContentTextForIngest.ts
@@ -12,6 +12,8 @@ export function formatContentTextForIngest(content: IngestContent): string {
       return formatFields([
         ['Title', content.title],
         ['Summary', content.summary],
+        ['Article text', content.articleText],
+        ['Article text source', content.articleTextSource],
       ]);
     }
     case 'crowd-report': {


### PR DESCRIPTION
## Summary

- Add optional enriched news article fields to the public ingest contract: `articleText`, `articleTextSource`, and `articleTextFetchedAt`.
- Export the allowed news article text source values for crawler-side producers.
- Include enriched article text in triage evidence formatting when present.
- Document the fields and add a changeset for the ingest contract and triage package.

## Validation

- `npm run test:ingest-contracts`
- `npm run test:triage`
- `npm run build:ingest-contracts`
- `npm run build:triage`
- `npm run check`

Note: Turbo emitted a non-fatal `IO error: Operation not permitted` warning, but all commands exited successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for optional article text enrichment with source attribution and timestamp metadata in news article processing.
  * Triage workflows now display enriched article text alongside article metadata when available.

* **Documentation**
  * Updated documentation with detailed examples and guidance for implementing the new article text fields.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/foldaway/mrtdown-data/pull/259?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->