### PR TITLE
docs: clarify schematic phase one handoff

### DIFF
--- a/docs/plans/active/schematic-system-map.md
+++ b/docs/plans/active/schematic-system-map.md
@@ -37,6 +37,8 @@ of the map.
   station ordering, interchange constraints, and reusable design rules.
 - Preserve explicit escape hatches for reviewed one-off visual exceptions.
 - Use complete generated version snapshots as the published storage contract.
+- Keep generated version snapshots out of source control by default; publish
+  them from deterministic generator output instead.
 - Support reviewed schematic edit submissions from trusted authoring clients,
   such as a protected `mrtdown-site` map designer.
 
@@ -89,9 +91,10 @@ inputs and rule configuration should also be versioned so any published snapshot
 can be regenerated deterministically.
 
 The canonical source of truth is the generator implementation plus its rule and
-constraint inputs. Generated snapshots are committed and published artifacts, not
-the authoring source. Validation should be able to regenerate the snapshots and
-fail when committed generated output is stale.
+constraint inputs. Generated snapshots are published artifacts, not committed
+authoring source. Validation should generate snapshots from source inputs and
+fail when the generated output is invalid, nondeterministic, or inconsistent
+with canonical references.
 
 Coordinates in this plan have four classes:
 
@@ -137,6 +140,12 @@ data/schematic-map/system/generator/engine/lta-system-map-2011.json
 data/schematic-map/system/generator/constraint/2012-01.json
 data/schematic-map/system/generator/constraint/2017-11.json
 data/schematic-map/system/manifest.json
+```
+
+Published archive output should expose generated complete snapshots, but these
+version files are not source-controlled by default:
+
+```text
 data/schematic-map/system/version/2012-01.json
 data/schematic-map/system/version/2017-11.json
 data/schematic-map/system/version/2019-12.json
@@ -241,15 +250,16 @@ Exit criteria:
 - The generated output is close enough to the current `2025-04` `mrtdown-site`
   hard-coded map for renderer parity work.
 - Any copied or fixed coordinates are documented as constraints or exceptions.
-- Snapshot validation fails if generated output is stale.
+- Snapshot validation fails if generated output is invalid, nondeterministic, or
+  inconsistent with canonical references.
 - Structural validation covers ids, station coverage, service-edge coverage,
-  duplicate ids, missing labels, and generated snapshot freshness before visual
-  pixel comparison is required.
+  duplicate ids, and missing labels before visual pixel comparison is required.
 
 ### Phase 4: Repository And CLI Support
 
 - Add file-backed schematic map repositories in `packages/fs`.
-- Add writer support for generated snapshots and constraint authoring.
+- Add writer support for published generated snapshots and source-controlled
+  constraint authoring.
 - Add CLI generation and validation for schematic map files.
 - Add CLI inspection helpers for listing versions, selecting the map version
   effective at a given date, and reporting hard-coded coordinate counts by
@@ -293,8 +303,8 @@ repository. The first expected client is a protected `mrtdown-site` map designer
 that uses the site renderer for visual editing and preview.
 
 - Define an edit bundle or branch layout that contains updated generator
-  constraints, regenerated complete map snapshot files, and metadata about the
-  source version and intended target version.
+  constraints, generator validation output or semantic diffs, and metadata about
+  the source version and intended target version.
 - Validate submitted files with the same canonical schema and reference checks
   used for hand-authored changes.
 - Create or document a workflow that turns designer output into a reviewed
@@ -345,17 +355,16 @@ Exit criteria:
 
 ### Phase 9: Migrate Remaining Versions
 
-- Add the remaining current timeline versions as generated complete canonical
-  snapshots.
+- Add generator source coverage for the remaining current timeline versions.
 - Validate each version independently.
 - Use semantic and visual review where practical.
-- Keep generated output or imported artifacts separate from generator source
-  changes.
+- Keep generated archive output or imported artifacts out of source control
+  unless a specific review requires committing a fixture.
 
 Exit criteria:
 
-- All existing `mrtdown-site` fixed system map timeline versions exist as
-  generated canonical schematic map data.
+- All existing `mrtdown-site` fixed system map timeline versions can be
+  generated as canonical schematic map data.
 - The data contract is stable enough for `mrtdown-site` to remove hard-coded
   map snapshots after its renderer migration is complete.
 - The amount of per-version hard-coded coordinate data is small, explained, and
@@ -370,6 +379,13 @@ Exit criteria:
 - 2026-05-25: Reframed the plan around a canonical generator that references
   current `mrtdown-site` hard-coded maps as baselines while minimizing copied
   coordinates.
+- 2026-05-26: Added the Phase 1 rule-discovery handoff to
+  `docs/schematic-map-reference-inventory.md`, covering renderer invariants,
+  initial line-family rules, coordinate classes, and unresolved coverage review
+  items for the `2025-04` baseline.
+- 2026-05-27: Clarified that generated schematic snapshots are publication
+  artifacts produced by the generator, not source-controlled data files by
+  default.
 
 ## Decision Log
 
@@ -377,6 +393,8 @@ Exit criteria:
   can reflow substantially when new lines are introduced.
 - 2026-05-24: Keep raw SVG path geometry available so artistically driven line
   bends and curves are preserved.
+- 2026-05-27: Prefer structured generated geometry from the first schema draft;
+  raw SVG path geometry is only a reviewed last-resort exception.
 - 2026-05-24: Keep rendering and interactive behavior out of canonical data;
   consumers own presentation and UI behavior.
 - 2026-05-24: Accept designer-originated schematic edits only through normal
@@ -387,8 +405,10 @@ Exit criteria:
 - 2026-05-25: Current hard-coded `mrtdown-site` maps are approved reference
   material for inventory, parity, and exception discovery.
 - 2026-05-25: The generator implementation plus rule and constraint inputs are
-  canonical; generated snapshots are committed and published artifacts that must
-  be reproducible.
+  canonical.
+- 2026-05-27: Generated snapshots are published artifacts produced by the
+  deterministic generator, not committed source files by default. This
+  supersedes the earlier assumption that generated snapshots would be committed.
 - 2026-05-25: Coordinate review distinguishes generated coordinates, reusable
   constraints, explained exceptions, and generated artifact coordinates.
 - 2026-05-25: Use `2025-04` as the first generated baseline.

--- a/docs/schematic-map-reference-inventory.md
+++ b/docs/schematic-map-reference-inventory.md
@@ -43,8 +43,10 @@ root group id, and top-level layer order.
 - Current renderer interaction ids are stable enough to preserve as generated
   snapshot ids: `line_*` for line groups and segments, `label_*` for station
   labels, and `node_*` for station nodes.
-- The generated snapshot schema should treat raw SVG path geometry as an escape
-  hatch. The `2025-04` reference includes 128 path-backed geometry ids.
+- The generated snapshot schema should prefer structured geometry. Raw SVG path
+  geometry remains a last-resort escape hatch for reviewed exceptions; the
+  `2025-04` reference includes 128 path-backed geometry ids that should not be
+  treated as the preferred baseline representation.
 - `2030-12` and `2032-12` each infer one more station id from line segments than
   from labels/nodes. That discrepancy should be reviewed before those future
   snapshots become canonical.
@@ -74,8 +76,87 @@ two separate concepts:
 The comparison found these review items:
 
 - `BDS`, `SGB`, and `XLN` appear in the `2025-04` map but are not operational
-  at that timestamp in canonical data; they should be represented as displayed
-  non-operational schematic coverage, not operational service graph coverage.
+  at that timestamp in canonical data. Omit non-operational displayed coverage
+  from the initial generator pass unless renderer parity requires it.
 - Segment ids should be generated from adjacent service path pairs. The
   published snapshot still needs stable ids and generated geometry, but the
   authoring inputs do not need to store every station-to-station segment.
+
+## Phase 1 Rule Discovery Handoff
+
+The first generator target is `2025-04`, with the `lta-system-map-2011` layout
+engine id from the active plan. These rules are inferred from the committed
+reference inventory and canonical service paths, not from a formal LTA design
+specification.
+
+### Renderer Contract Invariants
+
+- Keep map-frame dimensions version-scoped. Versions through `2025-04` use
+  `0 0 3140 2400`; versions from `2027-12` onward use `0 0 3596 2400`.
+- Preserve current interaction ids in generated snapshots: `line_*` for line
+  groups and station-to-station segments, `label_*` for station labels, and
+  `node_*` for station nodes.
+- Preserve layer ordering as explicit snapshot data. The `2025-04` baseline
+  uses `u/c`, `lines`, `labels`, then `nodes`.
+- Prefer structured generated geometry over raw SVG paths. The `2025-04`
+  baseline has 128 path-backed geometry ids, but Phase 2 should model structured
+  geometry first and keep raw paths only as explained last-resort exceptions.
+
+### Line-Family Rules For The Initial Engine
+
+- **Trunk corridors (`NSL`, `EWL`, `NEL`, `DTL`, `TEL`)** should be generated
+  from active bidirectional service paths, with one rendered station-to-station
+  segment per adjacent canonical station pair. Non-operational displayed
+  extensions can be omitted from the initial pass if that keeps the baseline
+  generator simpler.
+- **Branches and spurs** should stay attached to their service-path junctions
+  rather than becoming separate author-authored segment lists. The initial
+  branch cases are the `EWL` Changi branch from `TNM` to `CGA` via `XPO`, the
+  `CCL` extension services between `MRB` and `HBF`, and future/under-construction
+  displayed extensions.
+- **Orbital and loop lines (`CCL`, `BPLRT`, `PGLRT`, `SKLRT`)** need explicit
+  loop handling because adjacent service pairs alone do not encode the visual
+  treatment of the loop closure, branch spacing, or direction symmetry. The
+  `2025-04` map includes one non-station-to-station geometry id, `line_loop`.
+- **LRT systems** should be represented as compact local loop sublayouts
+  anchored to their MRT interchange stations: `BPLRT` at `CCK`, `PGLRT` at
+  `PGL`, and `SKLRT` at `SKG`. Their clockwise/counter-clockwise service paths
+  should collapse to the same displayed undirected segment ids.
+- **Interchanges** should be generated as composed station nodes, not a single
+  generic marker, because consumers need line-specific node parts for focused
+  line and disruption overlay behavior.
+- **Labels** should be generated as station-scoped layout hints rather than
+  localized text. Canonical station names remain outside schematic data.
+- **Construction and future display state** should eventually be represented
+  separately from operational topology, but it is not required for the initial
+  `2025-04` generator pass if non-operational displayed coverage is omitted.
+
+### Known Phase 1 Exceptions And Review Items
+
+- `BDS`, `SGB`, and `XLN` appear in the current `2025-04` schematic comparison
+  gap. They can be omitted from the first generator baseline. If a later parity
+  pass needs them, model them as displayed non-operational schematic coverage
+  rather than operational topology.
+- The previous `yck:yis` comparison mismatch is resolved after rebasing onto the
+  latest service-path data; no operational segment keys remain outside the
+  `2025-04` map inventory.
+- `2030-12` and `2032-12` infer one more station id from line segments than
+  from labels/nodes. Defer those future snapshots until the initial `2025-04`
+  schema and generator path can flag unmatched references.
+- The initial coordinate classification should use:
+  - `generated` for service-path-derived segment endpoints, station ordering,
+    and default label sides;
+  - `constraint` for map frame anchors, line corridor ordering, interchange
+    spacing, branch separation, and LRT loop anchors;
+  - `exception` for last-resort raw path geometry or fixed station/segment
+    placement that carries a written reason;
+  - `artifact` for coordinates emitted by generated snapshots.
+
+### Phase 2 Handoff
+
+The Phase 2 schema draft should start with enough structure to represent the
+`2025-04` reference without copying TSX: version metadata, frame, layer order,
+line groups, station nodes, labels, structured segment geometry, optional
+last-resort raw path exceptions, and coordinate class metadata for constraints
+and exceptions. Displayed non-operational coverage can wait until the first
+baseline needs it.


### PR DESCRIPTION
## Summary

- Documents the Phase 1 schematic rule-discovery handoff for renderer invariants, line-family rules, coordinate classes, and known coverage review items.
- Clarifies that generated schematic snapshots are publication artifacts from the deterministic generator, not source-controlled files by default.
- Records the current direction to prefer structured geometry, omit non-operational displayed coverage from the first pass, and rerun topology comparison after the latest service-data fix lands in this worktree.

## Validation

- `npm run check:docs`