### PR TITLE
feat: add schematic map schema draft

### DIFF
--- a/docs/plans/active/schematic-system-map.md
+++ b/docs/plans/active/schematic-system-map.md
@@ -210,8 +210,7 @@ geometry support until a later generator or parity pass proves it is necessary.
 - Include a layout engine id, starting with `lta-system-map-2011`.
 - Represent common geometry with structured primitives: points, polylines,
   cubic curves, labels, and node parts.
-- Include escape hatches for raw SVG path data, fixed anchors, and explicit
-  layer ordering.
+- Include escape hatches for fixed anchors and explicit layer ordering.
 - Include stable semantic ids for line groups, station nodes, station labels,
   and station-to-station segments.
 - Keep label text out of the schematic data where canonical station names

--- a/docs/plans/active/schematic-system-map.md
+++ b/docs/plans/active/schematic-system-map.md
@@ -198,6 +198,13 @@ Exit criteria:
 
 ### Phase 2: Schema Draft
 
+Start with a narrow schema before attempting layout generation. The first pass
+should define the renderer-neutral data contract for published snapshots plus
+minimal generator rule and constraint inputs. Do not include frontend-specific
+implementation details, localized label text, generated source-controlled
+version files, or layout algorithm behavior in this phase. Avoid raw SVG path
+geometry support until a later generator or parity pass proves it is necessary.
+
 - Add core schemas for generator rule configuration, per-version constraints,
   generated schematic map manifests, and generated version snapshots.
 - Include a layout engine id, starting with `lta-system-map-2011`.
@@ -386,6 +393,9 @@ Exit criteria:
 - 2026-05-27: Clarified that generated schematic snapshots are publication
   artifacts produced by the generator, not source-controlled data files by
   default.
+- 2026-05-27: Began Phase 2 with a narrow `packages/core` schema draft for
+  renderer-neutral snapshots, manifests, rule sets, and first-pass constraints;
+  raw SVG path geometry remains unsupported until proven necessary.
 
 ## Decision Log
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -18,6 +18,7 @@ export * from './schema/Landmark.js';
 export * from './schema/Line.js';
 export * from './schema/Manifest.js';
 export * from './schema/Operator.js';
+export * from './schema/SchematicMap.js';
 export * from './schema/Service.js';
 export * from './schema/Station.js';
 export * from './schema/Town.js';

--- a/packages/core/src/schema/SchematicMap.test.ts
+++ b/packages/core/src/schema/SchematicMap.test.ts
@@ -215,6 +215,12 @@ describe('SchematicMapVersionSnapshotSchema', () => {
     const result = SchematicMapTopologyReferenceSchema.parse(topology);
 
     expect(result).toEqual(topology);
+    expect(() =>
+      SchematicMapTopologyReferenceSchema.parse({
+        type: 'display_only',
+        stationIds: ['BDS'],
+      }),
+    ).toThrow(/reason/i);
   });
 
   it('allows operational support geometry that is not a station pair', () => {

--- a/packages/core/src/schema/SchematicMap.test.ts
+++ b/packages/core/src/schema/SchematicMap.test.ts
@@ -54,7 +54,62 @@ function minimalSnapshot() {
         },
       },
     ],
-    stationNodes: [] as Array<Record<string, unknown>>,
+    stationNodes: [
+      {
+        id: 'node_amk',
+        stationId: 'AMK',
+        displayStatus: 'operational',
+        layerId: 'lines',
+        center: { x: 1170, y: 550 },
+        lineIds: ['NSL'],
+        parts: [
+          {
+            id: 'node_amk_nsl',
+            lineId: 'NSL',
+            shape: {
+              type: 'circle',
+              center: { x: 1170, y: 550 },
+              radius: 11,
+            },
+            coordinateMetadata: {
+              coordinateClass: 'artifact',
+              generatedFrom: 'node_amk',
+            },
+          },
+        ],
+        coordinateMetadata: {
+          coordinateClass: 'constraint',
+          constraintId: 'anchor_amk',
+        },
+      },
+      {
+        id: 'node_bsh',
+        stationId: 'BSH',
+        displayStatus: 'operational',
+        layerId: 'lines',
+        center: { x: 1250, y: 630 },
+        lineIds: ['NSL'],
+        parts: [
+          {
+            id: 'node_bsh_nsl',
+            lineId: 'NSL',
+            shape: {
+              type: 'circle',
+              center: { x: 1250, y: 630 },
+              radius: 11,
+            },
+            coordinateMetadata: {
+              coordinateClass: 'artifact',
+              generatedFrom: 'node_bsh',
+            },
+          },
+        ],
+        coordinateMetadata: {
+          coordinateClass: 'constraint',
+          constraintId: 'anchor_bsh',
+        },
+      },
+    ] as Array<Record<string, unknown>>,
     labels: [] as Array<Record<string, unknown>>,
     stationCodeLabels: [] as Array<Record<string, unknown>>,
   };
@@ -148,6 +203,33 @@ describe('SchematicMapVersionSnapshotSchema', () => {
       ],
       stationNodes: [
         {
+          id: 'node_amk',
+          stationId: 'AMK',
+          displayStatus: 'operational',
+          layerId: 'nodes',
+          center: { x: 1170, y: 550 },
+          lineIds: ['NSL'],
+          coordinateMetadata: {
+            coordinateClass: 'constraint',
+            constraintId: 'anchor_amk',
+          },
+          parts: [
+            {
+              id: 'node_amk_nsl',
+              lineId: 'NSL',
+              shape: {
+                type: 'circle',
+                center: { x: 1170, y: 550 },
+                radius: 11,
+              },
+              coordinateMetadata: {
+                coordinateClass: 'artifact',
+                generatedFrom: 'node_amk',
+              },
+            },
+          ],
+        },
+        {
           id: 'node_bsh',
           stationId: 'BSH',
           displayStatus: 'operational',
@@ -183,6 +265,33 @@ describe('SchematicMapVersionSnapshotSchema', () => {
               coordinateMetadata: {
                 coordinateClass: 'artifact',
                 generatedFrom: 'node_bsh',
+              },
+            },
+          ],
+        },
+        {
+          id: 'node_lrc',
+          stationId: 'LRC',
+          displayStatus: 'operational',
+          layerId: 'nodes',
+          center: { x: 1450, y: 720 },
+          lineIds: ['CCL'],
+          coordinateMetadata: {
+            coordinateClass: 'constraint',
+            constraintId: 'anchor_lrc',
+          },
+          parts: [
+            {
+              id: 'node_lrc_ccl',
+              lineId: 'CCL',
+              shape: {
+                type: 'circle',
+                center: { x: 1450, y: 720 },
+                radius: 11,
+              },
+              coordinateMetadata: {
+                coordinateClass: 'artifact',
+                generatedFrom: 'node_lrc',
               },
             },
           ],
@@ -571,6 +680,41 @@ describe('SchematicMapVersionSnapshotSchema', () => {
     ).toThrow(/Duplicate stationCodeLabels id/);
   });
 
+  it('rejects duplicate station node station ids', () => {
+    const snapshot = minimalSnapshot();
+    snapshot.stationNodes.push({
+      id: 'node_bsh_copy',
+      stationId: 'BSH',
+      displayStatus: 'operational',
+      layerId: 'lines',
+      center: { x: 1260, y: 630 },
+      lineIds: ['NSL'],
+      parts: [
+        {
+          id: 'node_bsh_copy_nsl',
+          lineId: 'NSL',
+          shape: {
+            type: 'circle',
+            center: { x: 1260, y: 630 },
+            radius: 11,
+          },
+          coordinateMetadata: {
+            coordinateClass: 'artifact',
+            generatedFrom: 'node_bsh_copy',
+          },
+        },
+      ],
+      coordinateMetadata: {
+        coordinateClass: 'constraint',
+        constraintId: 'anchor_bsh_copy',
+      },
+    });
+
+    expect(() => SchematicMapVersionSnapshotSchema.parse(snapshot)).toThrow(
+      /Duplicate station node stationId/,
+    );
+  });
+
   it('rejects line groups that reference segments from another line', () => {
     const snapshot = minimalSnapshot();
     snapshot.segments[0].lineId = 'EWL';
@@ -603,6 +747,19 @@ describe('SchematicMapVersionSnapshotSchema', () => {
 
     expect(() => SchematicMapVersionSnapshotSchema.parse(snapshot)).toThrow(
       /is not included in a line group/,
+    );
+  });
+
+  it('rejects station-pair segment endpoints without station nodes', () => {
+    const snapshot = minimalSnapshot();
+    snapshot.segments[0].topology = {
+      type: 'station_pair',
+      fromStationId: 'AMK',
+      toStationId: 'BSHH',
+    };
+
+    expect(() => SchematicMapVersionSnapshotSchema.parse(snapshot)).toThrow(
+      /references station BSHH without a station node/,
     );
   });
 
@@ -692,7 +849,7 @@ describe('SchematicMapVersionSnapshotSchema', () => {
     const orphanStationCode = minimalSnapshot();
     orphanStationCode.stationCodeLabels.push({
       id: 'NS 17',
-      stationId: 'BSH',
+      stationId: 'BSHH',
       lineId: 'NSL',
       displayStatus: 'operational',
       layerId: 'lines',
@@ -710,6 +867,65 @@ describe('SchematicMapVersionSnapshotSchema', () => {
     expect(() =>
       SchematicMapVersionSnapshotSchema.parse(orphanStationCode),
     ).toThrow(/without a station node/);
+  });
+
+  it('rejects labels with statuses that differ from their station node', () => {
+    const stationNameLabel = minimalSnapshot();
+    stationNameLabel.labels.push({
+      id: 'label_bsh',
+      stationId: 'BSH',
+      displayStatus: 'planned',
+      layerId: 'lines',
+      anchor: { x: 100, y: 100 },
+      side: 'right',
+      coordinateMetadata: {
+        coordinateClass: 'generated',
+        ruleId: 'default-label',
+      },
+    });
+
+    const stationCodeLabel = minimalSnapshot();
+    stationCodeLabel.stationCodeLabels.push({
+      id: 'NS 17',
+      stationId: 'BSH',
+      lineId: 'NSL',
+      displayStatus: 'planned',
+      layerId: 'lines',
+      anchor: { x: 100, y: 100 },
+      side: 'left',
+      coordinateMetadata: {
+        coordinateClass: 'generated',
+        ruleId: 'station-code-label',
+      },
+    });
+
+    expect(() =>
+      SchematicMapVersionSnapshotSchema.parse(stationNameLabel),
+    ).toThrow(/has displayStatus planned, not operational/);
+    expect(() =>
+      SchematicMapVersionSnapshotSchema.parse(stationCodeLabel),
+    ).toThrow(/has displayStatus planned, not operational/);
+  });
+
+  it('rejects station-code labels for lines absent from their station node', () => {
+    const snapshot = minimalSnapshot();
+    snapshot.stationCodeLabels.push({
+      id: 'CC 15',
+      stationId: 'BSH',
+      lineId: 'CCL',
+      displayStatus: 'operational',
+      layerId: 'lines',
+      anchor: { x: 100, y: 100 },
+      side: 'left',
+      coordinateMetadata: {
+        coordinateClass: 'generated',
+        ruleId: 'station-code-label',
+      },
+    });
+
+    expect(() => SchematicMapVersionSnapshotSchema.parse(snapshot)).toThrow(
+      /line CCL, which is not listed on station BSH/,
+    );
   });
 });
 

--- a/packages/core/src/schema/SchematicMap.test.ts
+++ b/packages/core/src/schema/SchematicMap.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   SchematicMapConstraintSetSchema,
+  SchematicMapEffectiveDateSchema,
   SchematicMapGeometrySchema,
   SchematicMapRuleSetSchema,
   SchematicMapTopologyReferenceSchema,
@@ -177,6 +178,16 @@ describe('SchematicMapVersionSnapshotSchema', () => {
         },
       }),
     ).toThrow();
+  });
+});
+
+describe('SchematicMapEffectiveDateSchema', () => {
+  it('rejects impossible month values', () => {
+    expect(SchematicMapEffectiveDateSchema.parse('2025-01')).toBe('2025-01');
+    expect(SchematicMapEffectiveDateSchema.parse('2025-12')).toBe('2025-12');
+    expect(() => SchematicMapEffectiveDateSchema.parse('2025-00')).toThrow();
+    expect(() => SchematicMapEffectiveDateSchema.parse('2025-13')).toThrow();
+    expect(() => SchematicMapEffectiveDateSchema.parse('2025-99')).toThrow();
   });
 });
 

--- a/packages/core/src/schema/SchematicMap.test.ts
+++ b/packages/core/src/schema/SchematicMap.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, it } from 'vitest';
+import {
+  SchematicMapConstraintSetSchema,
+  SchematicMapGeometrySchema,
+  SchematicMapRuleSetSchema,
+  SchematicMapTopologyReferenceSchema,
+  SchematicMapVersionSnapshotSchema,
+} from './SchematicMap.js';
+
+describe('SchematicMapVersionSnapshotSchema', () => {
+  it('accepts a renderer-neutral system map slice without label text', () => {
+    const parsed = SchematicMapVersionSnapshotSchema.parse({
+      schemaVersion: 1,
+      mapId: 'system',
+      effectiveDate: '2025-04',
+      layoutEngineId: 'lta-system-map-2011',
+      generatedAt: '2026-05-27T00:00:00.000Z',
+      frame: {
+        x: 0,
+        y: 0,
+        width: 3140,
+        height: 2400,
+        coordinateMetadata: {
+          coordinateClass: 'constraint',
+          constraintId: 'frame_2025_04',
+        },
+      },
+      layers: [
+        { id: 'u/c', role: 'construction' },
+        { id: 'lines', role: 'line' },
+        { id: 'labels', role: 'label' },
+        { id: 'nodes', role: 'node' },
+      ],
+      lineGroups: [
+        {
+          id: 'line_NSL',
+          lineId: 'NSL',
+          displayStatus: 'operational',
+          layerId: 'lines',
+          segmentIds: ['line_amk:bsh'],
+        },
+        {
+          id: 'line_CCL',
+          lineId: 'CCL',
+          displayStatus: 'operational',
+          layerId: 'lines',
+          segmentIds: ['line_bsh:lrc'],
+        },
+      ],
+      segments: [
+        {
+          id: 'line_amk:bsh',
+          lineId: 'NSL',
+          displayStatus: 'operational',
+          layerId: 'lines',
+          topology: {
+            type: 'station_pair',
+            fromStationId: 'AMK',
+            toStationId: 'BSH',
+          },
+          geometry: {
+            type: 'polyline',
+            points: [
+              { x: 1170, y: 550 },
+              { x: 1250, y: 630 },
+            ],
+            coordinateMetadata: {
+              coordinateClass: 'generated',
+              ruleId: 'trunk-octilinear',
+            },
+          },
+        },
+        {
+          id: 'line_bsh:lrc',
+          lineId: 'CCL',
+          displayStatus: 'operational',
+          layerId: 'lines',
+          topology: {
+            type: 'station_pair',
+            fromStationId: 'BSH',
+            toStationId: 'LRC',
+          },
+          geometry: {
+            type: 'cubic_bezier',
+            start: { x: 1250, y: 630 },
+            control1: { x: 1300, y: 690 },
+            control2: { x: 1380, y: 720 },
+            end: { x: 1450, y: 720 },
+            coordinateMetadata: {
+              coordinateClass: 'constraint',
+              constraintId: 'ccl-bishan-curve',
+            },
+          },
+        },
+      ],
+      stationNodes: [
+        {
+          id: 'node_bsh',
+          stationId: 'BSH',
+          displayStatus: 'operational',
+          layerId: 'nodes',
+          center: { x: 1250, y: 630 },
+          lineIds: ['NSL', 'CCL'],
+          coordinateMetadata: {
+            coordinateClass: 'constraint',
+            constraintId: 'anchor_bsh',
+          },
+          parts: [
+            {
+              id: 'node_bsh_nsl',
+              lineId: 'NSL',
+              shape: {
+                type: 'circle',
+                center: { x: 1242, y: 630 },
+                radius: 11,
+              },
+              coordinateMetadata: {
+                coordinateClass: 'artifact',
+                generatedFrom: 'node_bsh',
+              },
+            },
+            {
+              id: 'node_bsh_ccl',
+              lineId: 'CCL',
+              shape: {
+                type: 'circle',
+                center: { x: 1258, y: 630 },
+                radius: 11,
+              },
+              coordinateMetadata: {
+                coordinateClass: 'artifact',
+                generatedFrom: 'node_bsh',
+              },
+            },
+          ],
+        },
+      ],
+      labels: [
+        {
+          id: 'label_bsh',
+          stationId: 'BSH',
+          displayStatus: 'operational',
+          layerId: 'labels',
+          anchor: { x: 1275, y: 600 },
+          side: 'top_right',
+          coordinateMetadata: {
+            coordinateClass: 'generated',
+            ruleId: 'default-interchange-label',
+          },
+        },
+      ],
+    });
+
+    expect(parsed.labels[0]).not.toHaveProperty('text');
+  });
+
+  it('allows displayed non-operational coverage only with an explicit reason', () => {
+    const topology = {
+      type: 'display_only',
+      stationIds: ['BDS'],
+      reason: 'Shown on the 2025-04 schematic before operational service.',
+    };
+
+    const result = SchematicMapTopologyReferenceSchema.parse(topology);
+
+    expect(result).toEqual(topology);
+  });
+
+  it('does not support raw SVG path geometry in the narrow schema', () => {
+    expect(() =>
+      SchematicMapGeometrySchema.parse({
+        type: 'raw_svg_path',
+        d: 'M 0 0 L 10 10',
+        coordinateMetadata: {
+          coordinateClass: 'exception',
+          reason: 'Legacy path copied from reference map.',
+        },
+      }),
+    ).toThrow();
+  });
+});
+
+describe('schematic map generator input schemas', () => {
+  it('accepts minimal rules and first-pass constraints', () => {
+    expect(
+      SchematicMapRuleSetSchema.parse({
+        schemaVersion: 1,
+        mapId: 'system',
+        layoutEngineId: 'lta-system-map-2011',
+        lineOrder: ['NSL', 'EWL', 'NEL', 'CCL', 'DTL', 'TEL'],
+      }),
+    ).toMatchObject({
+      layoutEngineId: 'lta-system-map-2011',
+    });
+
+    expect(
+      SchematicMapConstraintSetSchema.parse({
+        schemaVersion: 1,
+        mapId: 'system',
+        effectiveDate: '2025-04',
+        layoutEngineId: 'lta-system-map-2011',
+        constraints: [
+          {
+            id: 'frame_2025_04',
+            type: 'map_frame',
+            frame: { x: 0, y: 0, width: 3140, height: 2400 },
+          },
+          {
+            id: 'anchor_bsh',
+            type: 'station_anchor',
+            stationId: 'BSH',
+            point: { x: 1250, y: 630 },
+            reason: 'Keeps NSL and CCL interchange composition stable.',
+          },
+          {
+            id: 'label_bsh',
+            type: 'label_hint',
+            stationId: 'BSH',
+            side: 'top_right',
+          },
+        ],
+      }),
+    ).toMatchObject({
+      effectiveDate: '2025-04',
+      constraints: expect.arrayContaining([
+        expect.objectContaining({ type: 'station_anchor' }),
+      ]),
+    });
+  });
+});

--- a/packages/core/src/schema/SchematicMap.test.ts
+++ b/packages/core/src/schema/SchematicMap.test.ts
@@ -512,6 +512,23 @@ describe('SchematicMapVersionSnapshotSchema', () => {
       /has displayStatus planned, not operational/,
     );
   });
+
+  it('rejects segments that are omitted from line groups', () => {
+    const snapshot = minimalSnapshot();
+    snapshot.segments.push({
+      ...snapshot.segments[0],
+      id: 'line_bsh:nov',
+      topology: {
+        type: 'station_pair',
+        fromStationId: 'BSH',
+        toStationId: 'NOV',
+      },
+    });
+
+    expect(() => SchematicMapVersionSnapshotSchema.parse(snapshot)).toThrow(
+      /is not included in a line group/,
+    );
+  });
 });
 
 describe('SchematicMapEffectiveDateSchema', () => {
@@ -593,5 +610,30 @@ describe('schematic map generator input schemas', () => {
         expect.objectContaining({ type: 'station_anchor' }),
       ]),
     });
+  });
+
+  it('rejects duplicate constraint ids', () => {
+    expect(() =>
+      SchematicMapConstraintSetSchema.parse({
+        schemaVersion: 1,
+        mapId: 'system',
+        effectiveDate: '2025-04',
+        layoutEngineId: 'lta-system-map-2011',
+        constraints: [
+          {
+            id: 'anchor_bsh',
+            type: 'station_anchor',
+            stationId: 'BSH',
+            point: { x: 1250, y: 630 },
+          },
+          {
+            id: 'anchor_bsh',
+            type: 'label_hint',
+            stationId: 'BSH',
+            side: 'top_right',
+          },
+        ],
+      }),
+    ).toThrow(/Duplicate schematic map constraint id/);
   });
 });

--- a/packages/core/src/schema/SchematicMap.test.ts
+++ b/packages/core/src/schema/SchematicMap.test.ts
@@ -5,6 +5,7 @@ import {
   SchematicMapGeometrySchema,
   SchematicMapLabelSchema,
   SchematicMapRuleSetSchema,
+  SchematicMapSegmentSchema,
   SchematicMapStationNodeSchema,
   SchematicMapTopologyReferenceSchema,
   SchematicMapVersionSnapshotSchema,
@@ -283,6 +284,41 @@ describe('SchematicMapVersionSnapshotSchema', () => {
     expect(
       SchematicMapLabelSchema.parse({
         ...label,
+        displayReason: 'Shown before operational service for renderer parity.',
+      }),
+    ).toMatchObject({ displayReason: expect.any(String) });
+  });
+
+  it('requires display-only segments to explain why they are shown', () => {
+    const segment = {
+      id: 'line_bds:spr',
+      lineId: 'TEL',
+      displayStatus: 'display_only',
+      layerId: 'lines',
+      topology: {
+        type: 'station_pair',
+        fromStationId: 'BDS',
+        toStationId: 'SPR',
+      },
+      geometry: {
+        type: 'polyline',
+        points: [
+          { x: 100, y: 100 },
+          { x: 140, y: 100 },
+        ],
+        coordinateMetadata: {
+          coordinateClass: 'constraint',
+          constraintId: 'display-only-segment',
+        },
+      },
+    };
+
+    expect(() => SchematicMapSegmentSchema.parse(segment)).toThrow(
+      /displayReason/,
+    );
+    expect(
+      SchematicMapSegmentSchema.parse({
+        ...segment,
         displayReason: 'Shown before operational service for renderer parity.',
       }),
     ).toMatchObject({ displayReason: expect.any(String) });

--- a/packages/core/src/schema/SchematicMap.test.ts
+++ b/packages/core/src/schema/SchematicMap.test.ts
@@ -3,10 +3,59 @@ import {
   SchematicMapConstraintSetSchema,
   SchematicMapEffectiveDateSchema,
   SchematicMapGeometrySchema,
+  SchematicMapLabelSchema,
   SchematicMapRuleSetSchema,
+  SchematicMapStationNodeSchema,
   SchematicMapTopologyReferenceSchema,
   SchematicMapVersionSnapshotSchema,
 } from './SchematicMap.js';
+
+function minimalSnapshot() {
+  return {
+    schemaVersion: 1,
+    mapId: 'system',
+    effectiveDate: '2025-04',
+    layoutEngineId: 'lta-system-map-2011',
+    generatedAt: '2026-05-27T00:00:00.000Z',
+    frame: { x: 0, y: 0, width: 3140, height: 2400 },
+    layers: [{ id: 'lines', role: 'line' }],
+    lineGroups: [
+      {
+        id: 'line_NSL',
+        lineId: 'NSL',
+        displayStatus: 'operational',
+        layerId: 'lines',
+        segmentIds: ['line_amk:bsh'],
+      },
+    ],
+    segments: [
+      {
+        id: 'line_amk:bsh',
+        lineId: 'NSL',
+        displayStatus: 'operational',
+        layerId: 'lines',
+        topology: {
+          type: 'station_pair',
+          fromStationId: 'AMK',
+          toStationId: 'BSH',
+        },
+        geometry: {
+          type: 'polyline',
+          points: [
+            { x: 1170, y: 550 },
+            { x: 1250, y: 630 },
+          ],
+          coordinateMetadata: {
+            coordinateClass: 'generated',
+            ruleId: 'trunk-octilinear',
+          },
+        },
+      },
+    ],
+    stationNodes: [],
+    labels: [],
+  };
+}
 
 describe('SchematicMapVersionSnapshotSchema', () => {
   it('accepts a renderer-neutral system map slice without label text', () => {
@@ -178,6 +227,80 @@ describe('SchematicMapVersionSnapshotSchema', () => {
         },
       }),
     ).toThrow();
+  });
+
+  it('requires display-only station nodes and labels to explain why they are shown', () => {
+    const node = {
+      id: 'node_bds',
+      stationId: 'BDS',
+      displayStatus: 'display_only',
+      layerId: 'nodes',
+      center: { x: 100, y: 100 },
+      lineIds: ['TEL'],
+      parts: [
+        {
+          id: 'node_bds_tel',
+          lineId: 'TEL',
+          shape: {
+            type: 'circle',
+            center: { x: 100, y: 100 },
+            radius: 11,
+          },
+          coordinateMetadata: {
+            coordinateClass: 'artifact',
+            generatedFrom: 'node_bds',
+          },
+        },
+      ],
+      coordinateMetadata: {
+        coordinateClass: 'constraint',
+        constraintId: 'anchor_bds',
+      },
+    };
+    const label = {
+      id: 'label_bds',
+      stationId: 'BDS',
+      displayStatus: 'display_only',
+      layerId: 'labels',
+      anchor: { x: 120, y: 90 },
+      side: 'top_right',
+      coordinateMetadata: {
+        coordinateClass: 'generated',
+        ruleId: 'default-label',
+      },
+    };
+
+    expect(() => SchematicMapStationNodeSchema.parse(node)).toThrow(
+      /displayReason/,
+    );
+    expect(() => SchematicMapLabelSchema.parse(label)).toThrow(/displayReason/);
+    expect(
+      SchematicMapStationNodeSchema.parse({
+        ...node,
+        displayReason: 'Shown before operational service for renderer parity.',
+      }),
+    ).toMatchObject({ displayReason: expect.any(String) });
+    expect(
+      SchematicMapLabelSchema.parse({
+        ...label,
+        displayReason: 'Shown before operational service for renderer parity.',
+      }),
+    ).toMatchObject({ displayReason: expect.any(String) });
+  });
+
+  it('rejects snapshots with unknown internal layer or segment references', () => {
+    const missingLayer = minimalSnapshot();
+    missingLayer.segments[0].layerId = 'line';
+
+    const missingSegment = minimalSnapshot();
+    missingSegment.lineGroups[0].segmentIds = ['line_missing'];
+
+    expect(() => SchematicMapVersionSnapshotSchema.parse(missingLayer)).toThrow(
+      /Unknown layer id/,
+    );
+    expect(() =>
+      SchematicMapVersionSnapshotSchema.parse(missingSegment),
+    ).toThrow(/Unknown segment id/);
   });
 });
 

--- a/packages/core/src/schema/SchematicMap.test.ts
+++ b/packages/core/src/schema/SchematicMap.test.ts
@@ -390,6 +390,40 @@ describe('SchematicMapVersionSnapshotSchema', () => {
     );
   });
 
+  it('rejects station nodes that omit parts for listed parent lines', () => {
+    const node = {
+      id: 'node_bsh',
+      stationId: 'BSH',
+      displayStatus: 'operational',
+      layerId: 'nodes',
+      center: { x: 100, y: 100 },
+      lineIds: ['NSL', 'CCL'],
+      parts: [
+        {
+          id: 'node_bsh_nsl',
+          lineId: 'NSL',
+          shape: {
+            type: 'circle',
+            center: { x: 100, y: 100 },
+            radius: 11,
+          },
+          coordinateMetadata: {
+            coordinateClass: 'artifact',
+            generatedFrom: 'node_bsh',
+          },
+        },
+      ],
+      coordinateMetadata: {
+        coordinateClass: 'constraint',
+        constraintId: 'anchor_bsh',
+      },
+    };
+
+    expect(() => SchematicMapStationNodeSchema.parse(node)).toThrow(
+      /has no matching node part/,
+    );
+  });
+
   it('requires display-only segments to explain why they are shown', () => {
     const segment = {
       id: 'line_bds:spr',
@@ -467,6 +501,15 @@ describe('SchematicMapVersionSnapshotSchema', () => {
 
     expect(() => SchematicMapVersionSnapshotSchema.parse(snapshot)).toThrow(
       /belongs to EWL, not NSL/,
+    );
+  });
+
+  it('rejects line groups that reference segments with another display status', () => {
+    const snapshot = minimalSnapshot();
+    snapshot.segments[0].displayStatus = 'planned';
+
+    expect(() => SchematicMapVersionSnapshotSchema.parse(snapshot)).toThrow(
+      /has displayStatus planned, not operational/,
     );
   });
 });

--- a/packages/core/src/schema/SchematicMap.test.ts
+++ b/packages/core/src/schema/SchematicMap.test.ts
@@ -217,6 +217,39 @@ describe('SchematicMapVersionSnapshotSchema', () => {
     expect(result).toEqual(topology);
   });
 
+  it('allows operational support geometry that is not a station pair', () => {
+    expect(
+      SchematicMapSegmentSchema.parse({
+        id: 'line_loop',
+        lineId: 'CCL',
+        displayStatus: 'operational',
+        layerId: 'lines',
+        topology: {
+          type: 'support',
+          supportType: 'loop',
+          reason:
+            'Represents operational loop geometry that is not a station-to-station segment.',
+        },
+        geometry: {
+          type: 'polyline',
+          points: [
+            { x: 100, y: 100 },
+            { x: 120, y: 120 },
+          ],
+          coordinateMetadata: {
+            coordinateClass: 'generated',
+            ruleId: 'loop-support',
+          },
+        },
+      }),
+    ).toMatchObject({
+      topology: {
+        type: 'support',
+        supportType: 'loop',
+      },
+    });
+  });
+
   it('does not support raw SVG path geometry in the narrow schema', () => {
     expect(() =>
       SchematicMapGeometrySchema.parse({

--- a/packages/core/src/schema/SchematicMap.test.ts
+++ b/packages/core/src/schema/SchematicMap.test.ts
@@ -4,6 +4,7 @@ import {
   SchematicMapEffectiveDateSchema,
   SchematicMapGeometrySchema,
   SchematicMapLabelSchema,
+  SchematicMapManifestSchema,
   SchematicMapRuleSetSchema,
   SchematicMapSegmentSchema,
   SchematicMapStationNodeSchema,
@@ -256,6 +257,33 @@ describe('SchematicMapVersionSnapshotSchema', () => {
     });
   });
 
+  it('rejects operational segments with display-only topology', () => {
+    expect(() =>
+      SchematicMapSegmentSchema.parse({
+        id: 'line_bds:spr',
+        lineId: 'TEL',
+        displayStatus: 'operational',
+        layerId: 'lines',
+        topology: {
+          type: 'display_only',
+          stationIds: ['BDS', 'SPR'],
+          reason: 'Shown before operational service for renderer parity.',
+        },
+        geometry: {
+          type: 'polyline',
+          points: [
+            { x: 100, y: 100 },
+            { x: 140, y: 100 },
+          ],
+          coordinateMetadata: {
+            coordinateClass: 'constraint',
+            constraintId: 'display-only-segment',
+          },
+        },
+      }),
+    ).toThrow(/cannot be marked operational/);
+  });
+
   it('does not support raw SVG path geometry in the narrow schema', () => {
     expect(() =>
       SchematicMapGeometrySchema.parse({
@@ -326,6 +354,40 @@ describe('SchematicMapVersionSnapshotSchema', () => {
         displayReason: 'Shown before operational service for renderer parity.',
       }),
     ).toMatchObject({ displayReason: expect.any(String) });
+  });
+
+  it('rejects station node parts that are not listed on the parent node', () => {
+    const node = {
+      id: 'node_bsh',
+      stationId: 'BSH',
+      displayStatus: 'operational',
+      layerId: 'nodes',
+      center: { x: 100, y: 100 },
+      lineIds: ['NSL', 'CCL'],
+      parts: [
+        {
+          id: 'node_bsh_ewl',
+          lineId: 'EWL',
+          shape: {
+            type: 'circle',
+            center: { x: 100, y: 100 },
+            radius: 11,
+          },
+          coordinateMetadata: {
+            coordinateClass: 'artifact',
+            generatedFrom: 'node_bsh',
+          },
+        },
+      ],
+      coordinateMetadata: {
+        coordinateClass: 'constraint',
+        constraintId: 'anchor_bsh',
+      },
+    };
+
+    expect(() => SchematicMapStationNodeSchema.parse(node)).toThrow(
+      /not listed on the parent node/,
+    );
   });
 
   it('requires display-only segments to explain why they are shown', () => {
@@ -416,6 +478,29 @@ describe('SchematicMapEffectiveDateSchema', () => {
     expect(() => SchematicMapEffectiveDateSchema.parse('2025-00')).toThrow();
     expect(() => SchematicMapEffectiveDateSchema.parse('2025-13')).toThrow();
     expect(() => SchematicMapEffectiveDateSchema.parse('2025-99')).toThrow();
+  });
+});
+
+describe('SchematicMapManifestSchema', () => {
+  it('rejects duplicate effective dates', () => {
+    expect(() =>
+      SchematicMapManifestSchema.parse({
+        schemaVersion: 1,
+        mapId: 'system',
+        versions: [
+          {
+            effectiveDate: '2025-04',
+            path: 'version/2025-04.json',
+            layoutEngineId: 'lta-system-map-2011',
+          },
+          {
+            effectiveDate: '2025-04',
+            path: 'version/2025-04-copy.json',
+            layoutEngineId: 'lta-system-map-2011',
+          },
+        ],
+      }),
+    ).toThrow(/Duplicate schematic map effective date/);
   });
 });
 

--- a/packages/core/src/schema/SchematicMap.test.ts
+++ b/packages/core/src/schema/SchematicMap.test.ts
@@ -377,6 +377,36 @@ describe('SchematicMapVersionSnapshotSchema', () => {
       SchematicMapVersionSnapshotSchema.parse(missingSegment),
     ).toThrow(/Unknown segment id/);
   });
+
+  it('rejects snapshots with duplicate stable ids', () => {
+    const duplicateLayer = minimalSnapshot();
+    duplicateLayer.layers.push({ id: 'lines', role: 'line' });
+
+    const duplicateSegment = minimalSnapshot();
+    duplicateSegment.segments.push({ ...duplicateSegment.segments[0] });
+
+    const duplicateLineGroup = minimalSnapshot();
+    duplicateLineGroup.lineGroups.push({ ...duplicateLineGroup.lineGroups[0] });
+
+    expect(() =>
+      SchematicMapVersionSnapshotSchema.parse(duplicateLayer),
+    ).toThrow(/Duplicate layers id/);
+    expect(() =>
+      SchematicMapVersionSnapshotSchema.parse(duplicateSegment),
+    ).toThrow(/Duplicate segments id/);
+    expect(() =>
+      SchematicMapVersionSnapshotSchema.parse(duplicateLineGroup),
+    ).toThrow(/Duplicate lineGroups id/);
+  });
+
+  it('rejects line groups that reference segments from another line', () => {
+    const snapshot = minimalSnapshot();
+    snapshot.segments[0].lineId = 'EWL';
+
+    expect(() => SchematicMapVersionSnapshotSchema.parse(snapshot)).toThrow(
+      /belongs to EWL, not NSL/,
+    );
+  });
 });
 
 describe('SchematicMapEffectiveDateSchema', () => {

--- a/packages/core/src/schema/SchematicMap.test.ts
+++ b/packages/core/src/schema/SchematicMap.test.ts
@@ -54,8 +54,9 @@ function minimalSnapshot() {
         },
       },
     ],
-    stationNodes: [],
-    labels: [],
+    stationNodes: [] as Array<Record<string, unknown>>,
+    labels: [] as Array<Record<string, unknown>>,
+    stationCodeLabels: [] as Array<Record<string, unknown>>,
   };
 }
 
@@ -198,6 +199,21 @@ describe('SchematicMapVersionSnapshotSchema', () => {
           coordinateMetadata: {
             coordinateClass: 'generated',
             ruleId: 'default-interchange-label',
+          },
+        },
+      ],
+      stationCodeLabels: [
+        {
+          id: 'NS 17',
+          stationId: 'BSH',
+          lineId: 'NSL',
+          displayStatus: 'operational',
+          layerId: 'labels',
+          anchor: { x: 1235, y: 610 },
+          side: 'left',
+          coordinateMetadata: {
+            coordinateClass: 'generated',
+            ruleId: 'default-station-code-label',
           },
         },
       ],
@@ -484,6 +500,63 @@ describe('SchematicMapVersionSnapshotSchema', () => {
     const duplicateLineGroup = minimalSnapshot();
     duplicateLineGroup.lineGroups.push({ ...duplicateLineGroup.lineGroups[0] });
 
+    const duplicateStationCodeLabel = minimalSnapshot();
+    duplicateStationCodeLabel.stationNodes.push({
+      id: 'node_bsh',
+      stationId: 'BSH',
+      displayStatus: 'operational',
+      layerId: 'lines',
+      center: { x: 100, y: 100 },
+      lineIds: ['NSL'],
+      parts: [
+        {
+          id: 'node_bsh_nsl',
+          lineId: 'NSL',
+          shape: {
+            type: 'circle',
+            center: { x: 100, y: 100 },
+            radius: 11,
+          },
+          coordinateMetadata: {
+            coordinateClass: 'artifact',
+            generatedFrom: 'node_bsh',
+          },
+        },
+      ],
+      coordinateMetadata: {
+        coordinateClass: 'constraint',
+        constraintId: 'anchor_bsh',
+      },
+    });
+    duplicateStationCodeLabel.stationCodeLabels.push(
+      {
+        id: 'NS 17',
+        stationId: 'BSH',
+        lineId: 'NSL',
+        displayStatus: 'operational',
+        layerId: 'lines',
+        anchor: { x: 100, y: 100 },
+        side: 'left',
+        coordinateMetadata: {
+          coordinateClass: 'generated',
+          ruleId: 'station-code-label',
+        },
+      },
+      {
+        id: 'NS 17',
+        stationId: 'BSH',
+        lineId: 'NSL',
+        displayStatus: 'operational',
+        layerId: 'lines',
+        anchor: { x: 120, y: 100 },
+        side: 'right',
+        coordinateMetadata: {
+          coordinateClass: 'generated',
+          ruleId: 'station-code-label',
+        },
+      },
+    );
+
     expect(() =>
       SchematicMapVersionSnapshotSchema.parse(duplicateLayer),
     ).toThrow(/Duplicate layers id/);
@@ -493,6 +566,9 @@ describe('SchematicMapVersionSnapshotSchema', () => {
     expect(() =>
       SchematicMapVersionSnapshotSchema.parse(duplicateLineGroup),
     ).toThrow(/Duplicate lineGroups id/);
+    expect(() =>
+      SchematicMapVersionSnapshotSchema.parse(duplicateStationCodeLabel),
+    ).toThrow(/Duplicate stationCodeLabels id/);
   });
 
   it('rejects line groups that reference segments from another line', () => {
@@ -528,6 +604,112 @@ describe('SchematicMapVersionSnapshotSchema', () => {
     expect(() => SchematicMapVersionSnapshotSchema.parse(snapshot)).toThrow(
       /is not included in a line group/,
     );
+  });
+
+  it('rejects segment ids repeated in line group membership', () => {
+    const repeatedWithinGroup = minimalSnapshot();
+    repeatedWithinGroup.lineGroups[0].segmentIds = [
+      'line_amk:bsh',
+      'line_amk:bsh',
+    ];
+
+    const repeatedAcrossGroups = minimalSnapshot();
+    repeatedAcrossGroups.lineGroups.push({
+      ...repeatedAcrossGroups.lineGroups[0],
+      id: 'line_NSL_copy',
+    });
+
+    expect(() =>
+      SchematicMapVersionSnapshotSchema.parse(repeatedWithinGroup),
+    ).toThrow(/listed in multiple line group positions/);
+    expect(() =>
+      SchematicMapVersionSnapshotSchema.parse(repeatedAcrossGroups),
+    ).toThrow(/listed in multiple line group positions/);
+  });
+
+  it('rejects duplicate station node part ids', () => {
+    const node = {
+      id: 'node_bsh',
+      stationId: 'BSH',
+      displayStatus: 'operational',
+      layerId: 'nodes',
+      center: { x: 100, y: 100 },
+      lineIds: ['NSL'],
+      parts: [
+        {
+          id: 'node_bsh_nsl',
+          lineId: 'NSL',
+          shape: {
+            type: 'circle',
+            center: { x: 100, y: 100 },
+            radius: 11,
+          },
+          coordinateMetadata: {
+            coordinateClass: 'artifact',
+            generatedFrom: 'node_bsh',
+          },
+        },
+        {
+          id: 'node_bsh_nsl',
+          lineId: 'NSL',
+          shape: {
+            type: 'circle',
+            center: { x: 110, y: 100 },
+            radius: 11,
+          },
+          coordinateMetadata: {
+            coordinateClass: 'artifact',
+            generatedFrom: 'node_bsh',
+          },
+        },
+      ],
+      coordinateMetadata: {
+        coordinateClass: 'constraint',
+        constraintId: 'anchor_bsh',
+      },
+    };
+
+    expect(() => SchematicMapStationNodeSchema.parse(node)).toThrow(
+      /Duplicate station node part id/,
+    );
+  });
+
+  it('rejects labels and station-code labels without station nodes', () => {
+    const orphanLabel = minimalSnapshot();
+    orphanLabel.labels.push({
+      id: 'label_bshh',
+      stationId: 'BSHH',
+      displayStatus: 'operational',
+      layerId: 'lines',
+      anchor: { x: 100, y: 100 },
+      side: 'right',
+      coordinateMetadata: {
+        coordinateClass: 'generated',
+        ruleId: 'default-label',
+      },
+    });
+
+    const orphanStationCode = minimalSnapshot();
+    orphanStationCode.stationCodeLabels.push({
+      id: 'NS 17',
+      stationId: 'BSH',
+      lineId: 'NSL',
+      displayStatus: 'operational',
+      layerId: 'lines',
+      anchor: { x: 100, y: 100 },
+      side: 'left',
+      coordinateMetadata: {
+        coordinateClass: 'generated',
+        ruleId: 'station-code-label',
+      },
+    });
+
+    expect(() => SchematicMapVersionSnapshotSchema.parse(orphanLabel)).toThrow(
+      /without a station node/,
+    );
+    expect(() =>
+      SchematicMapVersionSnapshotSchema.parse(orphanStationCode),
+    ).toThrow(/without a station node/);
   });
 });
 

--- a/packages/core/src/schema/SchematicMap.ts
+++ b/packages/core/src/schema/SchematicMap.ts
@@ -13,7 +13,7 @@ export type SchematicMapSchemaVersion = z.infer<
  */
 export const SchematicMapEffectiveDateSchema = z
   .string()
-  .regex(/^\d{4}-\d{2}$/);
+  .regex(/^\d{4}-(0[1-9]|1[0-2])$/);
 export type SchematicMapEffectiveDate = z.infer<
   typeof SchematicMapEffectiveDateSchema
 >;

--- a/packages/core/src/schema/SchematicMap.ts
+++ b/packages/core/src/schema/SchematicMap.ts
@@ -349,12 +349,49 @@ export const SchematicMapVersionSnapshotSchema = z
     labels: z.array(SchematicMapLabelSchema),
   })
   .superRefine((snapshot, context) => {
+    const addDuplicateIdIssues = (
+      collectionName:
+        | 'layers'
+        | 'lineGroups'
+        | 'segments'
+        | 'stationNodes'
+        | 'labels',
+      entries: Array<{ id: string }>,
+    ) => {
+      const seenIds = new Set<string>();
+
+      entries.forEach((entry, index) => {
+        if (seenIds.has(entry.id)) {
+          context.addIssue({
+            code: 'custom',
+            message: `Duplicate ${collectionName} id: ${entry.id}`,
+            path: [collectionName, index, 'id'],
+          });
+          return;
+        }
+
+        seenIds.add(entry.id);
+      });
+    };
+
+    addDuplicateIdIssues('layers', snapshot.layers);
+    addDuplicateIdIssues('lineGroups', snapshot.lineGroups);
+    addDuplicateIdIssues('segments', snapshot.segments);
+    addDuplicateIdIssues('stationNodes', snapshot.stationNodes);
+    addDuplicateIdIssues('labels', snapshot.labels);
+
     const layerIds = new Set(snapshot.layers.map((layer) => layer.id));
-    const segmentIds = new Set(snapshot.segments.map((segment) => segment.id));
+    const segmentsById = new Map<string, SchematicMapSegment>();
     const layerReferences: Array<{
       layerId: string;
       path: Array<string | number>;
     }> = [];
+
+    for (const segment of snapshot.segments) {
+      if (!segmentsById.has(segment.id)) {
+        segmentsById.set(segment.id, segment);
+      }
+    }
 
     snapshot.lineGroups.forEach((lineGroup, index) => {
       layerReferences.push({
@@ -363,10 +400,21 @@ export const SchematicMapVersionSnapshotSchema = z
       });
 
       lineGroup.segmentIds.forEach((segmentId, segmentIndex) => {
-        if (!segmentIds.has(segmentId)) {
+        const segment = segmentsById.get(segmentId);
+
+        if (!segment) {
           context.addIssue({
             code: 'custom',
             message: `Unknown segment id: ${segmentId}`,
+            path: ['lineGroups', index, 'segmentIds', segmentIndex],
+          });
+          return;
+        }
+
+        if (segment.lineId !== lineGroup.lineId) {
+          context.addIssue({
+            code: 'custom',
+            message: `Segment ${segmentId} belongs to ${segment.lineId}, not ${lineGroup.lineId}`,
             path: ['lineGroups', index, 'segmentIds', segmentIndex],
           });
         }

--- a/packages/core/src/schema/SchematicMap.ts
+++ b/packages/core/src/schema/SchematicMap.ts
@@ -155,8 +155,9 @@ export const SchematicMapLayerSchema = z.object({
 export type SchematicMapLayer = z.infer<typeof SchematicMapLayerSchema>;
 
 /**
- * Link from schematic geometry back to canonical topology, or an explicit
- * display-only item with a written reason.
+ * Link from schematic geometry back to canonical topology, operational
+ * schematic support geometry, or an explicit display-only item with a written
+ * reason.
  */
 export const SchematicMapTopologyReferenceSchema = z.discriminatedUnion(
   'type',
@@ -165,6 +166,12 @@ export const SchematicMapTopologyReferenceSchema = z.discriminatedUnion(
       type: z.literal('station_pair'),
       fromStationId: z.string(),
       toStationId: z.string(),
+    }),
+    z.object({
+      type: z.literal('support'),
+      supportType: z.enum(['loop', 'connector', 'other']),
+      stationIds: z.array(z.string()).optional(),
+      reason: z.string().min(1),
     }),
     z.object({
       type: z.literal('display_only'),

--- a/packages/core/src/schema/SchematicMap.ts
+++ b/packages/core/src/schema/SchematicMap.ts
@@ -307,8 +307,19 @@ export const SchematicMapStationNodeSchema = z
   .superRefine((node, context) => {
     const lineIds = new Set(node.lineIds);
     const partLineIds = new Set(node.parts.map((part) => part.lineId));
+    const partIds = new Set<string>();
 
     node.parts.forEach((part, index) => {
+      if (partIds.has(part.id)) {
+        context.addIssue({
+          code: 'custom',
+          message: `Duplicate station node part id: ${part.id}`,
+          path: ['parts', index, 'id'],
+        });
+      }
+
+      partIds.add(part.id);
+
       if (!lineIds.has(part.lineId)) {
         context.addIssue({
           code: 'custom',
@@ -368,6 +379,28 @@ export const SchematicMapLabelSchema = z
 export type SchematicMapLabel = z.infer<typeof SchematicMapLabelSchema>;
 
 /**
+ * Station-code badge placement data. It stores code layout records only; code
+ * text still comes from canonical station data.
+ */
+export const SchematicMapStationCodeLabelSchema = z
+  .object({
+    id: z.string(),
+    stationId: z.string(),
+    lineId: z.string(),
+    displayStatus: SchematicMapDisplayStatusSchema,
+    displayReason: z.string().min(1).optional(),
+    layerId: z.string(),
+    anchor: SchematicMapPointSchema,
+    side: SchematicMapLabelSideSchema,
+    rotationDegrees: z.number().optional(),
+    coordinateMetadata: SchematicMapCoordinateMetadataSchema,
+  })
+  .superRefine(requireDisplayReasonForDisplayOnly);
+export type SchematicMapStationCodeLabel = z.infer<
+  typeof SchematicMapStationCodeLabelSchema
+>;
+
+/**
  * Complete published schematic map snapshot for one effective date.
  */
 export const SchematicMapVersionSnapshotSchema = z
@@ -383,6 +416,7 @@ export const SchematicMapVersionSnapshotSchema = z
     segments: z.array(SchematicMapSegmentSchema),
     stationNodes: z.array(SchematicMapStationNodeSchema),
     labels: z.array(SchematicMapLabelSchema),
+    stationCodeLabels: z.array(SchematicMapStationCodeLabelSchema),
   })
   .superRefine((snapshot, context) => {
     const addDuplicateIdIssues = (
@@ -391,7 +425,8 @@ export const SchematicMapVersionSnapshotSchema = z
         | 'lineGroups'
         | 'segments'
         | 'stationNodes'
-        | 'labels',
+        | 'labels'
+        | 'stationCodeLabels',
       entries: Array<{ id: string }>,
     ) => {
       const seenIds = new Set<string>();
@@ -415,8 +450,12 @@ export const SchematicMapVersionSnapshotSchema = z
     addDuplicateIdIssues('segments', snapshot.segments);
     addDuplicateIdIssues('stationNodes', snapshot.stationNodes);
     addDuplicateIdIssues('labels', snapshot.labels);
+    addDuplicateIdIssues('stationCodeLabels', snapshot.stationCodeLabels);
 
     const layerIds = new Set(snapshot.layers.map((layer) => layer.id));
+    const stationNodeIds = new Set(
+      snapshot.stationNodes.map((node) => node.stationId),
+    );
     const segmentsById = new Map<string, SchematicMapSegment>();
     const groupedSegmentIds = new Set<string>();
     const layerReferences: Array<{
@@ -437,6 +476,14 @@ export const SchematicMapVersionSnapshotSchema = z
       });
 
       lineGroup.segmentIds.forEach((segmentId, segmentIndex) => {
+        if (groupedSegmentIds.has(segmentId)) {
+          context.addIssue({
+            code: 'custom',
+            message: `Segment ${segmentId} is listed in multiple line group positions`,
+            path: ['lineGroups', index, 'segmentIds', segmentIndex],
+          });
+        }
+
         groupedSegmentIds.add(segmentId);
         const segment = segmentsById.get(segmentId);
 
@@ -494,6 +541,29 @@ export const SchematicMapVersionSnapshotSchema = z
         layerId: label.layerId,
         path: ['labels', index, 'layerId'],
       });
+
+      if (!stationNodeIds.has(label.stationId)) {
+        context.addIssue({
+          code: 'custom',
+          message: `Label ${label.id} references station ${label.stationId} without a station node`,
+          path: ['labels', index, 'stationId'],
+        });
+      }
+    });
+
+    snapshot.stationCodeLabels.forEach((label, index) => {
+      layerReferences.push({
+        layerId: label.layerId,
+        path: ['stationCodeLabels', index, 'layerId'],
+      });
+
+      if (!stationNodeIds.has(label.stationId)) {
+        context.addIssue({
+          code: 'custom',
+          message: `Station code label ${label.id} references station ${label.stationId} without a station node`,
+          path: ['stationCodeLabels', index, 'stationId'],
+        });
+      }
     });
 
     for (const reference of layerReferences) {

--- a/packages/core/src/schema/SchematicMap.ts
+++ b/packages/core/src/schema/SchematicMap.ts
@@ -1,0 +1,313 @@
+import z from 'zod';
+
+export const SchematicMapSchemaVersionSchema = z.literal(1);
+export type SchematicMapSchemaVersion = z.infer<
+  typeof SchematicMapSchemaVersionSchema
+>;
+
+export const SchematicMapEffectiveDateSchema = z
+  .string()
+  .regex(/^\d{4}-\d{2}$/);
+export type SchematicMapEffectiveDate = z.infer<
+  typeof SchematicMapEffectiveDateSchema
+>;
+
+export const SchematicMapLayoutEngineIdSchema = z.literal(
+  'lta-system-map-2011',
+);
+export type SchematicMapLayoutEngineId = z.infer<
+  typeof SchematicMapLayoutEngineIdSchema
+>;
+
+export const SchematicMapDisplayStatusSchema = z.enum([
+  'operational',
+  'under_construction',
+  'planned',
+  'display_only',
+]);
+export type SchematicMapDisplayStatus = z.infer<
+  typeof SchematicMapDisplayStatusSchema
+>;
+
+export const SchematicMapCoordinateMetadataSchema = z.discriminatedUnion(
+  'coordinateClass',
+  [
+    z.object({
+      coordinateClass: z.literal('generated'),
+      ruleId: z.string().optional(),
+    }),
+    z.object({
+      coordinateClass: z.literal('constraint'),
+      constraintId: z.string(),
+    }),
+    z.object({
+      coordinateClass: z.literal('exception'),
+      reason: z.string().min(1),
+    }),
+    z.object({
+      coordinateClass: z.literal('artifact'),
+      generatedFrom: z.string().optional(),
+    }),
+  ],
+);
+export type SchematicMapCoordinateMetadata = z.infer<
+  typeof SchematicMapCoordinateMetadataSchema
+>;
+
+export const SchematicMapPointSchema = z.object({
+  x: z.number(),
+  y: z.number(),
+});
+export type SchematicMapPoint = z.infer<typeof SchematicMapPointSchema>;
+
+export const SchematicMapFrameSchema = z.object({
+  x: z.number(),
+  y: z.number(),
+  width: z.number().positive(),
+  height: z.number().positive(),
+  coordinateMetadata: SchematicMapCoordinateMetadataSchema.optional(),
+});
+export type SchematicMapFrame = z.infer<typeof SchematicMapFrameSchema>;
+
+export const SchematicMapPolylineGeometrySchema = z.object({
+  type: z.literal('polyline'),
+  points: z.array(SchematicMapPointSchema).min(2),
+  coordinateMetadata: SchematicMapCoordinateMetadataSchema,
+});
+export type SchematicMapPolylineGeometry = z.infer<
+  typeof SchematicMapPolylineGeometrySchema
+>;
+
+export const SchematicMapCubicBezierGeometrySchema = z.object({
+  type: z.literal('cubic_bezier'),
+  start: SchematicMapPointSchema,
+  control1: SchematicMapPointSchema,
+  control2: SchematicMapPointSchema,
+  end: SchematicMapPointSchema,
+  coordinateMetadata: SchematicMapCoordinateMetadataSchema,
+});
+export type SchematicMapCubicBezierGeometry = z.infer<
+  typeof SchematicMapCubicBezierGeometrySchema
+>;
+
+export const SchematicMapGeometrySchema = z.discriminatedUnion('type', [
+  SchematicMapPolylineGeometrySchema,
+  SchematicMapCubicBezierGeometrySchema,
+]);
+export type SchematicMapGeometry = z.infer<typeof SchematicMapGeometrySchema>;
+
+export const SchematicMapLayerRoleSchema = z.enum([
+  'construction',
+  'line',
+  'label',
+  'node',
+  'other',
+]);
+export type SchematicMapLayerRole = z.infer<typeof SchematicMapLayerRoleSchema>;
+
+export const SchematicMapLayerSchema = z.object({
+  id: z.string(),
+  role: SchematicMapLayerRoleSchema,
+});
+export type SchematicMapLayer = z.infer<typeof SchematicMapLayerSchema>;
+
+export const SchematicMapTopologyReferenceSchema = z.discriminatedUnion(
+  'type',
+  [
+    z.object({
+      type: z.literal('station_pair'),
+      fromStationId: z.string(),
+      toStationId: z.string(),
+    }),
+    z.object({
+      type: z.literal('display_only'),
+      stationIds: z.array(z.string()).optional(),
+      reason: z.string().min(1),
+    }),
+  ],
+);
+export type SchematicMapTopologyReference = z.infer<
+  typeof SchematicMapTopologyReferenceSchema
+>;
+
+export const SchematicMapLineGroupSchema = z.object({
+  id: z.string(),
+  lineId: z.string(),
+  displayStatus: SchematicMapDisplayStatusSchema,
+  layerId: z.string(),
+  segmentIds: z.array(z.string()),
+});
+export type SchematicMapLineGroup = z.infer<typeof SchematicMapLineGroupSchema>;
+
+export const SchematicMapSegmentSchema = z.object({
+  id: z.string(),
+  lineId: z.string(),
+  displayStatus: SchematicMapDisplayStatusSchema,
+  layerId: z.string(),
+  topology: SchematicMapTopologyReferenceSchema,
+  geometry: SchematicMapGeometrySchema,
+});
+export type SchematicMapSegment = z.infer<typeof SchematicMapSegmentSchema>;
+
+export const SchematicMapNodePartShapeSchema = z.discriminatedUnion('type', [
+  z.object({
+    type: z.literal('circle'),
+    center: SchematicMapPointSchema,
+    radius: z.number().positive(),
+  }),
+  z.object({
+    type: z.literal('pill'),
+    center: SchematicMapPointSchema,
+    width: z.number().positive(),
+    height: z.number().positive(),
+    radius: z.number().nonnegative(),
+  }),
+]);
+export type SchematicMapNodePartShape = z.infer<
+  typeof SchematicMapNodePartShapeSchema
+>;
+
+export const SchematicMapStationNodePartSchema = z.object({
+  id: z.string(),
+  lineId: z.string(),
+  shape: SchematicMapNodePartShapeSchema,
+  coordinateMetadata: SchematicMapCoordinateMetadataSchema,
+});
+export type SchematicMapStationNodePart = z.infer<
+  typeof SchematicMapStationNodePartSchema
+>;
+
+export const SchematicMapStationNodeSchema = z.object({
+  id: z.string(),
+  stationId: z.string(),
+  displayStatus: SchematicMapDisplayStatusSchema,
+  layerId: z.string(),
+  center: SchematicMapPointSchema,
+  lineIds: z.array(z.string()).min(1),
+  parts: z.array(SchematicMapStationNodePartSchema).min(1),
+  coordinateMetadata: SchematicMapCoordinateMetadataSchema,
+});
+export type SchematicMapStationNode = z.infer<
+  typeof SchematicMapStationNodeSchema
+>;
+
+export const SchematicMapLabelSideSchema = z.enum([
+  'top',
+  'right',
+  'bottom',
+  'left',
+  'top_right',
+  'bottom_right',
+  'bottom_left',
+  'top_left',
+  'center',
+]);
+export type SchematicMapLabelSide = z.infer<typeof SchematicMapLabelSideSchema>;
+
+export const SchematicMapLabelSchema = z.object({
+  id: z.string(),
+  stationId: z.string(),
+  displayStatus: SchematicMapDisplayStatusSchema,
+  layerId: z.string(),
+  anchor: SchematicMapPointSchema,
+  side: SchematicMapLabelSideSchema,
+  rotationDegrees: z.number().optional(),
+  leaderLine: SchematicMapPolylineGeometrySchema.optional(),
+  coordinateMetadata: SchematicMapCoordinateMetadataSchema,
+});
+export type SchematicMapLabel = z.infer<typeof SchematicMapLabelSchema>;
+
+export const SchematicMapVersionSnapshotSchema = z.object({
+  schemaVersion: SchematicMapSchemaVersionSchema,
+  mapId: z.literal('system'),
+  effectiveDate: SchematicMapEffectiveDateSchema,
+  layoutEngineId: SchematicMapLayoutEngineIdSchema,
+  generatedAt: z.iso.datetime(),
+  frame: SchematicMapFrameSchema,
+  layers: z.array(SchematicMapLayerSchema).min(1),
+  lineGroups: z.array(SchematicMapLineGroupSchema),
+  segments: z.array(SchematicMapSegmentSchema),
+  stationNodes: z.array(SchematicMapStationNodeSchema),
+  labels: z.array(SchematicMapLabelSchema),
+});
+export type SchematicMapVersionSnapshot = z.infer<
+  typeof SchematicMapVersionSnapshotSchema
+>;
+
+export const SchematicMapManifestVersionSchema = z.object({
+  effectiveDate: SchematicMapEffectiveDateSchema,
+  path: z.string(),
+  layoutEngineId: SchematicMapLayoutEngineIdSchema,
+});
+export type SchematicMapManifestVersion = z.infer<
+  typeof SchematicMapManifestVersionSchema
+>;
+
+export const SchematicMapManifestSchema = z.object({
+  schemaVersion: SchematicMapSchemaVersionSchema,
+  mapId: z.literal('system'),
+  versions: z.array(SchematicMapManifestVersionSchema),
+});
+export type SchematicMapManifest = z.infer<typeof SchematicMapManifestSchema>;
+
+const SchematicMapConstraintBaseSchema = z.object({
+  id: z.string(),
+  reason: z.string().min(1).optional(),
+});
+
+export const SchematicMapConstraintSchema = z.discriminatedUnion('type', [
+  SchematicMapConstraintBaseSchema.extend({
+    type: z.literal('map_frame'),
+    frame: SchematicMapFrameSchema,
+  }),
+  SchematicMapConstraintBaseSchema.extend({
+    type: z.literal('station_anchor'),
+    stationId: z.string(),
+    point: SchematicMapPointSchema,
+  }),
+  SchematicMapConstraintBaseSchema.extend({
+    type: z.literal('segment_route_hint'),
+    lineId: z.string(),
+    fromStationId: z.string(),
+    toStationId: z.string(),
+    via: z.array(SchematicMapPointSchema).min(1),
+  }),
+  SchematicMapConstraintBaseSchema.extend({
+    type: z.literal('line_order'),
+    lineIds: z.array(z.string()).min(1),
+  }),
+  SchematicMapConstraintBaseSchema.extend({
+    type: z.literal('label_hint'),
+    stationId: z.string(),
+    side: SchematicMapLabelSideSchema,
+    offset: SchematicMapPointSchema.optional(),
+  }),
+  SchematicMapConstraintBaseSchema.extend({
+    type: z.literal('interchange_hint'),
+    stationId: z.string(),
+    lineIds: z.array(z.string()).min(2),
+    spacing: z.number().positive().optional(),
+  }),
+]);
+export type SchematicMapConstraint = z.infer<
+  typeof SchematicMapConstraintSchema
+>;
+
+export const SchematicMapConstraintSetSchema = z.object({
+  schemaVersion: SchematicMapSchemaVersionSchema,
+  mapId: z.literal('system'),
+  effectiveDate: SchematicMapEffectiveDateSchema,
+  layoutEngineId: SchematicMapLayoutEngineIdSchema,
+  constraints: z.array(SchematicMapConstraintSchema),
+});
+export type SchematicMapConstraintSet = z.infer<
+  typeof SchematicMapConstraintSetSchema
+>;
+
+export const SchematicMapRuleSetSchema = z.object({
+  schemaVersion: SchematicMapSchemaVersionSchema,
+  mapId: z.literal('system'),
+  layoutEngineId: SchematicMapLayoutEngineIdSchema,
+  lineOrder: z.array(z.string()),
+});
+export type SchematicMapRuleSet = z.infer<typeof SchematicMapRuleSetSchema>;

--- a/packages/core/src/schema/SchematicMap.ts
+++ b/packages/core/src/schema/SchematicMap.ts
@@ -453,9 +453,7 @@ export const SchematicMapVersionSnapshotSchema = z
     addDuplicateIdIssues('stationCodeLabels', snapshot.stationCodeLabels);
 
     const layerIds = new Set(snapshot.layers.map((layer) => layer.id));
-    const stationNodeIds = new Set(
-      snapshot.stationNodes.map((node) => node.stationId),
-    );
+    const stationNodeByStationId = new Map<string, SchematicMapStationNode>();
     const segmentsById = new Map<string, SchematicMapSegment>();
     const groupedSegmentIds = new Set<string>();
     const layerReferences: Array<{
@@ -468,6 +466,23 @@ export const SchematicMapVersionSnapshotSchema = z
         segmentsById.set(segment.id, segment);
       }
     }
+
+    snapshot.stationNodes.forEach((node, index) => {
+      if (stationNodeByStationId.has(node.stationId)) {
+        context.addIssue({
+          code: 'custom',
+          message: `Duplicate station node stationId: ${node.stationId}`,
+          path: ['stationNodes', index, 'stationId'],
+        });
+      } else {
+        stationNodeByStationId.set(node.stationId, node);
+      }
+
+      layerReferences.push({
+        layerId: node.layerId,
+        path: ['stationNodes', index, 'layerId'],
+      });
+    });
 
     snapshot.lineGroups.forEach((lineGroup, index) => {
       layerReferences.push({
@@ -527,13 +542,24 @@ export const SchematicMapVersionSnapshotSchema = z
           path: ['segments', index, 'id'],
         });
       }
-    });
 
-    snapshot.stationNodes.forEach((node, index) => {
-      layerReferences.push({
-        layerId: node.layerId,
-        path: ['stationNodes', index, 'layerId'],
-      });
+      if (segment.topology.type === 'station_pair') {
+        if (!stationNodeByStationId.has(segment.topology.fromStationId)) {
+          context.addIssue({
+            code: 'custom',
+            message: `Segment ${segment.id} references station ${segment.topology.fromStationId} without a station node`,
+            path: ['segments', index, 'topology', 'fromStationId'],
+          });
+        }
+
+        if (!stationNodeByStationId.has(segment.topology.toStationId)) {
+          context.addIssue({
+            code: 'custom',
+            message: `Segment ${segment.id} references station ${segment.topology.toStationId} without a station node`,
+            path: ['segments', index, 'topology', 'toStationId'],
+          });
+        }
+      }
     });
 
     snapshot.labels.forEach((label, index) => {
@@ -542,11 +568,19 @@ export const SchematicMapVersionSnapshotSchema = z
         path: ['labels', index, 'layerId'],
       });
 
-      if (!stationNodeIds.has(label.stationId)) {
+      const stationNode = stationNodeByStationId.get(label.stationId);
+
+      if (!stationNode) {
         context.addIssue({
           code: 'custom',
           message: `Label ${label.id} references station ${label.stationId} without a station node`,
           path: ['labels', index, 'stationId'],
+        });
+      } else if (label.displayStatus !== stationNode.displayStatus) {
+        context.addIssue({
+          code: 'custom',
+          message: `Label ${label.id} has displayStatus ${label.displayStatus}, not ${stationNode.displayStatus}`,
+          path: ['labels', index, 'displayStatus'],
         });
       }
     });
@@ -557,12 +591,30 @@ export const SchematicMapVersionSnapshotSchema = z
         path: ['stationCodeLabels', index, 'layerId'],
       });
 
-      if (!stationNodeIds.has(label.stationId)) {
+      const stationNode = stationNodeByStationId.get(label.stationId);
+
+      if (!stationNode) {
         context.addIssue({
           code: 'custom',
           message: `Station code label ${label.id} references station ${label.stationId} without a station node`,
           path: ['stationCodeLabels', index, 'stationId'],
         });
+      } else {
+        if (label.displayStatus !== stationNode.displayStatus) {
+          context.addIssue({
+            code: 'custom',
+            message: `Station code label ${label.id} has displayStatus ${label.displayStatus}, not ${stationNode.displayStatus}`,
+            path: ['stationCodeLabels', index, 'displayStatus'],
+          });
+        }
+
+        if (!stationNode.lineIds.includes(label.lineId)) {
+          context.addIssue({
+            code: 'custom',
+            message: `Station code label ${label.id} references line ${label.lineId}, which is not listed on station ${label.stationId}`,
+            path: ['stationCodeLabels', index, 'lineId'],
+          });
+        }
       }
     });
 

--- a/packages/core/src/schema/SchematicMap.ts
+++ b/packages/core/src/schema/SchematicMap.ts
@@ -1,10 +1,16 @@
 import z from 'zod';
 
+/**
+ * Version of the schematic map data contract, not the generated map version.
+ */
 export const SchematicMapSchemaVersionSchema = z.literal(1);
 export type SchematicMapSchemaVersion = z.infer<
   typeof SchematicMapSchemaVersionSchema
 >;
 
+/**
+ * Month-level effective date for a published schematic system map snapshot.
+ */
 export const SchematicMapEffectiveDateSchema = z
   .string()
   .regex(/^\d{4}-\d{2}$/);
@@ -12,6 +18,9 @@ export type SchematicMapEffectiveDate = z.infer<
   typeof SchematicMapEffectiveDateSchema
 >;
 
+/**
+ * Stable identifier for the layout engine that produced a snapshot.
+ */
 export const SchematicMapLayoutEngineIdSchema = z.literal(
   'lta-system-map-2011',
 );
@@ -19,6 +28,11 @@ export type SchematicMapLayoutEngineId = z.infer<
   typeof SchematicMapLayoutEngineIdSchema
 >;
 
+/**
+ * Whether a schematic item represents active service or displayed future
+ * coverage. Display-only coverage must remain explicit so it is not mistaken
+ * for canonical operational topology.
+ */
 export const SchematicMapDisplayStatusSchema = z.enum([
   'operational',
   'under_construction',
@@ -29,6 +43,11 @@ export type SchematicMapDisplayStatus = z.infer<
   typeof SchematicMapDisplayStatusSchema
 >;
 
+/**
+ * Explains where coordinates came from. Generated snapshots may contain
+ * artifact coordinates, but source inputs should prefer reusable rules and
+ * constraints over one-off exceptions.
+ */
 export const SchematicMapCoordinateMetadataSchema = z.discriminatedUnion(
   'coordinateClass',
   [
@@ -54,12 +73,19 @@ export type SchematicMapCoordinateMetadata = z.infer<
   typeof SchematicMapCoordinateMetadataSchema
 >;
 
+/**
+ * A point in the schematic coordinate system for the map frame.
+ */
 export const SchematicMapPointSchema = z.object({
   x: z.number(),
   y: z.number(),
 });
 export type SchematicMapPoint = z.infer<typeof SchematicMapPointSchema>;
 
+/**
+ * Dimensions of one generated map snapshot. Frame size is version-scoped
+ * because future maps can use wider layouts than current maps.
+ */
 export const SchematicMapFrameSchema = z.object({
   x: z.number(),
   y: z.number(),
@@ -69,6 +95,9 @@ export const SchematicMapFrameSchema = z.object({
 });
 export type SchematicMapFrame = z.infer<typeof SchematicMapFrameSchema>;
 
+/**
+ * Structured segment or leader-line geometry made from ordered points.
+ */
 export const SchematicMapPolylineGeometrySchema = z.object({
   type: z.literal('polyline'),
   points: z.array(SchematicMapPointSchema).min(2),
@@ -78,6 +107,10 @@ export type SchematicMapPolylineGeometry = z.infer<
   typeof SchematicMapPolylineGeometrySchema
 >;
 
+/**
+ * Structured curved geometry. Raw SVG path data is intentionally not part of
+ * the narrow Phase 2 schema.
+ */
 export const SchematicMapCubicBezierGeometrySchema = z.object({
   type: z.literal('cubic_bezier'),
   start: SchematicMapPointSchema,
@@ -90,12 +123,19 @@ export type SchematicMapCubicBezierGeometry = z.infer<
   typeof SchematicMapCubicBezierGeometrySchema
 >;
 
+/**
+ * Renderer-neutral geometry primitives supported by the initial data contract.
+ */
 export const SchematicMapGeometrySchema = z.discriminatedUnion('type', [
   SchematicMapPolylineGeometrySchema,
   SchematicMapCubicBezierGeometrySchema,
 ]);
 export type SchematicMapGeometry = z.infer<typeof SchematicMapGeometrySchema>;
 
+/**
+ * Semantic role for a rendering layer. Consumers still choose how to render
+ * each layer.
+ */
 export const SchematicMapLayerRoleSchema = z.enum([
   'construction',
   'line',
@@ -105,12 +145,19 @@ export const SchematicMapLayerRoleSchema = z.enum([
 ]);
 export type SchematicMapLayerRole = z.infer<typeof SchematicMapLayerRoleSchema>;
 
+/**
+ * Ordered layers in a published snapshot.
+ */
 export const SchematicMapLayerSchema = z.object({
   id: z.string(),
   role: SchematicMapLayerRoleSchema,
 });
 export type SchematicMapLayer = z.infer<typeof SchematicMapLayerSchema>;
 
+/**
+ * Link from schematic geometry back to canonical topology, or an explicit
+ * display-only item with a written reason.
+ */
 export const SchematicMapTopologyReferenceSchema = z.discriminatedUnion(
   'type',
   [
@@ -130,6 +177,9 @@ export type SchematicMapTopologyReference = z.infer<
   typeof SchematicMapTopologyReferenceSchema
 >;
 
+/**
+ * A line-level grouping used by consumers for styling, focus, and overlays.
+ */
 export const SchematicMapLineGroupSchema = z.object({
   id: z.string(),
   lineId: z.string(),
@@ -139,6 +189,9 @@ export const SchematicMapLineGroupSchema = z.object({
 });
 export type SchematicMapLineGroup = z.infer<typeof SchematicMapLineGroupSchema>;
 
+/**
+ * One rendered line segment in a generated snapshot.
+ */
 export const SchematicMapSegmentSchema = z.object({
   id: z.string(),
   lineId: z.string(),
@@ -149,6 +202,10 @@ export const SchematicMapSegmentSchema = z.object({
 });
 export type SchematicMapSegment = z.infer<typeof SchematicMapSegmentSchema>;
 
+/**
+ * Basic shapes that compose a station node. Interchanges can expose multiple
+ * line-specific parts for focused-line and disruption overlays.
+ */
 export const SchematicMapNodePartShapeSchema = z.discriminatedUnion('type', [
   z.object({
     type: z.literal('circle'),
@@ -167,6 +224,9 @@ export type SchematicMapNodePartShape = z.infer<
   typeof SchematicMapNodePartShapeSchema
 >;
 
+/**
+ * One line-specific piece of a composed station node.
+ */
 export const SchematicMapStationNodePartSchema = z.object({
   id: z.string(),
   lineId: z.string(),
@@ -177,6 +237,10 @@ export type SchematicMapStationNodePart = z.infer<
   typeof SchematicMapStationNodePartSchema
 >;
 
+/**
+ * Station marker geometry in a snapshot. Station names stay in canonical
+ * station data rather than schematic map data.
+ */
 export const SchematicMapStationNodeSchema = z.object({
   id: z.string(),
   stationId: z.string(),
@@ -191,6 +255,9 @@ export type SchematicMapStationNode = z.infer<
   typeof SchematicMapStationNodeSchema
 >;
 
+/**
+ * Relative side for label placement around a station anchor.
+ */
 export const SchematicMapLabelSideSchema = z.enum([
   'top',
   'right',
@@ -204,6 +271,9 @@ export const SchematicMapLabelSideSchema = z.enum([
 ]);
 export type SchematicMapLabelSide = z.infer<typeof SchematicMapLabelSideSchema>;
 
+/**
+ * Label placement data. It stores layout hints only, not localized text.
+ */
 export const SchematicMapLabelSchema = z.object({
   id: z.string(),
   stationId: z.string(),
@@ -217,6 +287,9 @@ export const SchematicMapLabelSchema = z.object({
 });
 export type SchematicMapLabel = z.infer<typeof SchematicMapLabelSchema>;
 
+/**
+ * Complete published schematic map snapshot for one effective date.
+ */
 export const SchematicMapVersionSnapshotSchema = z.object({
   schemaVersion: SchematicMapSchemaVersionSchema,
   mapId: z.literal('system'),
@@ -234,6 +307,9 @@ export type SchematicMapVersionSnapshot = z.infer<
   typeof SchematicMapVersionSnapshotSchema
 >;
 
+/**
+ * Manifest entry pointing to one generated snapshot file.
+ */
 export const SchematicMapManifestVersionSchema = z.object({
   effectiveDate: SchematicMapEffectiveDateSchema,
   path: z.string(),
@@ -243,6 +319,9 @@ export type SchematicMapManifestVersion = z.infer<
   typeof SchematicMapManifestVersionSchema
 >;
 
+/**
+ * Published manifest that lets consumers select a snapshot by effective date.
+ */
 export const SchematicMapManifestSchema = z.object({
   schemaVersion: SchematicMapSchemaVersionSchema,
   mapId: z.literal('system'),
@@ -250,11 +329,19 @@ export const SchematicMapManifestSchema = z.object({
 });
 export type SchematicMapManifest = z.infer<typeof SchematicMapManifestSchema>;
 
+/**
+ * Shared metadata for reviewed generator constraints.
+ */
 const SchematicMapConstraintBaseSchema = z.object({
   id: z.string(),
   reason: z.string().min(1).optional(),
 });
 
+/**
+ * Minimal first-pass generator constraints. Higher-level corridor and region
+ * constraints can be added once the generator proves they remove real
+ * duplication.
+ */
 export const SchematicMapConstraintSchema = z.discriminatedUnion('type', [
   SchematicMapConstraintBaseSchema.extend({
     type: z.literal('map_frame'),
@@ -293,6 +380,9 @@ export type SchematicMapConstraint = z.infer<
   typeof SchematicMapConstraintSchema
 >;
 
+/**
+ * Version-scoped constraints used by the generator for one effective date.
+ */
 export const SchematicMapConstraintSetSchema = z.object({
   schemaVersion: SchematicMapSchemaVersionSchema,
   mapId: z.literal('system'),
@@ -304,6 +394,9 @@ export type SchematicMapConstraintSet = z.infer<
   typeof SchematicMapConstraintSetSchema
 >;
 
+/**
+ * Shared layout rules for the named layout engine.
+ */
 export const SchematicMapRuleSetSchema = z.object({
   schemaVersion: SchematicMapSchemaVersionSchema,
   mapId: z.literal('system'),

--- a/packages/core/src/schema/SchematicMap.ts
+++ b/packages/core/src/schema/SchematicMap.ts
@@ -43,6 +43,34 @@ export type SchematicMapDisplayStatus = z.infer<
   typeof SchematicMapDisplayStatusSchema
 >;
 
+type DisplayOnlyReasonValue = {
+  displayStatus: SchematicMapDisplayStatus;
+  displayReason?: string;
+};
+
+type DisplayOnlyReasonContext = {
+  addIssue: (issue: {
+    code: 'custom';
+    message: string;
+    path: string[];
+  }) => void;
+};
+
+function requireDisplayReasonForDisplayOnly(
+  value: DisplayOnlyReasonValue,
+  context: DisplayOnlyReasonContext,
+): void {
+  if (value.displayStatus !== 'display_only' || value.displayReason) {
+    return;
+  }
+
+  context.addIssue({
+    code: 'custom',
+    message: 'displayReason is required when displayStatus is display_only',
+    path: ['displayReason'],
+  });
+}
+
 /**
  * Explains where coordinates came from. Generated snapshots may contain
  * artifact coordinates, but source inputs should prefer reusable rules and
@@ -209,15 +237,7 @@ export const SchematicMapSegmentSchema = z
     topology: SchematicMapTopologyReferenceSchema,
     geometry: SchematicMapGeometrySchema,
   })
-  .superRefine((segment, context) => {
-    if (segment.displayStatus === 'display_only' && !segment.displayReason) {
-      context.addIssue({
-        code: 'custom',
-        message: 'displayReason is required when displayStatus is display_only',
-        path: ['displayReason'],
-      });
-    }
-  });
+  .superRefine(requireDisplayReasonForDisplayOnly);
 export type SchematicMapSegment = z.infer<typeof SchematicMapSegmentSchema>;
 
 /**
@@ -271,15 +291,7 @@ export const SchematicMapStationNodeSchema = z
     parts: z.array(SchematicMapStationNodePartSchema).min(1),
     coordinateMetadata: SchematicMapCoordinateMetadataSchema,
   })
-  .superRefine((node, context) => {
-    if (node.displayStatus === 'display_only' && !node.displayReason) {
-      context.addIssue({
-        code: 'custom',
-        message: 'displayReason is required when displayStatus is display_only',
-        path: ['displayReason'],
-      });
-    }
-  });
+  .superRefine(requireDisplayReasonForDisplayOnly);
 export type SchematicMapStationNode = z.infer<
   typeof SchematicMapStationNodeSchema
 >;
@@ -316,15 +328,7 @@ export const SchematicMapLabelSchema = z
     leaderLine: SchematicMapPolylineGeometrySchema.optional(),
     coordinateMetadata: SchematicMapCoordinateMetadataSchema,
   })
-  .superRefine((label, context) => {
-    if (label.displayStatus === 'display_only' && !label.displayReason) {
-      context.addIssue({
-        code: 'custom',
-        message: 'displayReason is required when displayStatus is display_only',
-        path: ['displayReason'],
-      });
-    }
-  });
+  .superRefine(requireDisplayReasonForDisplayOnly);
 export type SchematicMapLabel = z.infer<typeof SchematicMapLabelSchema>;
 
 /**

--- a/packages/core/src/schema/SchematicMap.ts
+++ b/packages/core/src/schema/SchematicMap.ts
@@ -237,7 +237,19 @@ export const SchematicMapSegmentSchema = z
     topology: SchematicMapTopologyReferenceSchema,
     geometry: SchematicMapGeometrySchema,
   })
-  .superRefine(requireDisplayReasonForDisplayOnly);
+  .superRefine(requireDisplayReasonForDisplayOnly)
+  .superRefine((segment, context) => {
+    if (
+      segment.displayStatus === 'operational' &&
+      segment.topology.type === 'display_only'
+    ) {
+      context.addIssue({
+        code: 'custom',
+        message: 'display_only topology cannot be marked operational',
+        path: ['topology'],
+      });
+    }
+  });
 export type SchematicMapSegment = z.infer<typeof SchematicMapSegmentSchema>;
 
 /**
@@ -291,7 +303,20 @@ export const SchematicMapStationNodeSchema = z
     parts: z.array(SchematicMapStationNodePartSchema).min(1),
     coordinateMetadata: SchematicMapCoordinateMetadataSchema,
   })
-  .superRefine(requireDisplayReasonForDisplayOnly);
+  .superRefine(requireDisplayReasonForDisplayOnly)
+  .superRefine((node, context) => {
+    const lineIds = new Set(node.lineIds);
+
+    node.parts.forEach((part, index) => {
+      if (!lineIds.has(part.lineId)) {
+        context.addIssue({
+          code: 'custom',
+          message: `Node part ${part.id} belongs to ${part.lineId}, which is not listed on the parent node`,
+          path: ['parts', index, 'lineId'],
+        });
+      }
+    });
+  });
 export type SchematicMapStationNode = z.infer<
   typeof SchematicMapStationNodeSchema
 >;
@@ -471,11 +496,28 @@ export type SchematicMapManifestVersion = z.infer<
 /**
  * Published manifest that lets consumers select a snapshot by effective date.
  */
-export const SchematicMapManifestSchema = z.object({
-  schemaVersion: SchematicMapSchemaVersionSchema,
-  mapId: z.literal('system'),
-  versions: z.array(SchematicMapManifestVersionSchema),
-});
+export const SchematicMapManifestSchema = z
+  .object({
+    schemaVersion: SchematicMapSchemaVersionSchema,
+    mapId: z.literal('system'),
+    versions: z.array(SchematicMapManifestVersionSchema),
+  })
+  .superRefine((manifest, context) => {
+    const effectiveDates = new Set<string>();
+
+    manifest.versions.forEach((version, index) => {
+      if (effectiveDates.has(version.effectiveDate)) {
+        context.addIssue({
+          code: 'custom',
+          message: `Duplicate schematic map effective date: ${version.effectiveDate}`,
+          path: ['versions', index, 'effectiveDate'],
+        });
+        return;
+      }
+
+      effectiveDates.add(version.effectiveDate);
+    });
+  });
 export type SchematicMapManifest = z.infer<typeof SchematicMapManifestSchema>;
 
 /**

--- a/packages/core/src/schema/SchematicMap.ts
+++ b/packages/core/src/schema/SchematicMap.ts
@@ -241,16 +241,27 @@ export type SchematicMapStationNodePart = z.infer<
  * Station marker geometry in a snapshot. Station names stay in canonical
  * station data rather than schematic map data.
  */
-export const SchematicMapStationNodeSchema = z.object({
-  id: z.string(),
-  stationId: z.string(),
-  displayStatus: SchematicMapDisplayStatusSchema,
-  layerId: z.string(),
-  center: SchematicMapPointSchema,
-  lineIds: z.array(z.string()).min(1),
-  parts: z.array(SchematicMapStationNodePartSchema).min(1),
-  coordinateMetadata: SchematicMapCoordinateMetadataSchema,
-});
+export const SchematicMapStationNodeSchema = z
+  .object({
+    id: z.string(),
+    stationId: z.string(),
+    displayStatus: SchematicMapDisplayStatusSchema,
+    displayReason: z.string().min(1).optional(),
+    layerId: z.string(),
+    center: SchematicMapPointSchema,
+    lineIds: z.array(z.string()).min(1),
+    parts: z.array(SchematicMapStationNodePartSchema).min(1),
+    coordinateMetadata: SchematicMapCoordinateMetadataSchema,
+  })
+  .superRefine((node, context) => {
+    if (node.displayStatus === 'display_only' && !node.displayReason) {
+      context.addIssue({
+        code: 'custom',
+        message: 'displayReason is required when displayStatus is display_only',
+        path: ['displayReason'],
+      });
+    }
+  });
 export type SchematicMapStationNode = z.infer<
   typeof SchematicMapStationNodeSchema
 >;
@@ -274,35 +285,103 @@ export type SchematicMapLabelSide = z.infer<typeof SchematicMapLabelSideSchema>;
 /**
  * Label placement data. It stores layout hints only, not localized text.
  */
-export const SchematicMapLabelSchema = z.object({
-  id: z.string(),
-  stationId: z.string(),
-  displayStatus: SchematicMapDisplayStatusSchema,
-  layerId: z.string(),
-  anchor: SchematicMapPointSchema,
-  side: SchematicMapLabelSideSchema,
-  rotationDegrees: z.number().optional(),
-  leaderLine: SchematicMapPolylineGeometrySchema.optional(),
-  coordinateMetadata: SchematicMapCoordinateMetadataSchema,
-});
+export const SchematicMapLabelSchema = z
+  .object({
+    id: z.string(),
+    stationId: z.string(),
+    displayStatus: SchematicMapDisplayStatusSchema,
+    displayReason: z.string().min(1).optional(),
+    layerId: z.string(),
+    anchor: SchematicMapPointSchema,
+    side: SchematicMapLabelSideSchema,
+    rotationDegrees: z.number().optional(),
+    leaderLine: SchematicMapPolylineGeometrySchema.optional(),
+    coordinateMetadata: SchematicMapCoordinateMetadataSchema,
+  })
+  .superRefine((label, context) => {
+    if (label.displayStatus === 'display_only' && !label.displayReason) {
+      context.addIssue({
+        code: 'custom',
+        message: 'displayReason is required when displayStatus is display_only',
+        path: ['displayReason'],
+      });
+    }
+  });
 export type SchematicMapLabel = z.infer<typeof SchematicMapLabelSchema>;
 
 /**
  * Complete published schematic map snapshot for one effective date.
  */
-export const SchematicMapVersionSnapshotSchema = z.object({
-  schemaVersion: SchematicMapSchemaVersionSchema,
-  mapId: z.literal('system'),
-  effectiveDate: SchematicMapEffectiveDateSchema,
-  layoutEngineId: SchematicMapLayoutEngineIdSchema,
-  generatedAt: z.iso.datetime(),
-  frame: SchematicMapFrameSchema,
-  layers: z.array(SchematicMapLayerSchema).min(1),
-  lineGroups: z.array(SchematicMapLineGroupSchema),
-  segments: z.array(SchematicMapSegmentSchema),
-  stationNodes: z.array(SchematicMapStationNodeSchema),
-  labels: z.array(SchematicMapLabelSchema),
-});
+export const SchematicMapVersionSnapshotSchema = z
+  .object({
+    schemaVersion: SchematicMapSchemaVersionSchema,
+    mapId: z.literal('system'),
+    effectiveDate: SchematicMapEffectiveDateSchema,
+    layoutEngineId: SchematicMapLayoutEngineIdSchema,
+    generatedAt: z.iso.datetime(),
+    frame: SchematicMapFrameSchema,
+    layers: z.array(SchematicMapLayerSchema).min(1),
+    lineGroups: z.array(SchematicMapLineGroupSchema),
+    segments: z.array(SchematicMapSegmentSchema),
+    stationNodes: z.array(SchematicMapStationNodeSchema),
+    labels: z.array(SchematicMapLabelSchema),
+  })
+  .superRefine((snapshot, context) => {
+    const layerIds = new Set(snapshot.layers.map((layer) => layer.id));
+    const segmentIds = new Set(snapshot.segments.map((segment) => segment.id));
+    const layerReferences: Array<{
+      layerId: string;
+      path: Array<string | number>;
+    }> = [];
+
+    snapshot.lineGroups.forEach((lineGroup, index) => {
+      layerReferences.push({
+        layerId: lineGroup.layerId,
+        path: ['lineGroups', index, 'layerId'],
+      });
+
+      lineGroup.segmentIds.forEach((segmentId, segmentIndex) => {
+        if (!segmentIds.has(segmentId)) {
+          context.addIssue({
+            code: 'custom',
+            message: `Unknown segment id: ${segmentId}`,
+            path: ['lineGroups', index, 'segmentIds', segmentIndex],
+          });
+        }
+      });
+    });
+
+    snapshot.segments.forEach((segment, index) => {
+      layerReferences.push({
+        layerId: segment.layerId,
+        path: ['segments', index, 'layerId'],
+      });
+    });
+
+    snapshot.stationNodes.forEach((node, index) => {
+      layerReferences.push({
+        layerId: node.layerId,
+        path: ['stationNodes', index, 'layerId'],
+      });
+    });
+
+    snapshot.labels.forEach((label, index) => {
+      layerReferences.push({
+        layerId: label.layerId,
+        path: ['labels', index, 'layerId'],
+      });
+    });
+
+    for (const reference of layerReferences) {
+      if (!layerIds.has(reference.layerId)) {
+        context.addIssue({
+          code: 'custom',
+          message: `Unknown layer id: ${reference.layerId}`,
+          path: reference.path,
+        });
+      }
+    }
+  });
 export type SchematicMapVersionSnapshot = z.infer<
   typeof SchematicMapVersionSnapshotSchema
 >;

--- a/packages/core/src/schema/SchematicMap.ts
+++ b/packages/core/src/schema/SchematicMap.ts
@@ -418,6 +418,7 @@ export const SchematicMapVersionSnapshotSchema = z
 
     const layerIds = new Set(snapshot.layers.map((layer) => layer.id));
     const segmentsById = new Map<string, SchematicMapSegment>();
+    const groupedSegmentIds = new Set<string>();
     const layerReferences: Array<{
       layerId: string;
       path: Array<string | number>;
@@ -436,6 +437,7 @@ export const SchematicMapVersionSnapshotSchema = z
       });
 
       lineGroup.segmentIds.forEach((segmentId, segmentIndex) => {
+        groupedSegmentIds.add(segmentId);
         const segment = segmentsById.get(segmentId);
 
         if (!segment) {
@@ -470,6 +472,14 @@ export const SchematicMapVersionSnapshotSchema = z
         layerId: segment.layerId,
         path: ['segments', index, 'layerId'],
       });
+
+      if (!groupedSegmentIds.has(segment.id)) {
+        context.addIssue({
+          code: 'custom',
+          message: `Segment ${segment.id} is not included in a line group`,
+          path: ['segments', index, 'id'],
+        });
+      }
     });
 
     snapshot.stationNodes.forEach((node, index) => {
@@ -593,13 +603,30 @@ export type SchematicMapConstraint = z.infer<
 /**
  * Version-scoped constraints used by the generator for one effective date.
  */
-export const SchematicMapConstraintSetSchema = z.object({
-  schemaVersion: SchematicMapSchemaVersionSchema,
-  mapId: z.literal('system'),
-  effectiveDate: SchematicMapEffectiveDateSchema,
-  layoutEngineId: SchematicMapLayoutEngineIdSchema,
-  constraints: z.array(SchematicMapConstraintSchema),
-});
+export const SchematicMapConstraintSetSchema = z
+  .object({
+    schemaVersion: SchematicMapSchemaVersionSchema,
+    mapId: z.literal('system'),
+    effectiveDate: SchematicMapEffectiveDateSchema,
+    layoutEngineId: SchematicMapLayoutEngineIdSchema,
+    constraints: z.array(SchematicMapConstraintSchema),
+  })
+  .superRefine((constraintSet, context) => {
+    const constraintIds = new Set<string>();
+
+    constraintSet.constraints.forEach((constraint, index) => {
+      if (constraintIds.has(constraint.id)) {
+        context.addIssue({
+          code: 'custom',
+          message: `Duplicate schematic map constraint id: ${constraint.id}`,
+          path: ['constraints', index, 'id'],
+        });
+        return;
+      }
+
+      constraintIds.add(constraint.id);
+    });
+  });
 export type SchematicMapConstraintSet = z.infer<
   typeof SchematicMapConstraintSetSchema
 >;

--- a/packages/core/src/schema/SchematicMap.ts
+++ b/packages/core/src/schema/SchematicMap.ts
@@ -192,14 +192,25 @@ export type SchematicMapLineGroup = z.infer<typeof SchematicMapLineGroupSchema>;
 /**
  * One rendered line segment in a generated snapshot.
  */
-export const SchematicMapSegmentSchema = z.object({
-  id: z.string(),
-  lineId: z.string(),
-  displayStatus: SchematicMapDisplayStatusSchema,
-  layerId: z.string(),
-  topology: SchematicMapTopologyReferenceSchema,
-  geometry: SchematicMapGeometrySchema,
-});
+export const SchematicMapSegmentSchema = z
+  .object({
+    id: z.string(),
+    lineId: z.string(),
+    displayStatus: SchematicMapDisplayStatusSchema,
+    displayReason: z.string().min(1).optional(),
+    layerId: z.string(),
+    topology: SchematicMapTopologyReferenceSchema,
+    geometry: SchematicMapGeometrySchema,
+  })
+  .superRefine((segment, context) => {
+    if (segment.displayStatus === 'display_only' && !segment.displayReason) {
+      context.addIssue({
+        code: 'custom',
+        message: 'displayReason is required when displayStatus is display_only',
+        path: ['displayReason'],
+      });
+    }
+  });
 export type SchematicMapSegment = z.infer<typeof SchematicMapSegmentSchema>;
 
 /**

--- a/packages/core/src/schema/SchematicMap.ts
+++ b/packages/core/src/schema/SchematicMap.ts
@@ -306,6 +306,7 @@ export const SchematicMapStationNodeSchema = z
   .superRefine(requireDisplayReasonForDisplayOnly)
   .superRefine((node, context) => {
     const lineIds = new Set(node.lineIds);
+    const partLineIds = new Set(node.parts.map((part) => part.lineId));
 
     node.parts.forEach((part, index) => {
       if (!lineIds.has(part.lineId)) {
@@ -313,6 +314,16 @@ export const SchematicMapStationNodeSchema = z
           code: 'custom',
           message: `Node part ${part.id} belongs to ${part.lineId}, which is not listed on the parent node`,
           path: ['parts', index, 'lineId'],
+        });
+      }
+    });
+
+    node.lineIds.forEach((lineId, index) => {
+      if (!partLineIds.has(lineId)) {
+        context.addIssue({
+          code: 'custom',
+          message: `Node line ${lineId} has no matching node part`,
+          path: ['lineIds', index],
         });
       }
     });
@@ -440,6 +451,14 @@ export const SchematicMapVersionSnapshotSchema = z
           context.addIssue({
             code: 'custom',
             message: `Segment ${segmentId} belongs to ${segment.lineId}, not ${lineGroup.lineId}`,
+            path: ['lineGroups', index, 'segmentIds', segmentIndex],
+          });
+        }
+
+        if (segment.displayStatus !== lineGroup.displayStatus) {
+          context.addIssue({
+            code: 'custom',
+            message: `Segment ${segmentId} has displayStatus ${segment.displayStatus}, not ${lineGroup.displayStatus}`,
             path: ['lineGroups', index, 'segmentIds', segmentIndex],
           });
         }


### PR DESCRIPTION
## Summary

- Adds the first narrow `@mrtdown/core` schematic map schema draft for renderer-neutral system map snapshots, manifests, rule sets, and first-pass constraints.
- Keeps labels text-free so consumers continue to resolve localized names from canonical station and line data.
- Supports display-only/non-operational coverage with explicit reasons and intentionally leaves raw SVG path geometry unsupported until a later generator/parity pass proves it is necessary.
- Updates the active schematic system map plan with the Phase 2 schema boundary.

## Validation

- `npm run test:core`
- `npm run build:core`
- `npx biome check packages/core/src/schema/SchematicMap.ts packages/core/src/schema/SchematicMap.test.ts packages/core/src/index.ts docs/plans/active/schematic-system-map.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a renderer‑neutral schematic map contract for published snapshots and generator inputs, restricting geometry to structured primitives and enforcing cross‑field and referential integrity (e.g., layer/segment/line-group consistency, display-only reason rules).

* **Documentation**
  * Updated Phase 2 plan to define the narrowed schema scope, exclude frontend/localized/layout specifics, and record Phase 2 start.

* **Tests**
  * Added extensive validation tests covering snapshot, manifest, rule set, and constraint behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/foldaway/mrtdown-data/pull/271?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->