### PR TITLE
feat: organize pages index

### DIFF
--- a/packages/fs/src/index.test.ts
+++ b/packages/fs/src/index.test.ts
@@ -159,8 +159,11 @@ describe('@mrtdown/fs', () => {
       '2026-01-01T00:00:00Z',
     );
     expect(manifest.lines.BTL).toMatch(/^[0-9a-f]{64}$/);
-    expect(renderPagesIndex(manifest)).toContain('mrtdown-data');
-    expect(renderPagesIndex(manifest)).not.toContain('archive.tar.gz');
+    const pagesIndex = renderPagesIndex(manifest);
+    expect(pagesIndex).toContain('mrtdown-data');
+    expect(pagesIndex).toContain('href="#lines"');
+    expect(pagesIndex).toContain('<h2 id="exports">Exports</h2>');
+    expect(pagesIndex).not.toContain('archive.tar.gz');
     expect(renderPagesIndex(manifest, { includeArchiveLinks: true })).toContain(
       'archive.tar.gz',
     );

--- a/packages/fs/src/pagesIndex.ts
+++ b/packages/fs/src/pagesIndex.ts
@@ -13,6 +13,17 @@ export type PagesRootIndexOptions = {
 
 type Child = Element['children'][number];
 
+type FileLinkRow = {
+  href: string;
+  description: string;
+};
+
+type TableOfContentsItem = {
+  href: string;
+  label: string;
+  count?: number;
+};
+
 function linkElement(href: string, label = href): Element {
   return {
     type: 'element',
@@ -76,6 +87,9 @@ function buildDocument(
 :root { font-family: system-ui, sans-serif; line-height: 1.5; }
 body { max-width: 40rem; margin: 2rem auto; padding: 0 1rem; color: #111; }
 h1 { font-size: 1.5rem; }
+h2 { margin-top: 2rem; }
+nav ul { padding-left: 1.25rem; }
+nav li { margin: 0.2rem 0; }
 table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
 th, td { text-align: left; padding: 0.35rem 0.5rem; border-bottom: 1px solid #ddd; }
 th { font-weight: 600; width: 40%; }
@@ -99,49 +113,27 @@ a { color: #0b57d0; }`.trim(),
   };
 }
 
-function buildExportLinks(options: PagesIndexOptions): Element {
-  const children: Child[] = [
-    {
-      type: 'text',
-      value:
-        'Static data index for Singapore MRT/LRT status and history. The machine-readable manifest is published as ',
-    },
-    linkElement('manifest.json'),
-    { type: 'text', value: '.' },
-  ];
-
-  if (options.includeArchiveLinks) {
-    children.push(
-      { type: 'text', value: ' The full data directory is also available as ' },
-      linkElement('archive.tar.gz'),
-      { type: 'text', value: ' (gzipped tarball) or ' },
-      linkElement('archive.zip'),
-      { type: 'text', value: '.' },
-    );
-  }
-
-  if (options.includeFixtureExportLinks) {
-    children.push(
-      {
-        type: 'text',
-        value: ' The deterministic fixture export is published at ',
-      },
-      linkElement('fixtures/'),
-      { type: 'text', value: '.' },
-    );
-  }
-
-  children.push({
-    type: 'text',
-    value: ' Records are listed in alphabetical order by ID.',
-  });
-
+function paragraph(children: Child[]): Element {
   return {
     type: 'element',
     tagName: 'p',
     properties: {},
     children,
   };
+}
+
+function buildRepositoryParagraph(): Element {
+  return paragraph([
+    {
+      type: 'text',
+      value: 'Source data and package code are maintained in the ',
+    },
+    linkElement(
+      'https://github.com/foldaway/mrtdown-data',
+      'GitHub repository',
+    ),
+    { type: 'text', value: '.' },
+  ]);
 }
 
 function buildFooter(
@@ -175,6 +167,7 @@ function issuePathFromManifestId(id: string): string {
 
 function buildTable(
   title: string,
+  id: string,
   records: Record<string, string>,
   pathForId: (id: string) => string,
 ): Element[] {
@@ -213,7 +206,7 @@ function buildTable(
     {
       type: 'element',
       tagName: 'h2',
-      properties: {},
+      properties: { id },
       children: [{ type: 'text', value: title }],
     },
     {
@@ -253,7 +246,46 @@ function buildTable(
   ];
 }
 
-function buildFileRow(href: string, description: string): Element {
+function buildTableOfContents(items: TableOfContentsItem[]): Element[] {
+  return [
+    {
+      type: 'element',
+      tagName: 'h2',
+      properties: { id: 'contents' },
+      children: [{ type: 'text', value: 'Contents' }],
+    },
+    {
+      type: 'element',
+      tagName: 'nav',
+      properties: { ariaLabel: 'Table of contents' },
+      children: [
+        {
+          type: 'element',
+          tagName: 'ul',
+          properties: {},
+          children: items.map((item) => ({
+            type: 'element',
+            tagName: 'li',
+            properties: {},
+            children: [
+              linkElement(item.href, item.label),
+              ...(item.count === undefined
+                ? []
+                : [
+                    {
+                      type: 'text',
+                      value: ` (${item.count})`,
+                    } satisfies Child,
+                  ]),
+            ],
+          })),
+        },
+      ],
+    },
+  ];
+}
+
+function buildFileRow(row: FileLinkRow): Element {
   return {
     type: 'element',
     tagName: 'tr',
@@ -263,16 +295,96 @@ function buildFileRow(href: string, description: string): Element {
         type: 'element',
         tagName: 'td',
         properties: {},
-        children: [linkElement(href)],
+        children: [linkElement(row.href)],
       },
       {
         type: 'element',
         tagName: 'td',
         properties: {},
-        children: [{ type: 'text', value: description }],
+        children: [{ type: 'text', value: row.description }],
       },
     ],
   };
+}
+
+function buildFilesTable(
+  title: string,
+  id: string,
+  rows: FileLinkRow[],
+): Element[] {
+  return [
+    {
+      type: 'element',
+      tagName: 'h2',
+      properties: { id },
+      children: [{ type: 'text', value: title }],
+    },
+    {
+      type: 'element',
+      tagName: 'table',
+      properties: {},
+      children: [
+        {
+          type: 'element',
+          tagName: 'tbody',
+          properties: {},
+          children: [
+            {
+              type: 'element',
+              tagName: 'tr',
+              properties: {},
+              children: [
+                {
+                  type: 'element',
+                  tagName: 'th',
+                  properties: {},
+                  children: [{ type: 'text', value: 'File' }],
+                },
+                {
+                  type: 'element',
+                  tagName: 'th',
+                  properties: {},
+                  children: [{ type: 'text', value: 'Description' }],
+                },
+              ],
+            },
+            ...rows.map(buildFileRow),
+          ],
+        },
+      ],
+    },
+  ];
+}
+
+function buildExportRows(options: PagesIndexOptions): FileLinkRow[] {
+  const rows: FileLinkRow[] = [
+    {
+      href: 'manifest.json',
+      description: 'Machine-readable export manifest.',
+    },
+  ];
+
+  if (options.includeArchiveLinks) {
+    rows.push(
+      {
+        href: 'archive.tar.gz',
+        description: 'Full data directory as a gzipped tarball.',
+      },
+      {
+        href: 'archive.zip',
+        description: 'Full data directory as a ZIP archive.',
+      },
+    );
+  }
+
+  if (options.includeFixtureExportLinks) {
+    rows.push({
+      href: 'fixtures/',
+      description: 'Deterministic fixture export for package and CLI examples.',
+    });
+  }
+
+  return rows;
 }
 
 export function renderPagesRootIndex(
@@ -288,105 +400,41 @@ export function renderPagesRootIndex(
         properties: {},
         children: [{ type: 'text', value: 'mrtdown-data' }],
       },
-      {
-        type: 'element',
-        tagName: 'p',
-        properties: {},
-        children: [
-          {
-            type: 'text',
-            value:
-              'Static canonical target-layout data for Singapore MRT/LRT status and history is published at this root. A deterministic fixture export is also available for package and CLI examples.',
-          },
-        ],
-      },
-      {
-        type: 'element',
-        tagName: 'p',
-        properties: {},
-        children: [
-          {
-            type: 'text',
-            value: 'The canonical machine-readable manifest is ',
-          },
-          linkElement('manifest.json'),
-          {
-            type: 'text',
-            value: '. The full canonical data directory is also available as ',
-          },
-          linkElement('archive.tar.gz'),
-          { type: 'text', value: ' (gzipped tarball) or ' },
-          linkElement('archive.zip'),
-          {
-            type: 'text',
-            value: '. The fixture data index remains available as ',
-          },
-          linkElement('fixtures/'),
-          { type: 'text', value: '.' },
-        ],
-      },
-      linkElement(
-        'https://github.com/foldaway/mrtdown-data',
-        'GitHub repository',
-      ),
-      {
-        type: 'element',
-        tagName: 'h2',
-        properties: {},
-        children: [{ type: 'text', value: 'Developer files' }],
-      },
-      {
-        type: 'element',
-        tagName: 'table',
-        properties: {},
-        children: [
-          {
-            type: 'element',
-            tagName: 'tbody',
-            properties: {},
-            children: [
-              {
-                type: 'element',
-                tagName: 'tr',
-                properties: {},
-                children: [
-                  {
-                    type: 'element',
-                    tagName: 'th',
-                    properties: {},
-                    children: [{ type: 'text', value: 'File' }],
-                  },
-                  {
-                    type: 'element',
-                    tagName: 'th',
-                    properties: {},
-                    children: [{ type: 'text', value: 'Description' }],
-                  },
-                ],
-              },
-              buildFileRow('manifest.json', 'Canonical export manifest.'),
-              buildFileRow(
-                'archive.tar.gz',
-                'Canonical export as a gzipped tarball.',
-              ),
-              buildFileRow('archive.zip', 'Canonical export as a ZIP archive.'),
-              buildFileRow('fixtures/', 'Fixture data index.'),
-              buildFileRow(
-                'fixtures/manifest.json',
-                'Fixture export manifest.',
-              ),
-              buildFileRow(
-                'fixtures/archive.tar.gz',
-                'Fixture export as a gzipped tarball.',
-              ),
-              buildFileRow(
-                'fixtures/archive.zip',
-                'Fixture export as a ZIP archive.',
-              ),
-            ],
-          },
-        ],
-      },
+      paragraph([
+        {
+          type: 'text',
+          value:
+            'Static canonical target-layout data for Singapore MRT/LRT status and history is published at this root. A deterministic fixture export is also available for package and CLI examples.',
+        },
+      ]),
+      buildRepositoryParagraph(),
+      ...buildTableOfContents([
+        { href: '#developer-files', label: 'Developer files' },
+      ]),
+      ...buildFilesTable('Developer files', 'developer-files', [
+        { href: 'manifest.json', description: 'Canonical export manifest.' },
+        {
+          href: 'archive.tar.gz',
+          description: 'Canonical export as a gzipped tarball.',
+        },
+        {
+          href: 'archive.zip',
+          description: 'Canonical export as a ZIP archive.',
+        },
+        { href: 'fixtures/', description: 'Fixture data index.' },
+        {
+          href: 'fixtures/manifest.json',
+          description: 'Fixture export manifest.',
+        },
+        {
+          href: 'fixtures/archive.tar.gz',
+          description: 'Fixture export as a gzipped tarball.',
+        },
+        {
+          href: 'fixtures/archive.zip',
+          description: 'Fixture export as a ZIP archive.',
+        },
+      ]),
       buildFooter(generatedAt),
     ]),
   );
@@ -397,16 +445,51 @@ export function renderPagesIndex(
   options: PagesIndexOptions = {},
 ): string {
   const sections = [
-    ['Lines', manifest.lines, (id: string) => `line/${id}.json`],
-    ['Towns', manifest.towns, (id: string) => `town/${id}.json`],
-    ['Landmarks', manifest.landmarks, (id: string) => `landmark/${id}.json`],
-    ['Operators', manifest.operators, (id: string) => `operator/${id}.json`],
-    ['Services', manifest.services, (id: string) => `service/${id}.json`],
-    ['Stations', manifest.stations, (id: string) => `station/${id}.json`],
-    ['Issues', manifest.issues, issuePathFromManifestId],
-  ] satisfies Array<[string, Record<string, string>, (id: string) => string]>;
-  const tables = sections.flatMap(([title, records, pathForId]) =>
-    buildTable(title, records, pathForId),
+    {
+      id: 'lines',
+      title: 'Lines',
+      records: manifest.lines,
+      pathForId: (id: string) => `line/${id}.json`,
+    },
+    {
+      id: 'towns',
+      title: 'Towns',
+      records: manifest.towns,
+      pathForId: (id: string) => `town/${id}.json`,
+    },
+    {
+      id: 'landmarks',
+      title: 'Landmarks',
+      records: manifest.landmarks,
+      pathForId: (id: string) => `landmark/${id}.json`,
+    },
+    {
+      id: 'operators',
+      title: 'Operators',
+      records: manifest.operators,
+      pathForId: (id: string) => `operator/${id}.json`,
+    },
+    {
+      id: 'services',
+      title: 'Services',
+      records: manifest.services,
+      pathForId: (id: string) => `service/${id}.json`,
+    },
+    {
+      id: 'stations',
+      title: 'Stations',
+      records: manifest.stations,
+      pathForId: (id: string) => `station/${id}.json`,
+    },
+    {
+      id: 'issues',
+      title: 'Issues',
+      records: manifest.issues,
+      pathForId: issuePathFromManifestId,
+    },
+  ];
+  const tables = sections.flatMap((section) =>
+    buildTable(section.title, section.id, section.records, section.pathForId),
   );
   const generatedAt = new Date(manifest.generatedAt);
 
@@ -419,11 +502,23 @@ export function renderPagesIndex(
           properties: {},
           children: [{ type: 'text', value: 'mrtdown-data' }],
         },
-        buildExportLinks(options),
-        linkElement(
-          'https://github.com/foldaway/mrtdown-data',
-          'GitHub repository',
-        ),
+        paragraph([
+          {
+            type: 'text',
+            value:
+              'Static canonical target-layout data for Singapore MRT/LRT status and history. Records are listed in alphabetical order by ID.',
+          },
+        ]),
+        buildRepositoryParagraph(),
+        ...buildTableOfContents([
+          { href: '#exports', label: 'Exports' },
+          ...sections.map((section) => ({
+            href: `#${section.id}`,
+            label: section.title,
+            count: Object.keys(section.records).length,
+          })),
+        ]),
+        ...buildFilesTable('Exports', 'exports', buildExportRows(options)),
         ...tables,
         buildFooter(generatedAt, manifest.generatedAt),
       ],


### PR DESCRIPTION
## Summary

- Adds a table of contents to the generated static Pages indexes.
- Splits the dense introductory copy into overview, repository, and export sections.
- Adds stable section anchors and regression coverage for the generated `index.html` structure.

## Impact

The static `index.html` is easier to scan and navigate while preserving the existing generated data links and archive options.

## Validation

- `npx biome check --write packages/fs/src/pagesIndex.ts packages/fs/src/index.test.ts`
- `npm run test:fs`
- `npm run build:fs`
- `npm run pages:build`