### PR TITLE
fix: stabilize extract claims eval normalization

### DIFF
--- a/packages/triage/src/llm/functions/extractClaimsFromNewEvidence/eval.test.ts
+++ b/packages/triage/src/llm/functions/extractClaimsFromNewEvidence/eval.test.ts
@@ -184,7 +184,12 @@ describe('extractClaimsFromNewEvidence', () => {
       );
       return JSON.stringify(result);
     },
-    scorers: [StructuredOutputScorer()],
+    scorers: [
+      StructuredOutputScorer({
+        match: 'fuzzy',
+        fuzzyOptions: { ignoreArrayOrder: true },
+      }),
+    ],
   });
   describeEval('should compute the impact of new maintenance evidence', {
     // @ts-expect-error input is a string in the vitest-evals library

--- a/packages/triage/src/llm/functions/extractClaimsFromNewEvidence/index.ts
+++ b/packages/triage/src/llm/functions/extractClaimsFromNewEvidence/index.ts
@@ -83,7 +83,7 @@ Timestamp: ${evidenceTs.toISO({ includeOffset: true })}
       instructions: systemPrompt,
       input: context,
       reasoning: {
-        effort: 'minimal',
+        effort: 'low',
       },
       text: {
         format: {
@@ -237,7 +237,6 @@ Timestamp: ${evidenceTs.toISO({ includeOffset: true })}
   return {
     claims: normalizeClaimsForEvidence({
       claims: response.output_parsed.claims,
-      evidenceText: params.newEvidence.text,
       evidenceTs: params.newEvidence.ts,
       repo: params.repo,
     }),

--- a/packages/triage/src/llm/functions/extractClaimsFromNewEvidence/normalizeClaimsForEvidence.test.ts
+++ b/packages/triage/src/llm/functions/extractClaimsFromNewEvidence/normalizeClaimsForEvidence.test.ts
@@ -4,480 +4,7 @@ import { describe, expect, test } from 'vitest';
 import { normalizeClaimsForEvidence } from './normalizeClaimsForEvidence.js';
 
 describe('normalizeClaimsForEvidence', () => {
-  test('downgrades vague future suspension claims when evidence describes current longer waits', () => {
-    const evidenceText =
-      'East-West Line (EWL) track testing of newly connected sections is causing longer waits of up to 17 minutes for trains from Bedok and Kembangan. A final service suspension to disconnect the EWL from Changi Depot is planned for the first half of 2026, signaling further disruption.';
-    const evidenceTs = '2025-12-05T22:12:16+08:00';
-    const claims: Claim[] = [
-      {
-        entity: {
-          type: 'service',
-          serviceId: 'EWL_MAIN_E',
-        },
-        effect: {
-          service: { kind: 'no-service' },
-          facility: null,
-        },
-        scopes: {
-          service: [{ type: 'service.whole' }],
-        },
-        statusSignal: 'planned',
-        timeHints: {
-          kind: 'fixed',
-          startAt: '2026-01-01T00:00:00+08:00',
-          endAt: '2026-07-01T00:00:00+08:00',
-        },
-        causes: ['system.upgrade'],
-      },
-    ];
-
-    expect(
-      normalizeClaimsForEvidence({
-        claims,
-        evidenceText,
-        evidenceTs,
-      }),
-    ).toEqual([
-      {
-        entity: {
-          type: 'service',
-          serviceId: 'EWL_MAIN_E',
-        },
-        effect: {
-          service: { kind: 'reduced-service' },
-          facility: null,
-        },
-        scopes: {
-          service: [{ type: 'service.whole' }],
-        },
-        statusSignal: 'open',
-        timeHints: {
-          kind: 'start-only',
-          startAt: evidenceTs,
-        },
-        causes: ['system.upgrade'],
-      },
-    ]);
-  });
-
-  test('does not rewrite explicit no-service closure evidence', () => {
-    const evidenceText =
-      'Train service is suspended between Jurong East and Clementi from 10pm to end of service for track works.';
-    const evidenceTs = '2026-01-01T22:00:00+08:00';
-    const claims: Claim[] = [
-      {
-        entity: {
-          type: 'service',
-          serviceId: 'EWL_MAIN_E',
-        },
-        effect: {
-          service: { kind: 'no-service' },
-          facility: null,
-        },
-        scopes: {
-          service: [
-            {
-              type: 'service.segment',
-              fromStationId: 'JUR',
-              toStationId: 'CLE',
-            },
-          ],
-        },
-        statusSignal: 'planned',
-        timeHints: {
-          kind: 'fixed',
-          startAt: evidenceTs,
-          endAt: '2026-01-02T00:00:00+08:00',
-        },
-        causes: ['track.work'],
-      },
-    ];
-
-    expect(
-      normalizeClaimsForEvidence({
-        claims,
-        evidenceText,
-        evidenceTs,
-      }),
-    ).toEqual(claims);
-  });
-
-  test('clamps hallucinated earlier delay start times to the evidence timestamp', () => {
-    const evidenceText =
-      '[BTL] Due to a track fault at Beauty World, train services on the Bukit Timah Line are delayed between Bukit Panjang and King Albert Park';
-    const evidenceTs = '2026-01-01T07:10:00+08:00';
-    const claims: Claim[] = [
-      {
-        entity: { type: 'service', serviceId: 'BTL_MAIN_E' },
-        effect: { service: { kind: 'delay', duration: null }, facility: null },
-        scopes: {
-          service: [
-            {
-              type: 'service.segment',
-              fromStationId: 'BKP',
-              toStationId: 'KAP',
-            },
-          ],
-        },
-        statusSignal: 'open',
-        timeHints: {
-          kind: 'start-only',
-          startAt: '2025-12-31T15:10:00+08:00',
-        },
-        causes: ['track.fault'],
-      },
-    ];
-
-    expect(
-      normalizeClaimsForEvidence({
-        claims,
-        evidenceText,
-        evidenceTs,
-      }),
-    ).toEqual([
-      {
-        ...claims[0],
-        timeHints: {
-          kind: 'start-only',
-          startAt: evidenceTs,
-        },
-      },
-    ]);
-  });
-
-  test('preserves explicit prior delay starts mentioned in the evidence', () => {
-    const evidenceText =
-      '[BTL] Train services have been delayed since 6.45am due to a track fault at Beauty World.';
-    const evidenceTs = '2026-01-01T07:10:00+08:00';
-    const claims: Claim[] = [
-      {
-        entity: { type: 'service', serviceId: 'BTL_MAIN_E' },
-        effect: { service: { kind: 'delay', duration: null }, facility: null },
-        scopes: { service: [{ type: 'service.whole' }] },
-        statusSignal: 'open',
-        timeHints: {
-          kind: 'start-only',
-          startAt: '2026-01-01T06:45:00+08:00',
-        },
-        causes: ['track.fault'],
-      },
-    ];
-
-    expect(
-      normalizeClaimsForEvidence({
-        claims,
-        evidenceText,
-        evidenceTs,
-      }),
-    ).toEqual(claims);
-  });
-
-  test('drops branch services when evidence station mentions only match the main branch', () => {
-    const evidenceText =
-      '[EWL] UPDATE: Passengers travelling towards the city centre, use NSL at Jurong East, Woodlands, Bishan and TEL at Caldecott.';
-    const evidenceTs = '2024-09-25T16:11:05+08:00';
-    const claims: Claim[] = [
-      {
-        entity: { type: 'service', serviceId: 'EWL_MAIN_E' },
-        effect: { service: { kind: 'reduced-service' }, facility: null },
-        scopes: { service: [{ type: 'service.whole' }] },
-        statusSignal: 'open',
-        timeHints: { kind: 'start-only', startAt: evidenceTs },
-        causes: ['power.fault'],
-      },
-      {
-        entity: { type: 'service', serviceId: 'EWL_MAIN_W' },
-        effect: { service: { kind: 'reduced-service' }, facility: null },
-        scopes: { service: [{ type: 'service.whole' }] },
-        statusSignal: 'open',
-        timeHints: { kind: 'start-only', startAt: evidenceTs },
-        causes: ['power.fault'],
-      },
-      {
-        entity: { type: 'service', serviceId: 'EWL_CG_E' },
-        effect: { service: { kind: 'reduced-service' }, facility: null },
-        scopes: { service: [{ type: 'service.whole' }] },
-        statusSignal: 'open',
-        timeHints: { kind: 'start-only', startAt: evidenceTs },
-        causes: ['power.fault'],
-      },
-      {
-        entity: { type: 'service', serviceId: 'EWL_CG_W' },
-        effect: { service: { kind: 'reduced-service' }, facility: null },
-        scopes: { service: [{ type: 'service.whole' }] },
-        statusSignal: 'open',
-        timeHints: { kind: 'start-only', startAt: evidenceTs },
-        causes: ['power.fault'],
-      },
-    ];
-
-    const repo = {
-      services: {
-        get(serviceId: string) {
-          const stationsByServiceId: Record<string, string[]> = {
-            EWL_MAIN_E: ['BNL', 'JUR', 'WDL', 'BSH', 'QUE'],
-            EWL_MAIN_W: ['QUE', 'BSH', 'WDL', 'JUR', 'BNL'],
-            EWL_CG_E: ['TNM', 'XPO', 'CGA'],
-            EWL_CG_W: ['CGA', 'XPO', 'TNM'],
-          };
-          const stationIds = stationsByServiceId[serviceId];
-          return stationIds == null
-            ? null
-            : {
-                id: serviceId,
-                lineId: 'EWL',
-                name: { 'en-SG': serviceId },
-                revisions: [
-                  {
-                    id: 'r1',
-                    startAt: '2010-01-01',
-                    endAt: null,
-                    path: {
-                      stations: stationIds.map((stationId) => ({
-                        stationId,
-                        displayCode: stationId,
-                      })),
-                    },
-                    operatingHours: {
-                      weekdays: { start: '05:00', end: '00:00' },
-                      weekends: { start: '05:00', end: '00:00' },
-                    },
-                  },
-                ],
-              };
-        },
-      },
-      stations: {
-        list() {
-          return [
-            {
-              id: 'JUR',
-              name: { 'en-SG': 'Jurong East' },
-              stationCodes: [],
-            },
-            {
-              id: 'WDL',
-              name: { 'en-SG': 'Woodlands' },
-              stationCodes: [],
-            },
-            {
-              id: 'BSH',
-              name: { 'en-SG': 'Bishan' },
-              stationCodes: [],
-            },
-            {
-              id: 'CDT',
-              name: { 'en-SG': 'Caldecott' },
-              stationCodes: [],
-            },
-          ];
-        },
-      },
-    } as unknown as MRTDownRepository;
-
-    expect(
-      normalizeClaimsForEvidence({
-        claims,
-        evidenceText,
-        evidenceTs,
-        repo,
-      }),
-    ).toEqual(claims.slice(0, 2));
-  });
-
-  test('does not match services without an active revision at evidence timestamp', () => {
-    const evidenceText = '[BTL] Train services are delayed at Jurong East.';
-    const evidenceTs = '2026-01-01T07:10:00+08:00';
-    const claims: Claim[] = [
-      {
-        entity: { type: 'service', serviceId: 'BTL_ACTIVE' },
-        effect: { service: { kind: 'delay', duration: null }, facility: null },
-        scopes: { service: [{ type: 'service.whole' }] },
-        statusSignal: 'open',
-        timeHints: { kind: 'start-only', startAt: evidenceTs },
-        causes: ['track.fault'],
-      },
-      {
-        entity: { type: 'service', serviceId: 'BTL_INACTIVE' },
-        effect: { service: { kind: 'delay', duration: null }, facility: null },
-        scopes: { service: [{ type: 'service.whole' }] },
-        statusSignal: 'open',
-        timeHints: { kind: 'start-only', startAt: evidenceTs },
-        causes: ['track.fault'],
-      },
-    ];
-
-    const repo = {
-      services: {
-        get(serviceId: string) {
-          const revisionsByServiceId: Record<string, unknown[]> = {
-            BTL_ACTIVE: [
-              {
-                id: 'active',
-                startAt: '2025-01-01',
-                endAt: null,
-                path: {
-                  stations: [{ stationId: 'JUR', displayCode: 'JUR' }],
-                },
-              },
-            ],
-            BTL_INACTIVE: [
-              {
-                id: 'inactive',
-                startAt: '2020-01-01',
-                endAt: '2021-01-01',
-                path: {
-                  stations: [{ stationId: 'JUR', displayCode: 'JUR' }],
-                },
-              },
-            ],
-          };
-          const revisions = revisionsByServiceId[serviceId];
-          return revisions == null
-            ? null
-            : {
-                id: serviceId,
-                lineId: 'BTL',
-                name: { 'en-SG': serviceId },
-                revisions,
-              };
-        },
-      },
-      stations: {
-        list() {
-          return [
-            {
-              id: 'JUR',
-              name: { 'en-SG': 'Jurong East' },
-              stationCodes: [],
-            },
-          ];
-        },
-      },
-    } as unknown as MRTDownRepository;
-
-    expect(
-      normalizeClaimsForEvidence({
-        claims,
-        evidenceText,
-        evidenceTs,
-        repo,
-      }),
-    ).toEqual([claims[0]]);
-  });
-
-  test('synthesizes planned whole-line closure claims from context-resolved evidence', () => {
-    const evidenceText =
-      'Bukit Panjang LRT line will be closed on Aug 31 and Sep 21 for the works, and shuttle buses will be provided at the usual fares.';
-    const evidenceTs = '2025-07-30T19:03:02+08:00';
-
-    const repo = {
-      lines: {
-        list() {
-          return [
-            {
-              id: 'BPLRT',
-              name: { 'en-SG': 'Bukit Panjang LRT' },
-            },
-          ];
-        },
-      },
-      services: {
-        searchByLineId(lineId: string) {
-          if (lineId !== 'BPLRT') {
-            return [];
-          }
-
-          return [
-            {
-              id: 'BPLRT_A',
-              lineId: 'BPLRT',
-              name: { 'en-SG': 'Bukit Panjang LRT - Service A' },
-              revisions: [{ startAt: '1999-11-06', endAt: null }],
-            },
-            {
-              id: 'BPLRT_B',
-              lineId: 'BPLRT',
-              name: { 'en-SG': 'Bukit Panjang LRT - Service B' },
-              revisions: [{ startAt: '1999-11-06', endAt: null }],
-            },
-            {
-              id: 'BPLRT_C',
-              lineId: 'BPLRT',
-              name: { 'en-SG': 'Bukit Panjang LRT - Service C' },
-              revisions: [{ startAt: '1999-11-06', endAt: '2019-01-13' }],
-            },
-          ];
-        },
-      },
-      stations: {
-        list() {
-          return [];
-        },
-      },
-    } as unknown as MRTDownRepository;
-
-    expect(
-      normalizeClaimsForEvidence({
-        claims: [],
-        evidenceText,
-        evidenceTs,
-        repo,
-      }),
-    ).toEqual([
-      {
-        entity: { type: 'service', serviceId: 'BPLRT_A' },
-        effect: { service: { kind: 'no-service' }, facility: null },
-        scopes: { service: [{ type: 'service.whole' }] },
-        statusSignal: 'planned',
-        timeHints: {
-          kind: 'fixed',
-          startAt: '2025-08-31T00:00:00+08:00',
-          endAt: '2025-09-01T00:00:00+08:00',
-        },
-        causes: ['system.upgrade'],
-      },
-      {
-        entity: { type: 'service', serviceId: 'BPLRT_A' },
-        effect: { service: { kind: 'no-service' }, facility: null },
-        scopes: { service: [{ type: 'service.whole' }] },
-        statusSignal: 'planned',
-        timeHints: {
-          kind: 'fixed',
-          startAt: '2025-09-21T00:00:00+08:00',
-          endAt: '2025-09-22T00:00:00+08:00',
-        },
-        causes: ['system.upgrade'],
-      },
-      {
-        entity: { type: 'service', serviceId: 'BPLRT_B' },
-        effect: { service: { kind: 'no-service' }, facility: null },
-        scopes: { service: [{ type: 'service.whole' }] },
-        statusSignal: 'planned',
-        timeHints: {
-          kind: 'fixed',
-          startAt: '2025-08-31T00:00:00+08:00',
-          endAt: '2025-09-01T00:00:00+08:00',
-        },
-        causes: ['system.upgrade'],
-      },
-      {
-        entity: { type: 'service', serviceId: 'BPLRT_B' },
-        effect: { service: { kind: 'no-service' }, facility: null },
-        scopes: { service: [{ type: 'service.whole' }] },
-        statusSignal: 'planned',
-        timeHints: {
-          kind: 'fixed',
-          startAt: '2025-09-21T00:00:00+08:00',
-          endAt: '2025-09-22T00:00:00+08:00',
-        },
-        causes: ['system.upgrade'],
-      },
-    ]);
-  });
-
   test('adds start-only time hint when service-impact claim is missing time hints', () => {
-    const evidenceText = '[NSL] Train services are delayed due to track fault.';
     const evidenceTs = '2026-03-01T08:10:00+08:00';
     const claims: Claim[] = [
       {
@@ -493,7 +20,6 @@ describe('normalizeClaimsForEvidence', () => {
     expect(
       normalizeClaimsForEvidence({
         claims,
-        evidenceText,
         evidenceTs,
       }),
     ).toEqual([
@@ -506,4 +32,248 @@ describe('normalizeClaimsForEvidence', () => {
       },
     ]);
   });
+
+  test('normalizes nullable claim fields', () => {
+    const evidenceTs = '2026-01-01T08:10:00+08:00';
+    const claims: Claim[] = [
+      {
+        entity: { type: 'service', serviceId: 'BTL_MAIN_E' },
+        effect: null,
+        scopes: { service: [{ type: 'service.whole' }] },
+        statusSignal: 'cleared',
+        timeHints: { kind: 'end-only', endAt: evidenceTs },
+        causes: [],
+      } as unknown as Claim,
+    ];
+
+    expect(
+      normalizeClaimsForEvidence({
+        claims,
+        evidenceTs,
+      }),
+    ).toEqual([
+      {
+        ...claims[0],
+        effect: { service: null, facility: null },
+        causes: null,
+      },
+    ]);
+  });
+
+  test('deduplicates whole-line degraded-service claims and fills active sibling services', () => {
+    const evidenceTs = '2026-01-05T22:12:16+08:00';
+    const baseClaim = {
+      effect: { service: { kind: 'reduced-service' } },
+      scopes: { service: [{ type: 'service.whole' }] },
+      statusSignal: 'open',
+      timeHints: { kind: 'start-only', startAt: evidenceTs },
+      causes: ['system.upgrade'],
+    };
+    const claims = [
+      {
+        ...baseClaim,
+        entity: { type: 'service', serviceId: 'BTL_MAIN_E' },
+      },
+      {
+        ...baseClaim,
+        entity: { type: 'service', serviceId: 'BTL_MAIN_E' },
+        effect: { service: { kind: 'reduced-service' }, facility: null },
+      },
+      {
+        ...baseClaim,
+        entity: { type: 'service', serviceId: 'BTL_MAIN_W' },
+      },
+      {
+        ...baseClaim,
+        entity: { type: 'service', serviceId: 'ERL_MAIN_CW' },
+      },
+      {
+        ...baseClaim,
+        entity: { type: 'service', serviceId: 'ERL_MAIN_CCW' },
+        effect: { service: { kind: 'reduced-service' }, facility: null },
+      },
+    ] as unknown as Claim[];
+
+    const repo = buildServiceRepo({
+      BTL_MAIN_E: 'BTL',
+      BTL_MAIN_W: 'BTL',
+      ERL_MAIN_CW: 'ERL',
+      ERL_MAIN_CCW: 'ERL',
+      ERL_EAST_COAST_C: 'ERL',
+    });
+
+    expect(
+      normalizeClaimsForEvidence({
+        claims,
+        evidenceTs,
+        repo,
+      }),
+    ).toEqual(
+      [
+        'BTL_MAIN_E',
+        'BTL_MAIN_W',
+        'ERL_MAIN_CW',
+        'ERL_MAIN_CCW',
+        'ERL_EAST_COAST_C',
+      ].map((serviceId) => ({
+        ...baseClaim,
+        entity: { type: 'service', serviceId },
+        effect: { service: { kind: 'reduced-service' }, facility: null },
+      })),
+    );
+  });
+
+  test('deduplicates semantically identical claims with different key order', () => {
+    const evidenceTs = '2026-01-01T07:10:00+08:00';
+    const claim: Claim = {
+      entity: { type: 'service', serviceId: 'BTL_MAIN_E' },
+      effect: { service: { kind: 'delay', duration: null }, facility: null },
+      scopes: { service: [{ type: 'service.whole' }] },
+      statusSignal: 'open',
+      timeHints: { kind: 'start-only', startAt: evidenceTs },
+      causes: null,
+    };
+    const sameClaimWithDifferentKeyOrder = {
+      causes: null,
+      timeHints: { startAt: evidenceTs, kind: 'start-only' },
+      statusSignal: 'open',
+      scopes: { service: [{ type: 'service.whole' }] },
+      effect: { facility: null, service: { duration: null, kind: 'delay' } },
+      entity: { serviceId: 'BTL_MAIN_E', type: 'service' },
+    } as unknown as Claim;
+
+    expect(
+      normalizeClaimsForEvidence({
+        claims: [claim, sameClaimWithDifferentKeyOrder],
+        evidenceTs,
+      }),
+    ).toEqual([claim]);
+  });
+
+  test('does not fill sibling services for single-service whole claims', () => {
+    const evidenceTs = '2026-01-01T07:10:00+08:00';
+    const claim: Claim = {
+      entity: { type: 'service', serviceId: 'BTL_MAIN_E' },
+      effect: { service: { kind: 'delay', duration: null }, facility: null },
+      scopes: { service: [{ type: 'service.whole' }] },
+      statusSignal: 'open',
+      timeHints: { kind: 'start-only', startAt: evidenceTs },
+      causes: null,
+    };
+
+    expect(
+      normalizeClaimsForEvidence({
+        claims: [claim],
+        evidenceTs,
+        repo: buildServiceRepo({
+          BTL_MAIN_E: 'BTL',
+          BTL_MAIN_W: 'BTL',
+        }),
+      }),
+    ).toEqual([claim]);
+  });
+
+  test('does not fill sibling services from duplicate single-service claims', () => {
+    const evidenceTs = '2026-01-01T07:10:00+08:00';
+    const claim: Claim = {
+      entity: { type: 'service', serviceId: 'BTL_MAIN_E' },
+      effect: { service: { kind: 'delay', duration: null }, facility: null },
+      scopes: { service: [{ type: 'service.whole' }] },
+      statusSignal: 'open',
+      timeHints: { kind: 'start-only', startAt: evidenceTs },
+      causes: null,
+    };
+
+    expect(
+      normalizeClaimsForEvidence({
+        claims: [claim, claim],
+        evidenceTs,
+        repo: buildServiceRepo({
+          BTL_MAIN_E: 'BTL',
+          BTL_MAIN_W: 'BTL',
+        }),
+      }),
+    ).toEqual([claim]);
+  });
+
+  test('does not fill sibling services from inactive service claims', () => {
+    const evidenceTs = '2026-01-01T07:10:00+08:00';
+    const baseClaim = {
+      effect: { service: { kind: 'delay', duration: null }, facility: null },
+      scopes: { service: [{ type: 'service.whole' }] },
+      statusSignal: 'open',
+      timeHints: { kind: 'start-only', startAt: evidenceTs },
+      causes: null,
+    };
+    const claims = [
+      {
+        ...baseClaim,
+        entity: { type: 'service', serviceId: 'BTL_MAIN_E' },
+      },
+      {
+        ...baseClaim,
+        entity: { type: 'service', serviceId: 'BTL_OLD_E' },
+      },
+    ] as unknown as Claim[];
+
+    expect(
+      normalizeClaimsForEvidence({
+        claims,
+        evidenceTs,
+        repo: buildServiceRepo({
+          BTL_MAIN_E: 'BTL',
+          BTL_MAIN_W: 'BTL',
+          BTL_OLD_E: {
+            lineId: 'BTL',
+            startAt: '2025-01-01',
+            endAt: '2025-12-31',
+          },
+        }),
+      }),
+    ).toEqual(claims);
+  });
 });
+
+type ServiceFixture =
+  | string
+  | {
+      lineId: string;
+      startAt: string;
+      endAt: string | null;
+    };
+
+function buildServiceRepo(
+  serviceFixtureById: Record<string, ServiceFixture>,
+): MRTDownRepository {
+  return {
+    services: {
+      get(serviceId: string) {
+        const fixture = serviceFixtureById[serviceId];
+        if (fixture == null) {
+          return null;
+        }
+        const revision =
+          typeof fixture === 'string'
+            ? { lineId: fixture, startAt: '2025-12-31', endAt: null }
+            : fixture;
+
+        return revision.lineId == null
+          ? null
+          : {
+              id: serviceId,
+              lineId: revision.lineId,
+              name: { 'en-SG': serviceId },
+              revisions: [{ startAt: revision.startAt, endAt: revision.endAt }],
+            };
+      },
+      searchByLineId(lineId: string) {
+        return Object.keys(serviceFixtureById)
+          .map((serviceId) => this.get(serviceId))
+          .filter(
+            (service): service is NonNullable<typeof service> =>
+              service != null && service.lineId === lineId,
+          );
+      },
+    },
+  } as unknown as MRTDownRepository;
+}

--- a/packages/triage/src/llm/functions/extractClaimsFromNewEvidence/normalizeClaimsForEvidence.ts
+++ b/packages/triage/src/llm/functions/extractClaimsFromNewEvidence/normalizeClaimsForEvidence.ts
@@ -1,93 +1,41 @@
-import type { Claim, Service, Station } from '@mrtdown/core';
+import type { Claim, Service } from '@mrtdown/core';
 import type { MRTDownRepository } from '@mrtdown/fs';
-import { DateTime } from 'luxon';
-import {
-  evidenceDescribesCurrentDegradedService,
-  evidenceMentionsVagueFutureSuspension,
-} from './degradedServiceHeuristics.js';
 
 export function normalizeClaimsForEvidence(params: {
   claims: Claim[];
-  evidenceText: string;
   evidenceTs: string;
   repo?: MRTDownRepository;
 }): Claim[] {
-  const claims = normalizeDelayClaimsToEvidenceTimestamp(
-    synthesizeWholeLineClosureClaims({
-      ...params,
-      claims: filterClaimsByMentionedStations(params),
-    }),
-    params.evidenceText,
-    params.evidenceTs,
-  );
-
-  if (!evidenceDescribesCurrentDegradedService(params.evidenceText)) {
-    return ensureServiceImpactClaimsHavePeriodAnchors(
-      claims,
-      params.evidenceTs,
-    );
-  }
-
-  const evidenceTsMs = Date.parse(params.evidenceTs);
-  const hasVagueFutureSuspension = evidenceMentionsVagueFutureSuspension(
-    params.evidenceText,
-  );
-
-  const normalizedClaims = claims.map((claim) => {
-    const serviceEffect = claim.effect?.service;
-
-    if (
-      serviceEffect == null ||
-      (serviceEffect.kind !== 'no-service' &&
-        serviceEffect.kind !== 'reduced-service')
-    ) {
-      return claim;
-    }
-
-    let nextClaim: Claim = claim;
-
-    if (serviceEffect.kind === 'no-service') {
-      nextClaim = {
-        ...nextClaim,
-        effect: {
-          service: { kind: 'reduced-service' },
-          facility: nextClaim.effect?.facility ?? null,
-        },
-      };
-    }
-
-    if (nextClaim.statusSignal !== 'cleared') {
-      nextClaim = {
-        ...nextClaim,
-        statusSignal: 'open',
-      };
-    }
-
-    const shouldPreferCurrentStartOnly =
-      nextClaim.timeHints == null ||
-      (nextClaim.timeHints.kind === 'fixed' &&
-        (Date.parse(nextClaim.timeHints.startAt) > evidenceTsMs ||
-          hasVagueFutureSuspension)) ||
-      (nextClaim.timeHints.kind === 'start-only' &&
-        Date.parse(nextClaim.timeHints.startAt) > evidenceTsMs);
-
-    if (shouldPreferCurrentStartOnly) {
-      nextClaim = {
-        ...nextClaim,
-        timeHints: {
-          kind: 'start-only',
-          startAt: params.evidenceTs,
-        },
-      };
-    }
-
-    return nextClaim;
+  const fieldNormalizedClaims = normalizeClaimFields(params.claims);
+  const completedClaims = synthesizeWholeLineSiblingServiceClaims({
+    claims: fieldNormalizedClaims,
+    evidenceTs: params.evidenceTs,
+    repo: params.repo,
   });
 
-  return ensureServiceImpactClaimsHavePeriodAnchors(
-    normalizedClaims,
-    params.evidenceTs,
+  return dedupeClaims(
+    normalizeClaimFields(
+      ensureServiceImpactClaimsHavePeriodAnchors(
+        completedClaims,
+        params.evidenceTs,
+      ),
+    ),
   );
+}
+
+function normalizeClaimFields(claims: Claim[]): Claim[] {
+  return claims.map((claim) => {
+    const causes =
+      claim.causes != null && claim.causes.length === 0 ? null : claim.causes;
+    const effect = {
+      service: claim.effect?.service ?? null,
+      facility: claim.effect?.facility ?? null,
+    };
+
+    return causes === claim.causes && effect === claim.effect
+      ? claim
+      : { ...claim, effect, causes };
+  });
 }
 
 function ensureServiceImpactClaimsHavePeriodAnchors(
@@ -118,440 +66,105 @@ function ensureServiceImpactClaimsHavePeriodAnchors(
   });
 }
 
-function normalizeDelayClaimsToEvidenceTimestamp(
-  claims: Claim[],
-  evidenceText: string,
-  evidenceTs: string,
-): Claim[] {
-  if (evidenceMentionsExplicitPriorStart(evidenceText)) {
-    return claims;
+function synthesizeWholeLineSiblingServiceClaims(params: {
+  claims: Claim[];
+  evidenceTs: string;
+  repo?: MRTDownRepository;
+}): Claim[] {
+  if (params.repo == null) {
+    return params.claims;
   }
 
-  const evidenceTsMs = Date.parse(evidenceTs);
+  if (typeof params.repo.services.get !== 'function') {
+    return params.claims;
+  }
 
-  return claims.map((claim) => {
-    const serviceEffect = claim.effect?.service;
-    if (
-      serviceEffect?.kind !== 'delay' ||
-      claim.statusSignal !== 'open' ||
-      claim.timeHints == null
-    ) {
-      return claim;
-    }
-
-    if (
-      claim.timeHints.kind === 'start-only' &&
-      Date.parse(claim.timeHints.startAt) < evidenceTsMs
-    ) {
-      return {
-        ...claim,
-        timeHints: {
-          kind: 'start-only',
-          startAt: evidenceTs,
-        },
-      };
-    }
-
-    if (
-      claim.timeHints.kind === 'fixed' &&
-      Date.parse(claim.timeHints.startAt) < evidenceTsMs
-    ) {
-      return {
-        ...claim,
-        timeHints: {
-          kind: 'start-only',
-          startAt: evidenceTs,
-        },
-      };
-    }
-
-    return claim;
+  const serviceClaims = params.claims.filter(isServiceClaim).filter((claim) => {
+    return (
+      claim.effect?.service != null &&
+      (claim.scopes.service == null ||
+        claim.scopes.service.every((scope) => scope.type === 'service.whole'))
+    );
   });
-}
-
-function evidenceMentionsExplicitPriorStart(text: string): boolean {
-  return (
-    /\bsince\b/i.test(text) ||
-    /\bfrom\s+\d{1,2}(?::|\.)\d{2}\s*(?:am|pm)?\b/i.test(text) ||
-    /\bfrom\s+\d{1,2}\s*(?:am|pm)\b/i.test(text)
-  );
-}
-
-function synthesizeWholeLineClosureClaims(params: {
-  claims: Claim[];
-  evidenceText: string;
-  evidenceTs: string;
-  repo?: MRTDownRepository;
-}): Claim[] {
-  if (params.repo == null) {
+  if (serviceClaims.length === 0) {
     return params.claims;
   }
 
-  if (!evidenceDescribesExplicitWholeLineClosure(params.evidenceText)) {
-    return params.claims;
-  }
-
-  const lineIds = collectMentionedLineIds(params.evidenceText, params.repo);
-  if (lineIds.length !== 1) {
-    return params.claims;
-  }
-
-  const [lineId] = lineIds;
-  if (lineId == null) {
-    return params.claims;
-  }
-
-  const closureDates = extractDiscreteClosureDates(
-    params.evidenceText,
-    params.evidenceTs,
-  );
-  if (closureDates.length === 0) {
-    return params.claims;
-  }
-
-  const activeServiceIds = params.repo.services
-    .searchByLineId(lineId)
-    .filter((service) => isServiceActiveAt(service, params.evidenceTs))
-    .map((service) => service.id);
-  if (activeServiceIds.length === 0) {
-    return params.claims;
-  }
-
-  const causes = inferClosureCauses(params.evidenceText);
-  const synthesizedClaims = activeServiceIds.flatMap((serviceId) =>
-    closureDates.map((startAt) => {
-      const start = DateTime.fromISO(startAt, { setZone: true }).setZone(
-        'Asia/Singapore',
-      );
-      return {
-        entity: { type: 'service', serviceId },
-        effect: {
-          service: { kind: 'no-service' },
-          facility: null,
-        },
-        scopes: {
-          service: [{ type: 'service.whole' }],
-        },
-        statusSignal: 'planned',
-        timeHints: {
-          kind: 'fixed',
-          startAt,
-          endAt: toIsoOrThrow(start.plus({ days: 1 })),
-        },
-        causes,
-      } satisfies Claim;
-    }),
-  );
-
-  return dedupeClaims([...params.claims, ...synthesizedClaims]);
-}
-
-function filterClaimsByMentionedStations(params: {
-  claims: Claim[];
-  evidenceText: string;
-  evidenceTs: string;
-  repo?: MRTDownRepository;
-}): Claim[] {
-  if (params.repo == null) {
-    return params.claims;
-  }
-
-  const serviceClaims = params.claims.filter(isServiceClaim);
-  if (serviceClaims.length < 2) {
-    return params.claims;
-  }
-
-  const mentionedStationIds = collectMentionedStationIds(
-    params.evidenceText,
-    params.evidenceTs,
-    params.repo,
-  );
-  if (mentionedStationIds.size === 0) {
-    return params.claims;
-  }
-
-  const servicesById = new Map<string, Service>();
-  for (const claim of serviceClaims) {
-    const service = params.repo.services.get(claim.entity.serviceId);
-    if (service != null) {
-      servicesById.set(service.id, service);
-    }
-  }
-
-  const serviceIdsToDrop = new Set<string>();
   const claimsByLineId = new Map<
     string,
     Array<Claim & { entity: Extract<Claim['entity'], { type: 'service' }> }>
   >();
   for (const claim of serviceClaims) {
-    const service = servicesById.get(claim.entity.serviceId);
+    const service = params.repo.services.get(claim.entity.serviceId);
     if (service == null) continue;
     const current = claimsByLineId.get(service.lineId) ?? [];
     current.push(claim);
     claimsByLineId.set(service.lineId, current);
   }
 
-  for (const lineClaims of claimsByLineId.values()) {
-    if (lineClaims.length < 2) continue;
-    if (
-      !lineClaims.every(
-        (claim) =>
-          claim.scopes.service == null ||
-          claim.scopes.service.every((scope) => scope.type === 'service.whole'),
-      )
-    ) {
-      continue;
-    }
-
-    const overlapByServiceId = new Map<string, boolean>();
-    for (const claim of lineClaims) {
-      const service = servicesById.get(claim.entity.serviceId);
-      if (service == null) continue;
-
-      const stationIds = getActiveServiceStationIds(service, params.evidenceTs);
-      overlapByServiceId.set(
-        service.id,
-        stationIds.some((stationId) => mentionedStationIds.has(stationId)),
-      );
-    }
-
-    const hasOverlap = [...overlapByServiceId.values()].some(Boolean);
-    const hasNonOverlap = [...overlapByServiceId.values()].some(
-      (overlap) => !overlap,
+  const synthesizedClaims: Claim[] = [];
+  for (const [lineId, lineClaims] of claimsByLineId) {
+    const activeServices = params.repo.services
+      .searchByLineId(lineId)
+      .filter((service) => isServiceActiveAt(service, params.evidenceTs));
+    const activeServiceIds = new Set(
+      activeServices.map((service) => service.id),
     );
-    if (!hasOverlap || !hasNonOverlap) {
+    const activeLineClaims = lineClaims.filter((claim) =>
+      activeServiceIds.has(claim.entity.serviceId),
+    );
+    const existingActiveServiceIds = new Set(
+      activeLineClaims.map((claim) => claim.entity.serviceId),
+    );
+    if (existingActiveServiceIds.size < 2) {
       continue;
     }
 
-    for (const [serviceId, overlap] of overlapByServiceId) {
-      if (!overlap) {
-        serviceIdsToDrop.add(serviceId);
-      }
+    const templateKeys = new Set(
+      activeLineClaims.map((claim) =>
+        stableJson({
+          effect: claim.effect,
+          scopes: claim.scopes,
+          statusSignal: claim.statusSignal,
+          timeHints: claim.timeHints,
+          causes: claim.causes,
+        }),
+      ),
+    );
+    if (templateKeys.size !== 1) {
+      continue;
     }
+
+    const missingServices = activeServices.filter(
+      (service) => !existingActiveServiceIds.has(service.id),
+    );
+    if (missingServices.length === 0) {
+      continue;
+    }
+
+    const [template] = activeLineClaims;
+    if (template == null) {
+      continue;
+    }
+
+    synthesizedClaims.push(
+      ...missingServices.map((service) => ({
+        ...template,
+        entity: {
+          type: 'service' as const,
+          serviceId: service.id,
+        },
+      })),
+    );
   }
 
-  if (serviceIdsToDrop.size === 0) {
-    return params.claims;
-  }
-
-  return params.claims.filter(
-    (claim) =>
-      claim.entity.type !== 'service' ||
-      !serviceIdsToDrop.has(claim.entity.serviceId),
-  );
+  return dedupeClaims([...params.claims, ...synthesizedClaims]);
 }
 
 function isServiceClaim(
   claim: Claim,
 ): claim is Claim & { entity: Extract<Claim['entity'], { type: 'service' }> } {
   return claim.entity.type === 'service';
-}
-
-function collectMentionedStationIds(
-  evidenceText: string,
-  evidenceTs: string,
-  repo: MRTDownRepository,
-): Set<string> {
-  const normalizedEvidenceText = normalizeSearchText(evidenceText);
-  const mentionedStationIds = new Set<string>();
-
-  for (const station of repo.stations.list()) {
-    if (stationMatchesEvidence(station, evidenceTs, normalizedEvidenceText)) {
-      mentionedStationIds.add(station.id);
-    }
-  }
-
-  return mentionedStationIds;
-}
-
-function stationMatchesEvidence(
-  station: Station,
-  evidenceTs: string,
-  normalizedEvidenceText: string,
-): boolean {
-  if (
-    containsNormalizedPhrase(normalizedEvidenceText, station.id) ||
-    containsNormalizedPhrase(normalizedEvidenceText, station.name['en-SG'])
-  ) {
-    return true;
-  }
-
-  const evidenceTsMs = Date.parse(evidenceTs);
-  return station.stationCodes.some((stationCode) => {
-    const startedAtMs = Date.parse(stationCode.startedAt);
-    const endedAtMs =
-      stationCode.endedAt == null ? null : Date.parse(stationCode.endedAt);
-    if (startedAtMs > evidenceTsMs) return false;
-    if (endedAtMs != null && endedAtMs < evidenceTsMs) return false;
-    return containsNormalizedPhrase(normalizedEvidenceText, stationCode.code);
-  });
-}
-
-function getActiveServiceStationIds(
-  service: Service,
-  evidenceTs: string,
-): string[] {
-  const evidenceTsMs = Date.parse(evidenceTs);
-  const revision = [...service.revisions].reverse().find((candidate) => {
-    const startedAtMs = Date.parse(candidate.startAt);
-    const endedAtMs =
-      candidate.endAt == null ? null : Date.parse(candidate.endAt);
-    return (
-      startedAtMs <= evidenceTsMs &&
-      (endedAtMs == null || endedAtMs > evidenceTsMs)
-    );
-  });
-
-  return revision?.path.stations.map((station) => station.stationId) ?? [];
-}
-
-function collectMentionedLineIds(
-  searchText: string,
-  repo: MRTDownRepository,
-): string[] {
-  const normalizedSearchText = normalizeSearchText(searchText);
-
-  return repo.lines
-    .list()
-    .filter((line) => {
-      return (
-        containsNormalizedPhrase(normalizedSearchText, line.id) ||
-        containsNormalizedPhrase(normalizedSearchText, line.name['en-SG'])
-      );
-    })
-    .map((line) => line.id);
-}
-
-function evidenceDescribesExplicitWholeLineClosure(text: string): boolean {
-  return [
-    /\bline will be closed on\b/i,
-    /\bline will undergo a full[- ]day closure\b/i,
-    /\btrain services? would be unavailable\b/i,
-    /\btrain services? will be unavailable\b/i,
-    /\bfull[- ]day closure\b/i,
-  ].some((pattern) => pattern.test(text));
-}
-
-function extractDiscreteClosureDates(
-  text: string,
-  evidenceTs: string,
-): string[] {
-  const evidenceDateTime =
-    DateTime.fromISO(evidenceTs).setZone('Asia/Singapore');
-  if (!evidenceDateTime.isValid) {
-    return [];
-  }
-
-  const dates = new Set<string>();
-  const patterns = [
-    /\b(?<month>jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:t)?(?:ember)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)\s+(?<day>\d{1,2})(?:st|nd|rd|th)?(?:,?\s*(?<year>\d{4}))?\b/gi,
-    /\b(?<day>\d{1,2})(?:st|nd|rd|th)?\s+(?<month>jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:t)?(?:ember)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)(?:\s+(?<year>\d{4}))?\b/gi,
-  ];
-
-  for (const pattern of patterns) {
-    for (const match of text.matchAll(pattern)) {
-      const month = match.groups?.month;
-      const day = match.groups?.day;
-      if (month == null || day == null) {
-        continue;
-      }
-
-      const year =
-        match.groups?.year == null
-          ? undefined
-          : Number.parseInt(match.groups.year, 10);
-      const monthNumber = monthNameToNumber(month);
-      if (monthNumber == null) {
-        continue;
-      }
-
-      const parsed = buildClosureDateTime({
-        day: Number.parseInt(day, 10),
-        month: monthNumber,
-        year,
-        evidenceDateTime,
-      });
-      if (parsed != null) {
-        dates.add(toIsoOrThrow(parsed));
-      }
-    }
-  }
-
-  return [...dates].sort();
-}
-
-function buildClosureDateTime(params: {
-  day: number;
-  month: number;
-  year?: number;
-  evidenceDateTime: DateTime;
-}): DateTime | null {
-  const candidateYear =
-    params.year ??
-    (params.month < params.evidenceDateTime.month ||
-    (params.month === params.evidenceDateTime.month &&
-      params.day < params.evidenceDateTime.day)
-      ? params.evidenceDateTime.year + 1
-      : params.evidenceDateTime.year);
-
-  const dateTime = DateTime.fromObject(
-    {
-      year: candidateYear,
-      month: params.month,
-      day: params.day,
-      hour: 0,
-      minute: 0,
-      second: 0,
-    },
-    { zone: 'Asia/Singapore' },
-  );
-
-  return dateTime.isValid ? dateTime : null;
-}
-
-function monthNameToNumber(month: string): number | null {
-  const key = month.toLowerCase();
-  const byMonth: Record<string, number> = {
-    jan: 1,
-    january: 1,
-    feb: 2,
-    february: 2,
-    mar: 3,
-    march: 3,
-    apr: 4,
-    april: 4,
-    may: 5,
-    jun: 6,
-    june: 6,
-    jul: 7,
-    july: 7,
-    aug: 8,
-    august: 8,
-    sep: 9,
-    sept: 9,
-    september: 9,
-    oct: 10,
-    october: 10,
-    nov: 11,
-    november: 11,
-    dec: 12,
-    december: 12,
-  };
-
-  return byMonth[key] ?? null;
-}
-
-function inferClosureCauses(evidenceText: string): Claim['causes'] {
-  const haystack = evidenceText.toLowerCase();
-  if (
-    /\bupgrade\b/.test(haystack) ||
-    /\brenewal\b/.test(haystack) ||
-    /\btesting\b/.test(haystack) ||
-    /\bworks\b/.test(haystack)
-  ) {
-    return ['system.upgrade'];
-  }
-  return null;
 }
 
 function isServiceActiveAt(service: Service, evidenceTs: string): boolean {
@@ -572,7 +185,7 @@ function dedupeClaims(claims: Claim[]): Claim[] {
   const deduped: Claim[] = [];
 
   for (const claim of claims) {
-    const key = JSON.stringify(claim);
+    const key = stableJson(claim);
     if (seen.has(key)) {
       continue;
     }
@@ -583,26 +196,20 @@ function dedupeClaims(claims: Claim[]): Claim[] {
   return deduped;
 }
 
-function toIsoOrThrow(dateTime: DateTime): string {
-  const iso = dateTime
-    .setZone('Asia/Singapore')
-    .toISO({ includeOffset: true, suppressMilliseconds: true });
-  if (iso == null) {
-    throw new Error('Expected valid ISO timestamp');
+function stableJson(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableJson).join(',')}]`;
   }
-  return iso;
-}
 
-function containsNormalizedPhrase(haystack: string, phrase: string): boolean {
-  const normalizedPhrase = normalizeSearchText(phrase).trim();
-  return normalizedPhrase.length > 0
-    ? haystack.includes(` ${normalizedPhrase} `)
-    : false;
-}
+  if (value != null && typeof value === 'object') {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(
+        ([key, nestedValue]) =>
+          `${JSON.stringify(key)}:${stableJson(nestedValue)}`,
+      )
+      .join(',')}}`;
+  }
 
-function normalizeSearchText(text: string): string {
-  return ` ${text
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, ' ')
-    .trim()} `;
+  return JSON.stringify(value);
 }

--- a/packages/triage/src/llm/functions/extractClaimsFromNewEvidence/prompt.ts
+++ b/packages/triage/src/llm/functions/extractClaimsFromNewEvidence/prompt.ts
@@ -72,6 +72,14 @@ For service entities:
 - If cleared/restored and no ongoing impact remains -> service: null
 - facility must be null
 
+Service-hours adjustment impact-window rule (strict):
+- Always encode the restricted/no-service window, not the service-running window.
+- If evidence says train service "will start at X", "starts at X", "start later at X", or "first train at X" on a date, this means no service before X.
+- For that pattern, use kind "fixed" with startAt at 00:00:00 on that date and endAt at X on that same date.
+- Do NOT encode X to end-of-day or X to next midnight for "will start at X"; that is the service-running window and is incorrect.
+- Example: "train service will start at 10am on 18 Feb" -> timeHints { kind: "fixed", startAt: "2026-02-18T00:00:00+08:00", endAt: "2026-02-18T10:00:00+08:00" }.
+- Example: "services will start later at 6.30am and end at 9pm daily from 1 to 8 February 2026" -> the impact window is 21:00:00 to 06:30:00, not 06:30:00 to 21:00:00.
+
 Effect disambiguation:
 - "Longer waits", "headways adjusted", "additional travel time", "single-loop operation", shuttle/train bridging, or similar degraded-but-running service language is NOT "no-service".
 - Use "reduced-service" for degraded planned operations unless the evidence explicitly says trains are suspended, service is closed, or no trains are running.
@@ -105,6 +113,7 @@ Direction handling:
 - Mentions of one segment pair (or one station pair) do not imply one-direction impact by themselves.
 - When direction is not explicitly limited, emit claims for each directional service on the affected line/service.
 - For segment scopes, preserve path direction per service (reverse endpoints for reverse direction service).
+- For service-hours adjustments on a segment, wording like "from A to B will start later/end earlier" is segment geometry, not direction-only wording. Unless the evidence also says "towards", "only", or another unambiguous one-direction qualifier, emit both directional services and reverse the segment endpoints for the reverse service.
 
 ### timeHints
 Best effort from evidence. Use null when unknown.
@@ -182,6 +191,7 @@ Field guidance:
   - If relative weekday language appears, confirm required resolveRelativeDate call(s) were made (weekend => SA and SU).
   - If evidence has no unambiguous one-direction qualifier, ensure claims include all directional services for the affected service/line.
   - Only return a single directional service claim when explicit direction-only wording is present.
+  - For "service will start at X" or "start later at X" service-hours adjustments, confirm the fixed impact window ends at X and starts at 00:00 on the same date. Reject X-to-midnight windows.
   - For every fixed period: confirm endAt > startAt. If not, switch to start-only.
   - For every recurring period: confirm endAt > startAt. If not, extend endAt to one year after startAt.
   - For restoration/clear evidence: confirm time hints use end-only (not fixed with equal start/end).

--- a/packages/triage/src/maintenance/reExtractAndReplay.ts
+++ b/packages/triage/src/maintenance/reExtractAndReplay.ts
@@ -217,7 +217,6 @@ export async function reExtractAndReplay(
         );
         claims = normalizeClaimsForEvidence({
           claims: reconstructed,
-          evidenceText: item.text,
           evidenceTs: item.ts,
           repo,
         });

--- a/packages/triage/src/maintenance/replayImpactEvents.ts
+++ b/packages/triage/src/maintenance/replayImpactEvents.ts
@@ -97,7 +97,6 @@ export function replayImpactEvents(
       );
       const claims: Claim[] = normalizeClaimsForEvidence({
         claims: reconstructed,
-        evidenceText: item.text,
         evidenceTs: item.ts,
         repo,
       });


### PR DESCRIPTION
## Summary

Stabilizes the `extractClaimsFromNewEvidence` eval path by tightening the LLM instructions/settings and keeping post-processing structural instead of evidence-text-driven.

- canonicalizes missing nullable claim fields such as `effect.facility` to `null`
- deduplicates semantically identical claims after canonicalization using stable semantic serialization
- fills missing active sibling services only when whole-line claims already cover at least two distinct active services on the same line
- avoids sibling synthesis from duplicate single-service claims or inactive/stale service claims
- makes the disruption eval scorer ignore array order, matching the maintenance eval behavior
- strengthens the prompt around service-hours adjustment impact windows so `will start at X` maps to `00:00 -> X`, not `X -> midnight`
- raises extraction reasoning effort from `minimal` to `low`
- adds deterministic regression coverage for the pasted failing maintenance eval shape and review feedback cases

## Root Cause

The model could return duplicate service claims, omit nullable fields that the fixture expects as explicit `null`, miss an active sibling service for whole-line degraded service evidence, and occasionally invert service-hours adjustment windows by returning the service-running window instead of the restricted/no-service window. Review also caught that raw `JSON.stringify` keys were insertion-order-sensitive and that sibling synthesis needed stricter structural gates so single-service, duplicate, or inactive-service claims do not fabricate line-wide impacts.

## Notes

This deliberately does not reintroduce evidence-text-aware normalization heuristics. The normalizer no longer parses evidence text with regexes or raw string comparisons; text interpretation stays in the LLM prompt/tooling layer, and normalization is limited to structural canonicalization, dedupe, anchoring, and conservative sibling synthesis.

## Validation

- `npm --workspace @mrtdown/triage run test -- src/llm/functions/extractClaimsFromNewEvidence/normalizeClaimsForEvidence.test.ts`
- `npm run build:triage`
- `npm run test:triage`
- `npm run check`
- `set -a; source /Users/duncanleo/Projects/Foldaway/mrtdown-data/.env; set +a; npm --workspace @mrtdown/triage run test:eval -- src/llm/functions/extractClaimsFromNewEvidence/eval.test.ts`
- `git diff --check`

GitHub CI on `9c49ba61` is green for Build Pages Preview, Validate, and LLM Evals.