### PR TITLE
fix: ignore ingest items without canonical impact

### DIFF
--- a/packages/triage/src/llm/functions/triageNewEvidence/eval.test.ts
+++ b/packages/triage/src/llm/functions/triageNewEvidence/eval.test.ts
@@ -143,6 +143,24 @@ describe('triageNewEvidence', () => {
               },
             },
           },
+          {
+            input: {
+              newEvidence: {
+                ts: '2026-05-26T14:48:44+08:00',
+                text: '14:23-Due to vehicle breakdown along Sims Avenue East, at the junction with Chai Chee Drive after bus stop BS 83081, bus service 26 is diverted.',
+              },
+              repo,
+              // This is used by vitest-evals as the test name, as the library expects `input` to be a string.
+              toString() {
+                return 'Irrelevant bus-only service diversion';
+              },
+            },
+            expected: {
+              result: {
+                kind: 'irrelevant-content',
+              },
+            },
+          },
         ] satisfies {
           input: TriageNewEvidenceParams & { toString(): string };
           expected: TriageNewEvidenceResult;

--- a/packages/triage/src/llm/functions/triageNewEvidence/prompt.ts
+++ b/packages/triage/src/llm/functions/triageNewEvidence/prompt.ts
@@ -26,6 +26,16 @@ TOOL USE GUIDANCE:
 
 CLASSIFICATION RULES:
 
+Domain Gate:
+- This repository tracks Singapore MRT/LRT rail operations and station
+  facilities only.
+- Bus-only incidents, bus route diversions, bus stop incidents, road traffic,
+  and private vehicle breakdowns are irrelevant unless the evidence explicitly
+  states an impact on MRT/LRT train service, LRT service, or an MRT/LRT station
+  facility.
+- Do not create issues for bus service numbers, bus stops, or road locations
+  by themselves.
+
 Part of Existing Issue:
 - Evidence must match the service/line AND have geographic overlap (stations or segments)
 - For disruptions, geographic overlap means the existing issue already covers every station/segment named by the new evidence

--- a/packages/triage/src/util/ingestContent/index.test.ts
+++ b/packages/triage/src/util/ingestContent/index.test.ts
@@ -1,0 +1,80 @@
+import { constants } from 'node:fs';
+import { access, cp, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import type { IngestContent } from '@mrtdown/ingest-contracts';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { ingestContent } from './index.js';
+
+const mocks = vi.hoisted(() => ({
+  extractClaimsFromNewEvidence: vi.fn(),
+  generateIssueTitleAndSlug: vi.fn(),
+  translate: vi.fn(),
+  triageNewEvidence: vi.fn(),
+}));
+
+vi.mock('../../llm/functions/extractClaimsFromNewEvidence/index.js', () => ({
+  extractClaimsFromNewEvidence: mocks.extractClaimsFromNewEvidence,
+}));
+
+vi.mock('../../llm/functions/generateIssueTitleAndSlug/index.js', () => ({
+  generateIssueTitleAndSlug: mocks.generateIssueTitleAndSlug,
+}));
+
+vi.mock('../../llm/functions/translate/index.js', () => ({
+  translate: mocks.translate,
+}));
+
+vi.mock('../../llm/functions/triageNewEvidence/index.js', () => ({
+  triageNewEvidence: mocks.triageNewEvidence,
+}));
+
+const FIXTURE_DATA_DIR = resolve(
+  import.meta.dirname,
+  '../../../../../fixtures/data',
+);
+
+describe('ingestContent', () => {
+  let dataDir: string;
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    dataDir = await mkdtemp(join(tmpdir(), 'mrtdown-ingest-'));
+    await cp(FIXTURE_DATA_DIR, dataDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(dataDir, { force: true, recursive: true });
+  });
+
+  test('does not create a new issue when extraction produces no impact claims', async () => {
+    mocks.triageNewEvidence.mockResolvedValue({
+      result: { kind: 'part-of-new-issue', issueType: 'disruption' },
+    });
+    mocks.extractClaimsFromNewEvidence.mockResolvedValue({ claims: [] });
+
+    const content: IngestContent = {
+      source: 'mastodon',
+      accountName: 'LTA Train Service Alerts',
+      text: '14:23-Due to vehicle breakdown along Sims Avenue East, at the junction with Chai Chee Drive after bus stop BS 83081, bus service 26 is diverted.',
+      url: 'https://mastodon.social/@ltatrainservicealerts/116639539143966503',
+      createdAt: '2026-05-26T14:48:44.000+08:00',
+    };
+
+    await ingestContent(content, { dataDir });
+
+    expect(mocks.extractClaimsFromNewEvidence).toHaveBeenCalledOnce();
+    expect(mocks.generateIssueTitleAndSlug).not.toHaveBeenCalled();
+    expect(mocks.translate).not.toHaveBeenCalled();
+    await expectPathMissing(
+      join(
+        dataDir,
+        'issue/2026/05/2026-05-26-bus-service-26-vehicle-breakdown-sims-avenue-east-chai-chee-drive-bs-83081',
+      ),
+    );
+  });
+});
+
+async function expectPathMissing(path: string) {
+  await expect(access(path, constants.F_OK)).rejects.toThrow();
+}

--- a/packages/triage/src/util/ingestContent/index.ts
+++ b/packages/triage/src/util/ingestContent/index.ts
@@ -112,6 +112,13 @@ export async function ingestContent(
   const { claims } = extractResult;
   console.log('[ingestContent.extractClaimsFromNewEvidence]', claims);
 
+  if (triageResult.result.kind === 'part-of-new-issue' && claims.length === 0) {
+    console.log(
+      '[ingestContent] No impact claims extracted for new issue; skipping persistence.',
+    );
+    return null;
+  }
+
   // --- Resolve issue bundle: fetch existing or create new ---
   let issueBundle: IssueBundle;
   let shouldCreateIssue = false;


### PR DESCRIPTION
## Summary

- Add an MRT/LRT-only domain gate to the triage prompt so bus-only incidents are classified as irrelevant.
- Skip creating new canonical issues when extraction returns no impact claims.
- Add deterministic ingest coverage for the Bus Service 26 failure mode and a paid-eval fixture for bus-only diversion triage.

## Root Cause

The latest automated ingest PR was created from a bus-only Mastodon alert. Triage marked it as a new disruption, extraction returned `claims: []`, and ingestion still persisted a hollow issue with empty impact data.

## Validation

- `npm run test:triage`
- `npm run build:triage`
- `npm run check`
- `npm run data:validate`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Triage now focuses on Singapore MRT/LRT rail operations and station facilities only, filtering irrelevant bus and road incidents.

* **Bug Fixes**
  * System no longer creates empty issues when no impact claims are extracted.

* **Tests**
  * Added test coverage for filtering irrelevant bus service incidents.
  * Added test coverage for claim extraction with no impact claims.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/foldaway/mrtdown-data/pull/267?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->