### PR TITLE
feat: add schematic map CLI validation

### DIFF
--- a/docs/plans/active/schematic-system-map.md
+++ b/docs/plans/active/schematic-system-map.md
@@ -398,6 +398,9 @@ Exit criteria:
 - 2026-05-27: Added `packages/fs` schematic map path helpers, typed
   read/write functions, and repository/writer facades for generator rule sets,
   per-version constraints, manifests, and generated snapshot artifacts.
+- 2026-05-27: Began Phase 4 CLI and validation integration with
+  `schematic-map` validation scope plus CLI inspection for schematic
+  constraints, generated versions, manifests, and rule sets.
 
 ## Decision Log
 

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -87,19 +87,19 @@ async function seedSchematicMap(dataDir: string): Promise<void> {
         lineId: 'ISL',
         displayStatus: 'operational',
         layerId: 'lines',
-        segmentIds: ['line_ket:adm'],
+        segmentIds: ['line_ket:hku'],
       },
     ],
     segments: [
       {
-        id: 'line_ket:adm',
+        id: 'line_ket:hku',
         lineId: 'ISL',
         displayStatus: 'operational',
         layerId: 'lines',
         topology: {
           type: 'station_pair',
           fromStationId: 'KET',
-          toStationId: 'ADM',
+          toStationId: 'HKU',
         },
         geometry: {
           type: 'polyline',
@@ -143,15 +143,15 @@ async function seedSchematicMap(dataDir: string): Promise<void> {
         },
       },
       {
-        id: 'node_adm',
-        stationId: 'ADM',
+        id: 'node_hku',
+        stationId: 'HKU',
         displayStatus: 'operational',
         layerId: 'lines',
         center: { x: 200, y: 100 },
         lineIds: ['ISL'],
         parts: [
           {
-            id: 'node_adm_isl',
+            id: 'node_hku_isl',
             lineId: 'ISL',
             shape: {
               type: 'circle',
@@ -160,7 +160,7 @@ async function seedSchematicMap(dataDir: string): Promise<void> {
             },
             coordinateMetadata: {
               coordinateClass: 'artifact',
-              generatedFrom: 'node_adm',
+              generatedFrom: 'node_hku',
             },
           },
         ],

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -1,8 +1,14 @@
 import { readFileSync } from 'node:fs';
-import { mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { cp, mkdtemp, readFile, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import {
+  writeSchematicMapConstraintSet,
+  writeSchematicMapManifest,
+  writeSchematicMapRuleSet,
+  writeSchematicMapVersionSnapshot,
+} from '@mrtdown/fs';
 import { describe, expect, it } from 'vitest';
 import { runCli } from './index.js';
 
@@ -39,6 +45,158 @@ function createIo() {
     stdout,
     stderr,
   };
+}
+
+async function seedSchematicMap(dataDir: string): Promise<void> {
+  await writeSchematicMapRuleSet(dataDir, {
+    schemaVersion: 1,
+    mapId: 'system',
+    layoutEngineId: 'lta-system-map-2011',
+    lineOrder: ['ISL'],
+  });
+  await writeSchematicMapConstraintSet(dataDir, {
+    schemaVersion: 1,
+    mapId: 'system',
+    effectiveDate: '2025-04',
+    layoutEngineId: 'lta-system-map-2011',
+    constraints: [
+      {
+        id: 'frame_2025_04',
+        type: 'map_frame',
+        frame: { x: 0, y: 0, width: 3140, height: 2400 },
+      },
+      {
+        id: 'anchor_ket',
+        type: 'station_anchor',
+        stationId: 'KET',
+        point: { x: 100, y: 100 },
+      },
+    ],
+  });
+  await writeSchematicMapVersionSnapshot(dataDir, {
+    schemaVersion: 1,
+    mapId: 'system',
+    effectiveDate: '2025-04',
+    layoutEngineId: 'lta-system-map-2011',
+    generatedAt: '2026-05-27T00:00:00.000Z',
+    frame: { x: 0, y: 0, width: 3140, height: 2400 },
+    layers: [{ id: 'lines', role: 'line' }],
+    lineGroups: [
+      {
+        id: 'line_ISL',
+        lineId: 'ISL',
+        displayStatus: 'operational',
+        layerId: 'lines',
+        segmentIds: ['line_ket:adm'],
+      },
+    ],
+    segments: [
+      {
+        id: 'line_ket:adm',
+        lineId: 'ISL',
+        displayStatus: 'operational',
+        layerId: 'lines',
+        topology: {
+          type: 'station_pair',
+          fromStationId: 'KET',
+          toStationId: 'ADM',
+        },
+        geometry: {
+          type: 'polyline',
+          points: [
+            { x: 100, y: 100 },
+            { x: 200, y: 100 },
+          ],
+          coordinateMetadata: {
+            coordinateClass: 'generated',
+            ruleId: 'fixture-line',
+          },
+        },
+      },
+    ],
+    stationNodes: [
+      {
+        id: 'node_ket',
+        stationId: 'KET',
+        displayStatus: 'operational',
+        layerId: 'lines',
+        center: { x: 100, y: 100 },
+        lineIds: ['ISL'],
+        parts: [
+          {
+            id: 'node_ket_isl',
+            lineId: 'ISL',
+            shape: {
+              type: 'circle',
+              center: { x: 100, y: 100 },
+              radius: 8,
+            },
+            coordinateMetadata: {
+              coordinateClass: 'artifact',
+              generatedFrom: 'node_ket',
+            },
+          },
+        ],
+        coordinateMetadata: {
+          coordinateClass: 'constraint',
+          constraintId: 'anchor_ket',
+        },
+      },
+      {
+        id: 'node_adm',
+        stationId: 'ADM',
+        displayStatus: 'operational',
+        layerId: 'lines',
+        center: { x: 200, y: 100 },
+        lineIds: ['ISL'],
+        parts: [
+          {
+            id: 'node_adm_isl',
+            lineId: 'ISL',
+            shape: {
+              type: 'circle',
+              center: { x: 200, y: 100 },
+              radius: 8,
+            },
+            coordinateMetadata: {
+              coordinateClass: 'artifact',
+              generatedFrom: 'node_adm',
+            },
+          },
+        ],
+        coordinateMetadata: {
+          coordinateClass: 'generated',
+          ruleId: 'fixture-line',
+        },
+      },
+    ],
+    labels: [
+      {
+        id: 'label_ket',
+        stationId: 'KET',
+        displayStatus: 'operational',
+        layerId: 'lines',
+        anchor: { x: 100, y: 84 },
+        side: 'top',
+        coordinateMetadata: {
+          coordinateClass: 'generated',
+          ruleId: 'fixture-label',
+        },
+      },
+    ],
+    stationCodeLabels: [],
+  });
+  await writeSchematicMapManifest(dataDir, {
+    schemaVersion: 1,
+    mapId: 'system',
+    versions: [
+      {
+        effectiveDate: '2025-04',
+        path: 'version/2025-04.json',
+        layoutEngineId: 'lta-system-map-2011',
+      },
+    ],
+  });
 }
 
 describe('@mrtdown/cli', () => {
@@ -154,5 +312,47 @@ describe('@mrtdown/cli', () => {
     await expect(
       readFile(resolve(cwd, `data/station/${stationFilename}`), 'utf8'),
     ).resolves.toContain(fixtureMeta.stations.primary.name);
+  });
+
+  it('validates and inspects schematic map files', async () => {
+    const dataDir = await mkdtemp(join(tmpdir(), 'mrtdown-cli-'));
+    await cp(fixtureDataDir, dataDir, { recursive: true });
+    await seedSchematicMap(dataDir);
+
+    const validate = createIo();
+    await expect(
+      runCli(
+        ['--data-dir', dataDir, 'validate', '--scope', 'schematic-map'],
+        validate.io,
+      ),
+    ).resolves.toBe(0);
+    expect(JSON.parse(validate.stdout[0] as string)['schematic-map']).toBe(4);
+
+    const list = createIo();
+    await expect(
+      runCli(
+        ['--data-dir', dataDir, 'schematic-map', 'list', 'version'],
+        list.io,
+      ),
+    ).resolves.toBe(0);
+    expect(list.stdout).toEqual(['2025-04']);
+
+    const show = createIo();
+    await expect(
+      runCli(
+        [
+          '--data-dir',
+          dataDir,
+          'schematic-map',
+          'show',
+          'constraint',
+          '2025-04',
+        ],
+        show.io,
+      ),
+    ).resolves.toBe(0);
+    expect(JSON.parse(show.stdout[0] as string).value.constraints).toHaveLength(
+      2,
+    );
   });
 });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,7 +2,11 @@
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { IssueTypeSchema } from '@mrtdown/core';
+import {
+  IssueTypeSchema,
+  SchematicMapEffectiveDateSchema,
+  SchematicMapLayoutEngineIdSchema,
+} from '@mrtdown/core';
 import {
   buildIssueId,
   buildManifest,
@@ -11,8 +15,14 @@ import {
   entityCollections,
   listEntityIds,
   listIssueIds,
+  listSchematicMapConstraintSetEffectiveDates,
+  listSchematicMapVersionSnapshotEffectiveDates,
   readEntity,
   readIssueBundle,
+  readSchematicMapConstraintSet,
+  readSchematicMapManifest,
+  readSchematicMapRuleSet,
+  readSchematicMapVersionSnapshot,
   renderPagesIndex,
   type ValidationScope,
   validateDataRoot,
@@ -43,6 +53,8 @@ const usage = `Usage:
   mrtdown [--data-dir <path>] validate [--scope <scope>]
   mrtdown [--data-dir <path>] list <station|line|service|operator|town|landmark|issue>
   mrtdown [--data-dir <path>] show <station|line|service|operator|town|landmark|issue> <id>
+  mrtdown [--data-dir <path>] schematic-map list <constraint|version>
+  mrtdown [--data-dir <path>] schematic-map show <manifest|rules|constraint|version> [id]
   mrtdown [--data-dir <path>] create issue --date <YYYY-MM-DD> --title <title> [--slug <slug>] [--type <type>] [--source <source>]
   mrtdown [--data-dir <path>] create <station|line|service|operator|town|landmark> --file <path>
   mrtdown id issue --date <YYYY-MM-DD> --title <title>
@@ -119,6 +131,13 @@ function parseCollection(value: string): EntityCollection | 'issue' {
   throw new Error(`Unknown collection: ${value}`);
 }
 
+function parseValidationScope(value: string): ValidationScope {
+  if (value === 'schematic-map') {
+    return value;
+  }
+  return parseCollection(value);
+}
+
 async function writeTextFile(path: string, text: string): Promise<void> {
   await mkdir(dirname(path), { recursive: true });
   await writeFile(path, text);
@@ -135,7 +154,7 @@ async function runValidate(
     scope;
     scope = readOption(args, '--scope')
   ) {
-    scopes.push(parseCollection(scope) as ValidationScope);
+    scopes.push(parseValidationScope(scope));
   }
 
   const result = await validateDataRoot(
@@ -183,6 +202,66 @@ async function runShow(
       : await readEntity(globals.dataDir, collection, id);
   io.stdout(JSON.stringify(value, null, 2));
   return 0;
+}
+
+async function runSchematicMap(
+  args: string[],
+  globals: GlobalOptions,
+  io: CliIO,
+): Promise<number> {
+  const action = args.shift();
+
+  if (action === 'list') {
+    const kind = args.shift();
+    const values =
+      kind === 'constraint'
+        ? await listSchematicMapConstraintSetEffectiveDates(globals.dataDir)
+        : kind === 'version'
+          ? await listSchematicMapVersionSnapshotEffectiveDates(globals.dataDir)
+          : undefined;
+
+    if (!values) {
+      throw new Error('schematic-map list requires constraint or version');
+    }
+
+    io.stdout(values.join('\n'));
+    return 0;
+  }
+
+  if (action === 'show') {
+    const kind = args.shift();
+    const id = args.shift();
+    const value =
+      kind === 'manifest'
+        ? await readSchematicMapManifest(globals.dataDir)
+        : kind === 'rules'
+          ? await readSchematicMapRuleSet(
+              globals.dataDir,
+              id ? SchematicMapLayoutEngineIdSchema.parse(id) : undefined,
+            )
+          : kind === 'constraint' && id
+            ? await readSchematicMapConstraintSet(
+                globals.dataDir,
+                SchematicMapEffectiveDateSchema.parse(id),
+              )
+            : kind === 'version' && id
+              ? await readSchematicMapVersionSnapshot(
+                  globals.dataDir,
+                  SchematicMapEffectiveDateSchema.parse(id),
+                )
+              : undefined;
+
+    if (!value) {
+      throw new Error(
+        'schematic-map show requires manifest, rules, constraint <YYYY-MM>, or version <YYYY-MM>',
+      );
+    }
+
+    io.stdout(JSON.stringify(value, null, 2));
+    return 0;
+  }
+
+  throw new Error('schematic-map requires list or show');
 }
 
 async function runCreate(
@@ -286,6 +365,8 @@ export async function runCli(
         return await runList(command, globals, io);
       case 'show':
         return await runShow(command, globals, io);
+      case 'schematic-map':
+        return await runSchematicMap(command, globals, io);
       case 'create':
         return await runCreate(command, globals, io);
       case 'id':

--- a/packages/fs/src/index.test.ts
+++ b/packages/fs/src/index.test.ts
@@ -436,7 +436,7 @@ describe('@mrtdown/fs', () => {
           schemaVersion: 1,
           mapId: 'system',
           layoutEngineId: 'lta-system-map-2011',
-          lineOrder: ['NOPE'],
+          lineOrder: ['ISL', 'NOPE'],
         },
         null,
         2,
@@ -447,7 +447,10 @@ describe('@mrtdown/fs', () => {
 
     expect(result.ok).toBe(false);
     expect(result.errors).toContain(
-      'schematic-map/system/generator/engine/extra.json: lineOrder.0 NOPE does not exist in line/',
+      'schematic-map/system/generator/engine/extra.json: layoutEngineId lta-system-map-2011 does not match schematic-map/system/generator/engine/lta-system-map-2011.json',
+    );
+    expect(result.errors).toContain(
+      'schematic-map/system/generator/engine/extra.json: lineOrder.1 NOPE does not exist in line/',
     );
   });
 
@@ -531,6 +534,114 @@ describe('@mrtdown/fs', () => {
     );
     expect(result.errors).toContain(
       'schematic-map/system/manifest.json: versions.0.effectiveDate 2025-05 does not have a generated snapshot',
+    );
+  });
+
+  it('rejects schematic map manifest paths that are not manifest-relative', async () => {
+    const dataDir = await mkdtemp(join(tmpdir(), 'mrtdown-fs-'));
+    await cp(fixtureDataDir, dataDir, { recursive: true });
+    await writeSchematicMapVersionSnapshot(dataDir, {
+      schemaVersion: 1,
+      mapId: 'system',
+      effectiveDate: '2025-04',
+      layoutEngineId: 'lta-system-map-2011',
+      generatedAt: '2026-05-27T00:00:00.000Z',
+      frame: { x: 0, y: 0, width: 3140, height: 2400 },
+      layers: [{ id: 'lines', role: 'line' }],
+      lineGroups: [],
+      segments: [],
+      stationNodes: [],
+      labels: [],
+      stationCodeLabels: [],
+    });
+    await writeSchematicMapManifest(dataDir, {
+      schemaVersion: 1,
+      mapId: 'system',
+      versions: [
+        {
+          effectiveDate: '2025-04',
+          path: 'schematic-map/system/version/2025-04.json',
+          layoutEngineId: 'lta-system-map-2011',
+        },
+      ],
+    });
+
+    const result = await validateDataRoot(dataDir, ['schematic-map']);
+
+    expect(result.ok).toBe(false);
+    expect(result.errors).toContain(
+      'schematic-map/system/manifest.json: versions.0.path schematic-map/system/version/2025-04.json does not match version/2025-04.json',
+    );
+  });
+
+  it('rejects schematic map station nodes on unrelated lines', async () => {
+    const dataDir = await mkdtemp(join(tmpdir(), 'mrtdown-fs-'));
+    await cp(fixtureDataDir, dataDir, { recursive: true });
+    await writeSchematicMapVersionSnapshot(dataDir, {
+      schemaVersion: 1,
+      mapId: 'system',
+      effectiveDate: '2025-04',
+      layoutEngineId: 'lta-system-map-2011',
+      generatedAt: '2026-05-27T00:00:00.000Z',
+      frame: { x: 0, y: 0, width: 3140, height: 2400 },
+      layers: [{ id: 'lines', role: 'line' }],
+      lineGroups: [],
+      segments: [],
+      stationNodes: [
+        {
+          id: 'node_ket',
+          stationId: 'KET',
+          displayStatus: 'operational',
+          layerId: 'lines',
+          center: { x: 100, y: 100 },
+          lineIds: ['TWL'],
+          parts: [
+            {
+              id: 'node_ket_twl',
+              lineId: 'TWL',
+              shape: {
+                type: 'circle',
+                center: { x: 100, y: 100 },
+                radius: 8,
+              },
+              coordinateMetadata: {
+                coordinateClass: 'artifact',
+                generatedFrom: 'node_ket',
+              },
+            },
+          ],
+          coordinateMetadata: {
+            coordinateClass: 'generated',
+            ruleId: 'fixture-line',
+          },
+        },
+      ],
+      labels: [],
+      stationCodeLabels: [
+        {
+          id: 'code_ket_twl',
+          stationId: 'KET',
+          lineId: 'TWL',
+          displayStatus: 'operational',
+          layerId: 'lines',
+          anchor: { x: 100, y: 120 },
+          side: 'bottom',
+          coordinateMetadata: {
+            coordinateClass: 'generated',
+            ruleId: 'fixture-label',
+          },
+        },
+      ],
+    });
+
+    const result = await validateDataRoot(dataDir, ['schematic-map']);
+
+    expect(result.ok).toBe(false);
+    expect(result.errors).toContain(
+      'schematic-map/system/version/2025-04.json: stationNodes.0.lineIds.0 TWL is not a station code line for station KET',
+    );
+    expect(result.errors).toContain(
+      'schematic-map/system/version/2025-04.json: stationCodeLabels.0.lineId TWL is not a station code line for station KET',
     );
   });
 

--- a/packages/fs/src/index.test.ts
+++ b/packages/fs/src/index.test.ts
@@ -42,6 +42,7 @@ import {
   visibleDirEntries,
   writeSchematicMapConstraintSet,
   writeSchematicMapManifest,
+  writeSchematicMapRuleSet,
   writeSchematicMapVersionSnapshot,
   writeUnknownEntity,
 } from './index.js';
@@ -693,10 +694,10 @@ describe('@mrtdown/fs', () => {
 
     expect(result.ok).toBe(false);
     expect(result.errors).toContain(
-      'schematic-map/system/version/2025-04.json: stationNodes.0.lineIds.0 TWL is not a station code line for station KET',
+      'schematic-map/system/version/2025-04.json: stationNodes.0.lineIds.0 TWL is not an active station code line for station KET at 2025-04',
     );
     expect(result.errors).toContain(
-      'schematic-map/system/version/2025-04.json: stationCodeLabels.0.lineId TWL is not a station code line for station KET',
+      'schematic-map/system/version/2025-04.json: stationCodeLabels.0.lineId TWL is not an active station code line for station KET at 2025-04',
     );
   });
 
@@ -722,7 +723,41 @@ describe('@mrtdown/fs', () => {
 
     expect(result.ok).toBe(false);
     expect(result.errors).toContain(
-      'schematic-map/system/generator/constraint/2025-04.json: constraints.0.lineIds.1 TWL is not a station code line for station KET',
+      'schematic-map/system/generator/constraint/2025-04.json: constraints.0.lineIds.1 TWL is not an active station code line for station KET at 2025-04',
+    );
+  });
+
+  it('rejects schematic map route hints on unrelated station lines', async () => {
+    const dataDir = await mkdtemp(join(tmpdir(), 'mrtdown-fs-'));
+    await cp(fixtureDataDir, dataDir, { recursive: true });
+    await writeSchematicMapRuleSet(dataDir, {
+      schemaVersion: 1,
+      mapId: 'system',
+      layoutEngineId: 'lta-system-map-2011',
+      lineOrder: ['TWL'],
+    });
+    await writeSchematicMapConstraintSet(dataDir, {
+      schemaVersion: 1,
+      mapId: 'system',
+      effectiveDate: '2025-04',
+      layoutEngineId: 'lta-system-map-2011',
+      constraints: [
+        {
+          id: 'route_hint_ket_hku',
+          type: 'segment_route_hint',
+          lineId: 'TWL',
+          fromStationId: 'KET',
+          toStationId: 'HKU',
+          via: [{ x: 100, y: 100 }],
+        },
+      ],
+    });
+
+    const result = await validateDataRoot(dataDir, ['schematic-map']);
+
+    expect(result.ok).toBe(false);
+    expect(result.errors).toContain(
+      'schematic-map/system/generator/constraint/2025-04.json: constraints.0.fromStationId TWL is not an active station code line for station KET at 2025-04',
     );
   });
 
@@ -834,13 +869,245 @@ describe('@mrtdown/fs', () => {
 
     expect(result.ok).toBe(false);
     expect(result.errors).toContain(
-      'schematic-map/system/version/2025-04.json: segments.0.topology.fromStationId TWL is not a station code line for station KET',
+      'schematic-map/system/version/2025-04.json: segments.0.topology.fromStationId TWL is not an active station code line for station KET at 2025-04',
     );
   });
 
   it('rejects schematic map station-pair segments without adjacent service edges', async () => {
     const dataDir = await mkdtemp(join(tmpdir(), 'mrtdown-fs-'));
     await cp(fixtureDataDir, dataDir, { recursive: true });
+    await writeSchematicMapVersionSnapshot(dataDir, {
+      schemaVersion: 1,
+      mapId: 'system',
+      effectiveDate: '2025-04',
+      layoutEngineId: 'lta-system-map-2011',
+      generatedAt: '2026-05-27T00:00:00.000Z',
+      frame: { x: 0, y: 0, width: 3140, height: 2400 },
+      layers: [{ id: 'lines', role: 'line' }],
+      lineGroups: [
+        {
+          id: 'line_ISL',
+          lineId: 'ISL',
+          displayStatus: 'operational',
+          layerId: 'lines',
+          segmentIds: ['line_ket:adm'],
+        },
+      ],
+      segments: [
+        {
+          id: 'line_ket:adm',
+          lineId: 'ISL',
+          displayStatus: 'operational',
+          layerId: 'lines',
+          topology: {
+            type: 'station_pair',
+            fromStationId: 'KET',
+            toStationId: 'ADM',
+          },
+          geometry: {
+            type: 'polyline',
+            points: [
+              { x: 100, y: 100 },
+              { x: 200, y: 100 },
+            ],
+            coordinateMetadata: {
+              coordinateClass: 'generated',
+              ruleId: 'fixture-line',
+            },
+          },
+        },
+      ],
+      stationNodes: [
+        {
+          id: 'node_ket',
+          stationId: 'KET',
+          displayStatus: 'operational',
+          layerId: 'lines',
+          center: { x: 100, y: 100 },
+          lineIds: ['ISL'],
+          parts: [
+            {
+              id: 'node_ket_isl',
+              lineId: 'ISL',
+              shape: {
+                type: 'circle',
+                center: { x: 100, y: 100 },
+                radius: 8,
+              },
+              coordinateMetadata: {
+                coordinateClass: 'artifact',
+                generatedFrom: 'node_ket',
+              },
+            },
+          ],
+          coordinateMetadata: {
+            coordinateClass: 'generated',
+            ruleId: 'fixture-line',
+          },
+        },
+        {
+          id: 'node_adm',
+          stationId: 'ADM',
+          displayStatus: 'operational',
+          layerId: 'lines',
+          center: { x: 200, y: 100 },
+          lineIds: ['ISL'],
+          parts: [
+            {
+              id: 'node_adm_isl',
+              lineId: 'ISL',
+              shape: {
+                type: 'circle',
+                center: { x: 200, y: 100 },
+                radius: 8,
+              },
+              coordinateMetadata: {
+                coordinateClass: 'artifact',
+                generatedFrom: 'node_adm',
+              },
+            },
+          ],
+          coordinateMetadata: {
+            coordinateClass: 'generated',
+            ruleId: 'fixture-line',
+          },
+        },
+      ],
+      labels: [],
+      stationCodeLabels: [],
+    });
+
+    const result = await validateDataRoot(dataDir, ['schematic-map']);
+
+    expect(result.ok).toBe(false);
+    expect(result.errors).toContain(
+      'schematic-map/system/version/2025-04.json: segments.0.topology KET:ADM is not an adjacent service edge for line ISL',
+    );
+  });
+
+  it('rejects schematic map references without matching layout engine rules', async () => {
+    const dataDir = await mkdtemp(join(tmpdir(), 'mrtdown-fs-'));
+    await cp(fixtureDataDir, dataDir, { recursive: true });
+    await writeSchematicMapConstraintSet(dataDir, {
+      schemaVersion: 1,
+      mapId: 'system',
+      effectiveDate: '2025-04',
+      layoutEngineId: 'lta-system-map-2011',
+      constraints: [],
+    });
+
+    const result = await validateDataRoot(dataDir, ['schematic-map']);
+
+    expect(result.ok).toBe(false);
+    expect(result.errors).toContain(
+      'schematic-map/system/generator/constraint/2025-04.json: layoutEngineId lta-system-map-2011 does not have a schematic map rule set',
+    );
+  });
+
+  it('rejects schematic map station lines outside station code active windows', async () => {
+    const dataDir = await mkdtemp(join(tmpdir(), 'mrtdown-fs-'));
+    await cp(fixtureDataDir, dataDir, { recursive: true });
+    const stationPath = join(dataDir, 'station/KET.json');
+    const station = JSON.parse(await readFile(stationPath, 'utf8')) as {
+      stationCodes: unknown[];
+    };
+    station.stationCodes.push({
+      lineId: 'TWL',
+      code: 'TWL99',
+      startedAt: '2025-05-01T00:00:00Z',
+      endedAt: null,
+      structureType: 'underground',
+    });
+    await writeFile(stationPath, `${JSON.stringify(station, null, 2)}\n`);
+    await writeSchematicMapRuleSet(dataDir, {
+      schemaVersion: 1,
+      mapId: 'system',
+      layoutEngineId: 'lta-system-map-2011',
+      lineOrder: ['TWL'],
+    });
+    await writeSchematicMapVersionSnapshot(dataDir, {
+      schemaVersion: 1,
+      mapId: 'system',
+      effectiveDate: '2025-04',
+      layoutEngineId: 'lta-system-map-2011',
+      generatedAt: '2026-05-27T00:00:00.000Z',
+      frame: { x: 0, y: 0, width: 3140, height: 2400 },
+      layers: [{ id: 'lines', role: 'line' }],
+      lineGroups: [],
+      segments: [],
+      stationNodes: [
+        {
+          id: 'node_ket',
+          stationId: 'KET',
+          displayStatus: 'operational',
+          layerId: 'lines',
+          center: { x: 100, y: 100 },
+          lineIds: ['TWL'],
+          parts: [
+            {
+              id: 'node_ket_twl',
+              lineId: 'TWL',
+              shape: {
+                type: 'circle',
+                center: { x: 100, y: 100 },
+                radius: 8,
+              },
+              coordinateMetadata: {
+                coordinateClass: 'artifact',
+                generatedFrom: 'node_ket',
+              },
+            },
+          ],
+          coordinateMetadata: {
+            coordinateClass: 'generated',
+            ruleId: 'fixture-line',
+          },
+        },
+      ],
+      labels: [],
+      stationCodeLabels: [],
+    });
+
+    const result = await validateDataRoot(dataDir, ['schematic-map']);
+
+    expect(result.ok).toBe(false);
+    expect(result.errors).toContain(
+      'schematic-map/system/version/2025-04.json: stationNodes.0.lineIds.0 TWL is not an active station code line for station KET at 2025-04',
+    );
+  });
+
+  it('rejects schematic map station-pair edges from future service revisions', async () => {
+    const dataDir = await mkdtemp(join(tmpdir(), 'mrtdown-fs-'));
+    await cp(fixtureDataDir, dataDir, { recursive: true });
+    const servicePath = join(dataDir, 'service/ISL_MAIN_E.json');
+    const service = JSON.parse(await readFile(servicePath, 'utf8')) as {
+      revisions: Array<{
+        id: string;
+        startAt: string;
+        endAt: string | null;
+        path: { stations: Array<{ stationId: string; displayCode: string }> };
+        operatingHours: unknown;
+      }>;
+    };
+    service.revisions.push({
+      ...service.revisions[0],
+      id: 'r_future_direct',
+      startAt: '2025-05-01',
+      endAt: null,
+      path: {
+        stations: [
+          { stationId: 'KET', displayCode: 'ISL1' },
+          { stationId: 'ADM', displayCode: 'ISL6' },
+        ],
+      },
+    });
+    await writeFile(servicePath, `${JSON.stringify(service, null, 2)}\n`);
+    await writeSchematicMapRuleSet(dataDir, {
+      schemaVersion: 1,
+      mapId: 'system',
+      layoutEngineId: 'lta-system-map-2011',
+      lineOrder: ['ISL'],
+    });
     await writeSchematicMapVersionSnapshot(dataDir, {
       schemaVersion: 1,
       mapId: 'system',

--- a/packages/fs/src/index.test.ts
+++ b/packages/fs/src/index.test.ts
@@ -1507,6 +1507,49 @@ describe('@mrtdown/fs', () => {
     expect(result.ok).toBe(true);
   });
 
+  it('allows future-display interchange constraints before station codes start', async () => {
+    const dataDir = await mkdtemp(join(tmpdir(), 'mrtdown-fs-'));
+    await cp(fixtureDataDir, dataDir, { recursive: true });
+
+    const stationPath = join(dataDir, 'station/KET.json');
+    const station = JSON.parse(await readFile(stationPath, 'utf8')) as {
+      stationCodes: unknown[];
+    };
+    station.stationCodes.push({
+      lineId: 'TWL',
+      code: 'TWL99',
+      startedAt: '2025-05-01T00:00:00Z',
+      endedAt: null,
+      structureType: 'underground',
+    });
+    await writeFile(stationPath, `${JSON.stringify(station, null, 2)}\n`);
+
+    await writeSchematicMapRuleSet(dataDir, {
+      schemaVersion: 1,
+      mapId: 'system',
+      layoutEngineId: 'lta-system-map-2011',
+      lineOrder: ['ISL', 'TWL'],
+    });
+    await writeSchematicMapConstraintSet(dataDir, {
+      schemaVersion: 1,
+      mapId: 'system',
+      effectiveDate: '2025-04',
+      layoutEngineId: 'lta-system-map-2011',
+      constraints: [
+        {
+          id: 'future_interchange',
+          type: 'interchange_hint',
+          stationId: 'KET',
+          lineIds: ['ISL', 'TWL'],
+        },
+      ],
+    });
+
+    const result = await validateDataRoot(dataDir, ['schematic-map']);
+
+    expect(result.ok).toBe(true);
+  });
+
   it('allows non-operational station-pair segments before service edges open', async () => {
     const dataDir = await mkdtemp(join(tmpdir(), 'mrtdown-fs-'));
     await cp(fixtureDataDir, dataDir, { recursive: true });

--- a/packages/fs/src/index.test.ts
+++ b/packages/fs/src/index.test.ts
@@ -395,6 +395,32 @@ describe('@mrtdown/fs', () => {
     });
   });
 
+  it('rejects schematic map references that are missing from canonical data', async () => {
+    const dataDir = await mkdtemp(join(tmpdir(), 'mrtdown-fs-'));
+    await cp(fixtureDataDir, dataDir, { recursive: true });
+    await writeSchematicMapConstraintSet(dataDir, {
+      schemaVersion: 1,
+      mapId: 'system',
+      effectiveDate: '2025-04',
+      layoutEngineId: 'lta-system-map-2011',
+      constraints: [
+        {
+          id: 'missing_station_anchor',
+          type: 'station_anchor',
+          stationId: 'NOPE',
+          point: { x: 100, y: 100 },
+        },
+      ],
+    });
+
+    const result = await validateDataRoot(dataDir, ['schematic-map']);
+
+    expect(result.ok).toBe(false);
+    expect(result.errors).toContain(
+      'schematic-map/system/generator/constraint/2025-04.json: constraints.0.stationId NOPE does not exist in station/',
+    );
+  });
+
   it('includes issue impact events in manifest hashes', async () => {
     const dataDir = await mkdtemp(join(tmpdir(), 'mrtdown-fs-'));
     await cp(fixtureDataDir, dataDir, { recursive: true });

--- a/packages/fs/src/index.test.ts
+++ b/packages/fs/src/index.test.ts
@@ -1076,6 +1076,155 @@ describe('@mrtdown/fs', () => {
     );
   });
 
+  it('allows schematic map active checks within the effective month', async () => {
+    const dataDir = await mkdtemp(join(tmpdir(), 'mrtdown-fs-'));
+    await cp(fixtureDataDir, dataDir, { recursive: true });
+
+    for (const stationId of ['KET', 'HKU']) {
+      const stationPath = join(dataDir, `station/${stationId}.json`);
+      const station = JSON.parse(await readFile(stationPath, 'utf8')) as {
+        stationCodes: Array<{ lineId: string; startedAt: string }>;
+      };
+      const islandLineCode = station.stationCodes.find(
+        (code) => code.lineId === 'ISL',
+      );
+      if (!islandLineCode) {
+        throw new Error(`Missing fixture ISL code for ${stationId}`);
+      }
+      islandLineCode.startedAt = '2025-04-30T00:00:00Z';
+      await writeFile(stationPath, `${JSON.stringify(station, null, 2)}\n`);
+    }
+
+    const servicePath = join(dataDir, 'service/ISL_MAIN_E.json');
+    const service = JSON.parse(await readFile(servicePath, 'utf8')) as {
+      revisions: Array<{ startAt: string }>;
+    };
+    service.revisions[0].startAt = '2025-04-30';
+    await writeFile(servicePath, `${JSON.stringify(service, null, 2)}\n`);
+
+    await writeSchematicMapRuleSet(dataDir, {
+      schemaVersion: 1,
+      mapId: 'system',
+      layoutEngineId: 'lta-system-map-2011',
+      lineOrder: ['ISL'],
+    });
+    await writeSchematicMapVersionSnapshot(dataDir, {
+      schemaVersion: 1,
+      mapId: 'system',
+      effectiveDate: '2025-04',
+      layoutEngineId: 'lta-system-map-2011',
+      generatedAt: '2026-05-27T00:00:00.000Z',
+      frame: { x: 0, y: 0, width: 3140, height: 2400 },
+      layers: [{ id: 'lines', role: 'line' }],
+      lineGroups: [
+        {
+          id: 'line_ISL',
+          lineId: 'ISL',
+          displayStatus: 'operational',
+          layerId: 'lines',
+          segmentIds: ['line_ket:hku'],
+        },
+      ],
+      segments: [
+        {
+          id: 'line_ket:hku',
+          lineId: 'ISL',
+          displayStatus: 'operational',
+          layerId: 'lines',
+          topology: {
+            type: 'station_pair',
+            fromStationId: 'KET',
+            toStationId: 'HKU',
+          },
+          geometry: {
+            type: 'polyline',
+            points: [
+              { x: 100, y: 100 },
+              { x: 200, y: 100 },
+            ],
+            coordinateMetadata: {
+              coordinateClass: 'generated',
+              ruleId: 'fixture-line',
+            },
+          },
+        },
+      ],
+      stationNodes: [
+        {
+          id: 'node_ket',
+          stationId: 'KET',
+          displayStatus: 'operational',
+          layerId: 'lines',
+          center: { x: 100, y: 100 },
+          lineIds: ['ISL'],
+          parts: [
+            {
+              id: 'node_ket_isl',
+              lineId: 'ISL',
+              shape: {
+                type: 'circle',
+                center: { x: 100, y: 100 },
+                radius: 8,
+              },
+              coordinateMetadata: {
+                coordinateClass: 'generated',
+                ruleId: 'fixture-node',
+              },
+            },
+          ],
+          coordinateMetadata: {
+            coordinateClass: 'generated',
+            ruleId: 'fixture-node',
+          },
+        },
+        {
+          id: 'node_hku',
+          stationId: 'HKU',
+          displayStatus: 'operational',
+          layerId: 'lines',
+          center: { x: 200, y: 100 },
+          lineIds: ['ISL'],
+          parts: [
+            {
+              id: 'node_hku_isl',
+              lineId: 'ISL',
+              shape: {
+                type: 'circle',
+                center: { x: 200, y: 100 },
+                radius: 8,
+              },
+              coordinateMetadata: {
+                coordinateClass: 'generated',
+                ruleId: 'fixture-node',
+              },
+            },
+          ],
+          coordinateMetadata: {
+            coordinateClass: 'generated',
+            ruleId: 'fixture-node',
+          },
+        },
+      ],
+      labels: [],
+      stationCodeLabels: [],
+    });
+    await writeSchematicMapManifest(dataDir, {
+      schemaVersion: 1,
+      mapId: 'system',
+      versions: [
+        {
+          effectiveDate: '2025-04',
+          path: 'version/2025-04.json',
+          layoutEngineId: 'lta-system-map-2011',
+        },
+      ],
+    });
+
+    const result = await validateDataRoot(dataDir, ['schematic-map']);
+
+    expect(result.ok).toBe(true);
+  });
+
   it('rejects schematic map station-pair edges from future service revisions', async () => {
     const dataDir = await mkdtemp(join(tmpdir(), 'mrtdown-fs-'));
     await cp(fixtureDataDir, dataDir, { recursive: true });
@@ -1311,6 +1460,53 @@ describe('@mrtdown/fs', () => {
     expect(result.ok).toBe(true);
   });
 
+  it('allows future-display route constraints before station codes start', async () => {
+    const dataDir = await mkdtemp(join(tmpdir(), 'mrtdown-fs-'));
+    await cp(fixtureDataDir, dataDir, { recursive: true });
+
+    for (const stationId of ['KET', 'ADM']) {
+      const stationPath = join(dataDir, `station/${stationId}.json`);
+      const station = JSON.parse(await readFile(stationPath, 'utf8')) as {
+        stationCodes: unknown[];
+      };
+      station.stationCodes.push({
+        lineId: 'TWL',
+        code: `${stationId}99`,
+        startedAt: '2025-05-01T00:00:00Z',
+        endedAt: null,
+        structureType: 'underground',
+      });
+      await writeFile(stationPath, `${JSON.stringify(station, null, 2)}\n`);
+    }
+
+    await writeSchematicMapRuleSet(dataDir, {
+      schemaVersion: 1,
+      mapId: 'system',
+      layoutEngineId: 'lta-system-map-2011',
+      lineOrder: ['TWL'],
+    });
+    await writeSchematicMapConstraintSet(dataDir, {
+      schemaVersion: 1,
+      mapId: 'system',
+      effectiveDate: '2025-04',
+      layoutEngineId: 'lta-system-map-2011',
+      constraints: [
+        {
+          id: 'future_twl_route',
+          type: 'segment_route_hint',
+          lineId: 'TWL',
+          fromStationId: 'KET',
+          toStationId: 'ADM',
+          via: [{ x: 100, y: 100 }],
+        },
+      ],
+    });
+
+    const result = await validateDataRoot(dataDir, ['schematic-map']);
+
+    expect(result.ok).toBe(true);
+  });
+
   it('allows non-operational station-pair segments before service edges open', async () => {
     const dataDir = await mkdtemp(join(tmpdir(), 'mrtdown-fs-'));
     await cp(fixtureDataDir, dataDir, { recursive: true });
@@ -1466,6 +1662,207 @@ describe('@mrtdown/fs', () => {
     expect(result.ok).toBe(false);
     expect(result.errors).toContain(
       'schematic-map/system/version/2025-04.json: effectiveDate 2025-04 is not listed in schematic map manifest',
+    );
+  });
+
+  it('rejects schematic map snapshot constraint metadata without matching constraints', async () => {
+    const dataDir = await mkdtemp(join(tmpdir(), 'mrtdown-fs-'));
+    await cp(fixtureDataDir, dataDir, { recursive: true });
+    await writeSchematicMapRuleSet(dataDir, {
+      schemaVersion: 1,
+      mapId: 'system',
+      layoutEngineId: 'lta-system-map-2011',
+      lineOrder: ['ISL'],
+    });
+    await writeSchematicMapConstraintSet(dataDir, {
+      schemaVersion: 1,
+      mapId: 'system',
+      effectiveDate: '2025-04',
+      layoutEngineId: 'lta-system-map-2011',
+      constraints: [
+        {
+          id: 'known_anchor',
+          type: 'station_anchor',
+          stationId: 'KET',
+          point: { x: 100, y: 100 },
+        },
+      ],
+    });
+    await writeSchematicMapVersionSnapshot(dataDir, {
+      schemaVersion: 1,
+      mapId: 'system',
+      effectiveDate: '2025-04',
+      layoutEngineId: 'lta-system-map-2011',
+      generatedAt: '2026-05-27T00:00:00.000Z',
+      frame: {
+        x: 0,
+        y: 0,
+        width: 3140,
+        height: 2400,
+        coordinateMetadata: {
+          coordinateClass: 'constraint',
+          constraintId: 'missing_frame',
+        },
+      },
+      layers: [
+        { id: 'lines', role: 'line' },
+        { id: 'labels', role: 'label' },
+      ],
+      lineGroups: [
+        {
+          id: 'line_ISL',
+          lineId: 'ISL',
+          displayStatus: 'operational',
+          layerId: 'lines',
+          segmentIds: ['line_ket:hku'],
+        },
+      ],
+      segments: [
+        {
+          id: 'line_ket:hku',
+          lineId: 'ISL',
+          displayStatus: 'operational',
+          layerId: 'lines',
+          topology: {
+            type: 'station_pair',
+            fromStationId: 'KET',
+            toStationId: 'HKU',
+          },
+          geometry: {
+            type: 'polyline',
+            points: [
+              { x: 100, y: 100 },
+              { x: 200, y: 100 },
+            ],
+            coordinateMetadata: {
+              coordinateClass: 'constraint',
+              constraintId: 'missing_segment',
+            },
+          },
+        },
+      ],
+      stationNodes: [
+        {
+          id: 'node_ket',
+          stationId: 'KET',
+          displayStatus: 'operational',
+          layerId: 'lines',
+          center: { x: 100, y: 100 },
+          lineIds: ['ISL'],
+          parts: [
+            {
+              id: 'node_ket_isl',
+              lineId: 'ISL',
+              shape: {
+                type: 'circle',
+                center: { x: 100, y: 100 },
+                radius: 8,
+              },
+              coordinateMetadata: {
+                coordinateClass: 'constraint',
+                constraintId: 'missing_part',
+              },
+            },
+          ],
+          coordinateMetadata: {
+            coordinateClass: 'constraint',
+            constraintId: 'missing_node',
+          },
+        },
+        {
+          id: 'node_hku',
+          stationId: 'HKU',
+          displayStatus: 'operational',
+          layerId: 'lines',
+          center: { x: 200, y: 100 },
+          lineIds: ['ISL'],
+          parts: [
+            {
+              id: 'node_hku_isl',
+              lineId: 'ISL',
+              shape: {
+                type: 'circle',
+                center: { x: 200, y: 100 },
+                radius: 8,
+              },
+              coordinateMetadata: {
+                coordinateClass: 'generated',
+                ruleId: 'fixture-node',
+              },
+            },
+          ],
+          coordinateMetadata: {
+            coordinateClass: 'generated',
+            ruleId: 'fixture-node',
+          },
+        },
+      ],
+      labels: [
+        {
+          id: 'label_ket',
+          stationId: 'KET',
+          displayStatus: 'operational',
+          layerId: 'labels',
+          anchor: { x: 100, y: 80 },
+          side: 'top',
+          leaderLine: {
+            type: 'polyline',
+            points: [
+              { x: 100, y: 90 },
+              { x: 100, y: 100 },
+            ],
+            coordinateMetadata: {
+              coordinateClass: 'constraint',
+              constraintId: 'missing_leader',
+            },
+          },
+          coordinateMetadata: {
+            coordinateClass: 'constraint',
+            constraintId: 'missing_label',
+          },
+        },
+      ],
+      stationCodeLabels: [
+        {
+          id: 'code_ket_isl',
+          stationId: 'KET',
+          lineId: 'ISL',
+          displayStatus: 'operational',
+          layerId: 'labels',
+          anchor: { x: 100, y: 120 },
+          side: 'bottom',
+          coordinateMetadata: {
+            coordinateClass: 'constraint',
+            constraintId: 'missing_code',
+          },
+        },
+      ],
+    });
+    await writeSchematicMapManifest(dataDir, {
+      schemaVersion: 1,
+      mapId: 'system',
+      versions: [
+        {
+          effectiveDate: '2025-04',
+          path: 'version/2025-04.json',
+          layoutEngineId: 'lta-system-map-2011',
+        },
+      ],
+    });
+
+    const result = await validateDataRoot(dataDir, ['schematic-map']);
+
+    expect(result.ok).toBe(false);
+    expect(result.errors).toEqual(
+      expect.arrayContaining([
+        'schematic-map/system/version/2025-04.json: frame.coordinateMetadata.constraintId missing_frame does not exist in schematic map constraints for 2025-04',
+        'schematic-map/system/version/2025-04.json: segments.0.geometry.coordinateMetadata.constraintId missing_segment does not exist in schematic map constraints for 2025-04',
+        'schematic-map/system/version/2025-04.json: stationNodes.0.parts.0.coordinateMetadata.constraintId missing_part does not exist in schematic map constraints for 2025-04',
+        'schematic-map/system/version/2025-04.json: stationNodes.0.coordinateMetadata.constraintId missing_node does not exist in schematic map constraints for 2025-04',
+        'schematic-map/system/version/2025-04.json: labels.0.leaderLine.coordinateMetadata.constraintId missing_leader does not exist in schematic map constraints for 2025-04',
+        'schematic-map/system/version/2025-04.json: labels.0.coordinateMetadata.constraintId missing_label does not exist in schematic map constraints for 2025-04',
+        'schematic-map/system/version/2025-04.json: stationCodeLabels.0.coordinateMetadata.constraintId missing_code does not exist in schematic map constraints for 2025-04',
+      ]),
     );
   });
 

--- a/packages/fs/src/index.test.ts
+++ b/packages/fs/src/index.test.ts
@@ -421,6 +421,119 @@ describe('@mrtdown/fs', () => {
     );
   });
 
+  it('validates every schematic map rule set file', async () => {
+    const dataDir = await mkdtemp(join(tmpdir(), 'mrtdown-fs-'));
+    await cp(fixtureDataDir, dataDir, { recursive: true });
+    const ruleSetPath = join(
+      dataDir,
+      'schematic-map/system/generator/engine/extra.json',
+    );
+    await mkdir(dirname(ruleSetPath), { recursive: true });
+    await writeFile(
+      ruleSetPath,
+      `${JSON.stringify(
+        {
+          schemaVersion: 1,
+          mapId: 'system',
+          layoutEngineId: 'lta-system-map-2011',
+          lineOrder: ['NOPE'],
+        },
+        null,
+        2,
+      )}\n`,
+    );
+
+    const result = await validateDataRoot(dataDir, ['schematic-map']);
+
+    expect(result.ok).toBe(false);
+    expect(result.errors).toContain(
+      'schematic-map/system/generator/engine/extra.json: lineOrder.0 NOPE does not exist in line/',
+    );
+  });
+
+  it('rejects schematic map constraint files with mismatched effective dates', async () => {
+    const dataDir = await mkdtemp(join(tmpdir(), 'mrtdown-fs-'));
+    await cp(fixtureDataDir, dataDir, { recursive: true });
+    const constraintPath = join(
+      dataDir,
+      schematicSystemMapConstraintSetPath('2025-04'),
+    );
+    await mkdir(dirname(constraintPath), { recursive: true });
+    await writeFile(
+      constraintPath,
+      `${JSON.stringify(
+        {
+          schemaVersion: 1,
+          mapId: 'system',
+          effectiveDate: '2025-05',
+          layoutEngineId: 'lta-system-map-2011',
+          constraints: [],
+        },
+        null,
+        2,
+      )}\n`,
+    );
+
+    const result = await validateDataRoot(dataDir, ['schematic-map']);
+
+    expect(result.ok).toBe(false);
+    expect(result.errors).toContain(
+      'schematic-map/system/generator/constraint/2025-04.json: effectiveDate 2025-05 does not match schematic-map/system/generator/constraint/2025-05.json',
+    );
+  });
+
+  it('rejects schematic map snapshots that satisfy a manifest from the wrong file path', async () => {
+    const dataDir = await mkdtemp(join(tmpdir(), 'mrtdown-fs-'));
+    await cp(fixtureDataDir, dataDir, { recursive: true });
+    const snapshotPath = join(
+      dataDir,
+      schematicSystemMapVersionSnapshotPath('2025-04'),
+    );
+    await mkdir(dirname(snapshotPath), { recursive: true });
+    await writeFile(
+      snapshotPath,
+      `${JSON.stringify(
+        {
+          schemaVersion: 1,
+          mapId: 'system',
+          effectiveDate: '2025-05',
+          layoutEngineId: 'lta-system-map-2011',
+          generatedAt: '2026-05-27T00:00:00.000Z',
+          frame: { x: 0, y: 0, width: 3140, height: 2400 },
+          layers: [{ id: 'lines', role: 'line' }],
+          lineGroups: [],
+          segments: [],
+          stationNodes: [],
+          labels: [],
+          stationCodeLabels: [],
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    await writeSchematicMapManifest(dataDir, {
+      schemaVersion: 1,
+      mapId: 'system',
+      versions: [
+        {
+          effectiveDate: '2025-05',
+          path: 'version/2025-05.json',
+          layoutEngineId: 'lta-system-map-2011',
+        },
+      ],
+    });
+
+    const result = await validateDataRoot(dataDir, ['schematic-map']);
+
+    expect(result.ok).toBe(false);
+    expect(result.errors).toContain(
+      'schematic-map/system/version/2025-04.json: effectiveDate 2025-05 does not match schematic-map/system/version/2025-05.json',
+    );
+    expect(result.errors).toContain(
+      'schematic-map/system/manifest.json: versions.0.effectiveDate 2025-05 does not have a generated snapshot',
+    );
+  });
+
   it('includes issue impact events in manifest hashes', async () => {
     const dataDir = await mkdtemp(join(tmpdir(), 'mrtdown-fs-'));
     await cp(fixtureDataDir, dataDir, { recursive: true });

--- a/packages/fs/src/index.test.ts
+++ b/packages/fs/src/index.test.ts
@@ -550,7 +550,62 @@ describe('@mrtdown/fs', () => {
       layers: [{ id: 'lines', role: 'line' }],
       lineGroups: [],
       segments: [],
-      stationNodes: [],
+      stationNodes: [
+        {
+          id: 'node_ket',
+          stationId: 'KET',
+          displayStatus: 'operational',
+          layerId: 'lines',
+          center: { x: 100, y: 100 },
+          lineIds: ['TWL'],
+          parts: [
+            {
+              id: 'node_ket_twl',
+              lineId: 'TWL',
+              shape: {
+                type: 'circle',
+                center: { x: 100, y: 100 },
+                radius: 8,
+              },
+              coordinateMetadata: {
+                coordinateClass: 'artifact',
+                generatedFrom: 'node_ket',
+              },
+            },
+          ],
+          coordinateMetadata: {
+            coordinateClass: 'generated',
+            ruleId: 'fixture-line',
+          },
+        },
+        {
+          id: 'node_hku',
+          stationId: 'HKU',
+          displayStatus: 'operational',
+          layerId: 'lines',
+          center: { x: 200, y: 100 },
+          lineIds: ['TWL'],
+          parts: [
+            {
+              id: 'node_hku_twl',
+              lineId: 'TWL',
+              shape: {
+                type: 'circle',
+                center: { x: 200, y: 100 },
+                radius: 8,
+              },
+              coordinateMetadata: {
+                coordinateClass: 'artifact',
+                generatedFrom: 'node_hku',
+              },
+            },
+          ],
+          coordinateMetadata: {
+            coordinateClass: 'generated',
+            ruleId: 'fixture-line',
+          },
+        },
+      ],
       labels: [],
       stationCodeLabels: [],
     });
@@ -642,6 +697,256 @@ describe('@mrtdown/fs', () => {
     );
     expect(result.errors).toContain(
       'schematic-map/system/version/2025-04.json: stationCodeLabels.0.lineId TWL is not a station code line for station KET',
+    );
+  });
+
+  it('rejects schematic map interchange hints on unrelated station lines', async () => {
+    const dataDir = await mkdtemp(join(tmpdir(), 'mrtdown-fs-'));
+    await cp(fixtureDataDir, dataDir, { recursive: true });
+    await writeSchematicMapConstraintSet(dataDir, {
+      schemaVersion: 1,
+      mapId: 'system',
+      effectiveDate: '2025-04',
+      layoutEngineId: 'lta-system-map-2011',
+      constraints: [
+        {
+          id: 'interchange_ket_twl',
+          type: 'interchange_hint',
+          stationId: 'KET',
+          lineIds: ['ISL', 'TWL'],
+        },
+      ],
+    });
+
+    const result = await validateDataRoot(dataDir, ['schematic-map']);
+
+    expect(result.ok).toBe(false);
+    expect(result.errors).toContain(
+      'schematic-map/system/generator/constraint/2025-04.json: constraints.0.lineIds.1 TWL is not a station code line for station KET',
+    );
+  });
+
+  it('rejects schematic map station-pair segments on unrelated lines', async () => {
+    const dataDir = await mkdtemp(join(tmpdir(), 'mrtdown-fs-'));
+    await cp(fixtureDataDir, dataDir, { recursive: true });
+    await writeSchematicMapVersionSnapshot(dataDir, {
+      schemaVersion: 1,
+      mapId: 'system',
+      effectiveDate: '2025-04',
+      layoutEngineId: 'lta-system-map-2011',
+      generatedAt: '2026-05-27T00:00:00.000Z',
+      frame: { x: 0, y: 0, width: 3140, height: 2400 },
+      layers: [{ id: 'lines', role: 'line' }],
+      lineGroups: [
+        {
+          id: 'line_TWL',
+          lineId: 'TWL',
+          displayStatus: 'operational',
+          layerId: 'lines',
+          segmentIds: ['line_ket:hku'],
+        },
+      ],
+      segments: [
+        {
+          id: 'line_ket:hku',
+          lineId: 'TWL',
+          displayStatus: 'operational',
+          layerId: 'lines',
+          topology: {
+            type: 'station_pair',
+            fromStationId: 'KET',
+            toStationId: 'HKU',
+          },
+          geometry: {
+            type: 'polyline',
+            points: [
+              { x: 100, y: 100 },
+              { x: 200, y: 100 },
+            ],
+            coordinateMetadata: {
+              coordinateClass: 'generated',
+              ruleId: 'fixture-line',
+            },
+          },
+        },
+      ],
+      stationNodes: [
+        {
+          id: 'node_ket',
+          stationId: 'KET',
+          displayStatus: 'operational',
+          layerId: 'lines',
+          center: { x: 100, y: 100 },
+          lineIds: ['TWL'],
+          parts: [
+            {
+              id: 'node_ket_twl',
+              lineId: 'TWL',
+              shape: {
+                type: 'circle',
+                center: { x: 100, y: 100 },
+                radius: 8,
+              },
+              coordinateMetadata: {
+                coordinateClass: 'artifact',
+                generatedFrom: 'node_ket',
+              },
+            },
+          ],
+          coordinateMetadata: {
+            coordinateClass: 'generated',
+            ruleId: 'fixture-line',
+          },
+        },
+        {
+          id: 'node_hku',
+          stationId: 'HKU',
+          displayStatus: 'operational',
+          layerId: 'lines',
+          center: { x: 200, y: 100 },
+          lineIds: ['TWL'],
+          parts: [
+            {
+              id: 'node_hku_twl',
+              lineId: 'TWL',
+              shape: {
+                type: 'circle',
+                center: { x: 200, y: 100 },
+                radius: 8,
+              },
+              coordinateMetadata: {
+                coordinateClass: 'artifact',
+                generatedFrom: 'node_hku',
+              },
+            },
+          ],
+          coordinateMetadata: {
+            coordinateClass: 'generated',
+            ruleId: 'fixture-line',
+          },
+        },
+      ],
+      labels: [],
+      stationCodeLabels: [],
+    });
+
+    const result = await validateDataRoot(dataDir, ['schematic-map']);
+
+    expect(result.ok).toBe(false);
+    expect(result.errors).toContain(
+      'schematic-map/system/version/2025-04.json: segments.0.topology.fromStationId TWL is not a station code line for station KET',
+    );
+  });
+
+  it('rejects schematic map station-pair segments without adjacent service edges', async () => {
+    const dataDir = await mkdtemp(join(tmpdir(), 'mrtdown-fs-'));
+    await cp(fixtureDataDir, dataDir, { recursive: true });
+    await writeSchematicMapVersionSnapshot(dataDir, {
+      schemaVersion: 1,
+      mapId: 'system',
+      effectiveDate: '2025-04',
+      layoutEngineId: 'lta-system-map-2011',
+      generatedAt: '2026-05-27T00:00:00.000Z',
+      frame: { x: 0, y: 0, width: 3140, height: 2400 },
+      layers: [{ id: 'lines', role: 'line' }],
+      lineGroups: [
+        {
+          id: 'line_ISL',
+          lineId: 'ISL',
+          displayStatus: 'operational',
+          layerId: 'lines',
+          segmentIds: ['line_ket:adm'],
+        },
+      ],
+      segments: [
+        {
+          id: 'line_ket:adm',
+          lineId: 'ISL',
+          displayStatus: 'operational',
+          layerId: 'lines',
+          topology: {
+            type: 'station_pair',
+            fromStationId: 'KET',
+            toStationId: 'ADM',
+          },
+          geometry: {
+            type: 'polyline',
+            points: [
+              { x: 100, y: 100 },
+              { x: 200, y: 100 },
+            ],
+            coordinateMetadata: {
+              coordinateClass: 'generated',
+              ruleId: 'fixture-line',
+            },
+          },
+        },
+      ],
+      stationNodes: [
+        {
+          id: 'node_ket',
+          stationId: 'KET',
+          displayStatus: 'operational',
+          layerId: 'lines',
+          center: { x: 100, y: 100 },
+          lineIds: ['ISL'],
+          parts: [
+            {
+              id: 'node_ket_isl',
+              lineId: 'ISL',
+              shape: {
+                type: 'circle',
+                center: { x: 100, y: 100 },
+                radius: 8,
+              },
+              coordinateMetadata: {
+                coordinateClass: 'artifact',
+                generatedFrom: 'node_ket',
+              },
+            },
+          ],
+          coordinateMetadata: {
+            coordinateClass: 'generated',
+            ruleId: 'fixture-line',
+          },
+        },
+        {
+          id: 'node_adm',
+          stationId: 'ADM',
+          displayStatus: 'operational',
+          layerId: 'lines',
+          center: { x: 200, y: 100 },
+          lineIds: ['ISL'],
+          parts: [
+            {
+              id: 'node_adm_isl',
+              lineId: 'ISL',
+              shape: {
+                type: 'circle',
+                center: { x: 200, y: 100 },
+                radius: 8,
+              },
+              coordinateMetadata: {
+                coordinateClass: 'artifact',
+                generatedFrom: 'node_adm',
+              },
+            },
+          ],
+          coordinateMetadata: {
+            coordinateClass: 'generated',
+            ruleId: 'fixture-line',
+          },
+        },
+      ],
+      labels: [],
+      stationCodeLabels: [],
+    });
+
+    const result = await validateDataRoot(dataDir, ['schematic-map']);
+
+    expect(result.ok).toBe(false);
+    expect(result.errors).toContain(
+      'schematic-map/system/version/2025-04.json: segments.0.topology KET:ADM is not an adjacent service edge for line ISL',
     );
   });
 

--- a/packages/fs/src/index.test.ts
+++ b/packages/fs/src/index.test.ts
@@ -694,10 +694,10 @@ describe('@mrtdown/fs', () => {
 
     expect(result.ok).toBe(false);
     expect(result.errors).toContain(
-      'schematic-map/system/version/2025-04.json: stationNodes.0.lineIds.0 TWL is not an active station code line for station KET at 2025-04',
+      'schematic-map/system/version/2025-04.json: stationNodes.0.lineIds.0 TWL is not a station code line for station KET',
     );
     expect(result.errors).toContain(
-      'schematic-map/system/version/2025-04.json: stationCodeLabels.0.lineId TWL is not an active station code line for station KET at 2025-04',
+      'schematic-map/system/version/2025-04.json: stationCodeLabels.0.lineId TWL is not a station code line for station KET',
     );
   });
 
@@ -723,7 +723,7 @@ describe('@mrtdown/fs', () => {
 
     expect(result.ok).toBe(false);
     expect(result.errors).toContain(
-      'schematic-map/system/generator/constraint/2025-04.json: constraints.0.lineIds.1 TWL is not an active station code line for station KET at 2025-04',
+      'schematic-map/system/generator/constraint/2025-04.json: constraints.0.lineIds.1 TWL is not a station code line for station KET',
     );
   });
 
@@ -757,7 +757,7 @@ describe('@mrtdown/fs', () => {
 
     expect(result.ok).toBe(false);
     expect(result.errors).toContain(
-      'schematic-map/system/generator/constraint/2025-04.json: constraints.0.fromStationId TWL is not an active station code line for station KET at 2025-04',
+      'schematic-map/system/generator/constraint/2025-04.json: constraints.0.fromStationId TWL is not a station code line for station KET',
     );
   });
 
@@ -869,7 +869,7 @@ describe('@mrtdown/fs', () => {
 
     expect(result.ok).toBe(false);
     expect(result.errors).toContain(
-      'schematic-map/system/version/2025-04.json: segments.0.topology.fromStationId TWL is not an active station code line for station KET at 2025-04',
+      'schematic-map/system/version/2025-04.json: segments.0.topology.fromStationId TWL is not a station code line for station KET',
     );
   });
 
@@ -1214,6 +1214,258 @@ describe('@mrtdown/fs', () => {
     expect(result.ok).toBe(false);
     expect(result.errors).toContain(
       'schematic-map/system/version/2025-04.json: segments.0.topology KET:ADM is not an adjacent service edge for line ISL',
+    );
+  });
+
+  it('allows non-operational schematic station coverage before station codes start', async () => {
+    const dataDir = await mkdtemp(join(tmpdir(), 'mrtdown-fs-'));
+    await cp(fixtureDataDir, dataDir, { recursive: true });
+    const stationPath = join(dataDir, 'station/KET.json');
+    const station = JSON.parse(await readFile(stationPath, 'utf8')) as {
+      stationCodes: unknown[];
+    };
+    station.stationCodes.push({
+      lineId: 'TWL',
+      code: 'TWL99',
+      startedAt: '2025-05-01T00:00:00Z',
+      endedAt: null,
+      structureType: 'underground',
+    });
+    await writeFile(stationPath, `${JSON.stringify(station, null, 2)}\n`);
+    await writeSchematicMapRuleSet(dataDir, {
+      schemaVersion: 1,
+      mapId: 'system',
+      layoutEngineId: 'lta-system-map-2011',
+      lineOrder: ['TWL'],
+    });
+    await writeSchematicMapVersionSnapshot(dataDir, {
+      schemaVersion: 1,
+      mapId: 'system',
+      effectiveDate: '2025-04',
+      layoutEngineId: 'lta-system-map-2011',
+      generatedAt: '2026-05-27T00:00:00.000Z',
+      frame: { x: 0, y: 0, width: 3140, height: 2400 },
+      layers: [{ id: 'lines', role: 'line' }],
+      lineGroups: [],
+      segments: [],
+      stationNodes: [
+        {
+          id: 'node_ket',
+          stationId: 'KET',
+          displayStatus: 'planned',
+          layerId: 'lines',
+          center: { x: 100, y: 100 },
+          lineIds: ['TWL'],
+          parts: [
+            {
+              id: 'node_ket_twl',
+              lineId: 'TWL',
+              shape: {
+                type: 'circle',
+                center: { x: 100, y: 100 },
+                radius: 8,
+              },
+              coordinateMetadata: {
+                coordinateClass: 'artifact',
+                generatedFrom: 'node_ket',
+              },
+            },
+          ],
+          coordinateMetadata: {
+            coordinateClass: 'generated',
+            ruleId: 'fixture-line',
+          },
+        },
+      ],
+      labels: [],
+      stationCodeLabels: [
+        {
+          id: 'code_ket_twl',
+          stationId: 'KET',
+          lineId: 'TWL',
+          displayStatus: 'planned',
+          layerId: 'lines',
+          anchor: { x: 100, y: 120 },
+          side: 'bottom',
+          coordinateMetadata: {
+            coordinateClass: 'generated',
+            ruleId: 'fixture-label',
+          },
+        },
+      ],
+    });
+    await writeSchematicMapManifest(dataDir, {
+      schemaVersion: 1,
+      mapId: 'system',
+      versions: [
+        {
+          effectiveDate: '2025-04',
+          path: 'version/2025-04.json',
+          layoutEngineId: 'lta-system-map-2011',
+        },
+      ],
+    });
+
+    const result = await validateDataRoot(dataDir, ['schematic-map']);
+
+    expect(result.ok).toBe(true);
+  });
+
+  it('allows non-operational station-pair segments before service edges open', async () => {
+    const dataDir = await mkdtemp(join(tmpdir(), 'mrtdown-fs-'));
+    await cp(fixtureDataDir, dataDir, { recursive: true });
+    await writeSchematicMapRuleSet(dataDir, {
+      schemaVersion: 1,
+      mapId: 'system',
+      layoutEngineId: 'lta-system-map-2011',
+      lineOrder: ['ISL'],
+    });
+    await writeSchematicMapVersionSnapshot(dataDir, {
+      schemaVersion: 1,
+      mapId: 'system',
+      effectiveDate: '2025-04',
+      layoutEngineId: 'lta-system-map-2011',
+      generatedAt: '2026-05-27T00:00:00.000Z',
+      frame: { x: 0, y: 0, width: 3140, height: 2400 },
+      layers: [{ id: 'lines', role: 'line' }],
+      lineGroups: [
+        {
+          id: 'line_ISL',
+          lineId: 'ISL',
+          displayStatus: 'planned',
+          layerId: 'lines',
+          segmentIds: ['line_ket:adm'],
+        },
+      ],
+      segments: [
+        {
+          id: 'line_ket:adm',
+          lineId: 'ISL',
+          displayStatus: 'planned',
+          layerId: 'lines',
+          topology: {
+            type: 'station_pair',
+            fromStationId: 'KET',
+            toStationId: 'ADM',
+          },
+          geometry: {
+            type: 'polyline',
+            points: [
+              { x: 100, y: 100 },
+              { x: 200, y: 100 },
+            ],
+            coordinateMetadata: {
+              coordinateClass: 'generated',
+              ruleId: 'fixture-line',
+            },
+          },
+        },
+      ],
+      stationNodes: [
+        {
+          id: 'node_ket',
+          stationId: 'KET',
+          displayStatus: 'operational',
+          layerId: 'lines',
+          center: { x: 100, y: 100 },
+          lineIds: ['ISL'],
+          parts: [
+            {
+              id: 'node_ket_isl',
+              lineId: 'ISL',
+              shape: {
+                type: 'circle',
+                center: { x: 100, y: 100 },
+                radius: 8,
+              },
+              coordinateMetadata: {
+                coordinateClass: 'artifact',
+                generatedFrom: 'node_ket',
+              },
+            },
+          ],
+          coordinateMetadata: {
+            coordinateClass: 'generated',
+            ruleId: 'fixture-line',
+          },
+        },
+        {
+          id: 'node_adm',
+          stationId: 'ADM',
+          displayStatus: 'operational',
+          layerId: 'lines',
+          center: { x: 200, y: 100 },
+          lineIds: ['ISL'],
+          parts: [
+            {
+              id: 'node_adm_isl',
+              lineId: 'ISL',
+              shape: {
+                type: 'circle',
+                center: { x: 200, y: 100 },
+                radius: 8,
+              },
+              coordinateMetadata: {
+                coordinateClass: 'artifact',
+                generatedFrom: 'node_adm',
+              },
+            },
+          ],
+          coordinateMetadata: {
+            coordinateClass: 'generated',
+            ruleId: 'fixture-line',
+          },
+        },
+      ],
+      labels: [],
+      stationCodeLabels: [],
+    });
+    await writeSchematicMapManifest(dataDir, {
+      schemaVersion: 1,
+      mapId: 'system',
+      versions: [
+        {
+          effectiveDate: '2025-04',
+          path: 'version/2025-04.json',
+          layoutEngineId: 'lta-system-map-2011',
+        },
+      ],
+    });
+
+    const result = await validateDataRoot(dataDir, ['schematic-map']);
+
+    expect(result.ok).toBe(true);
+  });
+
+  it('rejects schematic map snapshots omitted from the manifest', async () => {
+    const dataDir = await mkdtemp(join(tmpdir(), 'mrtdown-fs-'));
+    await cp(fixtureDataDir, dataDir, { recursive: true });
+    await writeSchematicMapRuleSet(dataDir, {
+      schemaVersion: 1,
+      mapId: 'system',
+      layoutEngineId: 'lta-system-map-2011',
+      lineOrder: ['ISL'],
+    });
+    await writeSchematicMapVersionSnapshot(dataDir, {
+      schemaVersion: 1,
+      mapId: 'system',
+      effectiveDate: '2025-04',
+      layoutEngineId: 'lta-system-map-2011',
+      generatedAt: '2026-05-27T00:00:00.000Z',
+      frame: { x: 0, y: 0, width: 3140, height: 2400 },
+      layers: [{ id: 'lines', role: 'line' }],
+      lineGroups: [],
+      segments: [],
+      stationNodes: [],
+      labels: [],
+      stationCodeLabels: [],
+    });
+
+    const result = await validateDataRoot(dataDir, ['schematic-map']);
+
+    expect(result.ok).toBe(false);
+    expect(result.errors).toContain(
+      'schematic-map/system/version/2025-04.json: effectiveDate 2025-04 is not listed in schematic map manifest',
     );
   });
 

--- a/packages/fs/src/schematicMaps.ts
+++ b/packages/fs/src/schematicMaps.ts
@@ -144,6 +144,27 @@ export async function readSchematicMapRuleSet(
   );
 }
 
+export async function listSchematicMapRuleSets(
+  dataDir: string,
+): Promise<SchematicMapRecord<SchematicMapRuleSet>[]> {
+  const dir = join(
+    dataDir,
+    schematicSystemMapRootPath(),
+    DIR_SCHEMATIC_MAP_GENERATOR,
+    DIR_SCHEMATIC_MAP_ENGINE,
+  );
+  const files = await listJsonFiles(dir);
+  return Promise.all(
+    files.map(async (file) =>
+      schematicMapRecord(
+        dataDir,
+        file,
+        await readJsonFile(file, SchematicMapRuleSetSchema),
+      ),
+    ),
+  );
+}
+
 export async function writeSchematicMapRuleSet(
   dataDir: string,
   ruleSet: SchematicMapRuleSet,

--- a/packages/fs/src/validate.ts
+++ b/packages/fs/src/validate.ts
@@ -1,6 +1,7 @@
 import type {
   IssueBundle,
   SchematicMapConstraintSet,
+  SchematicMapCoordinateMetadata,
   SchematicMapManifest,
   SchematicMapRuleSet,
   SchematicMapVersionSnapshot,
@@ -318,8 +319,19 @@ function stationPairKey(fromStationId: string, toStationId: string): string {
   return [fromStationId, toStationId].sort().join(':');
 }
 
-function effectiveDateTimestampForValidation(effectiveDate: string): number {
-  return timestampForValidation(`${effectiveDate}-01T00:00:00Z`);
+function effectiveMonthIntervalForValidation(effectiveDate: string): {
+  start: number;
+  end: number;
+} {
+  const [year, month] = effectiveDate.split('-').map(Number);
+  if (!year || !month) {
+    throw new Error(`Invalid effective date for validation: ${effectiveDate}`);
+  }
+
+  return {
+    start: Date.UTC(year, month - 1, 1),
+    end: Date.UTC(year, month, 1),
+  };
 }
 
 function intervalContainsEffectiveDate(
@@ -327,16 +339,15 @@ function intervalContainsEffectiveDate(
   endedAt: string | null,
   effectiveDate: string,
 ): boolean {
-  const effectiveDateTimestamp =
-    effectiveDateTimestampForValidation(effectiveDate);
+  const effectiveMonth = effectiveMonthIntervalForValidation(effectiveDate);
   const startedAtTimestamp = timestampForValidation(startedAt);
   const endedAtTimestamp = endedAt
     ? timestampForValidation(endedAt)
     : Number.POSITIVE_INFINITY;
 
   return (
-    startedAtTimestamp <= effectiveDateTimestamp &&
-    effectiveDateTimestamp < endedAtTimestamp
+    startedAtTimestamp < effectiveMonth.end &&
+    effectiveMonth.start < endedAtTimestamp
   );
 }
 
@@ -466,6 +477,7 @@ async function validateSchematicMapReferences(
   const serviceRecords = await loadEntityRecords(dataDir, records, 'service');
   const serviceEdgesByLineAndEffectiveDate = new Map<string, Set<string>>();
   const schematicMap = await loadSchematicMapRecords(dataDir, records);
+  const constraintIdsByEffectiveDate = new Map<string, Set<string>>();
   const errors: string[] = [];
 
   const serviceEdgesForLineAtEffectiveDate = (
@@ -562,6 +574,23 @@ async function validateSchematicMapReferences(
     }
   };
 
+  const requireKnownConstraintCoordinateMetadata = (
+    path: string,
+    coordinateMetadata: SchematicMapCoordinateMetadata | undefined,
+    effectiveDate: string,
+  ) => {
+    if (coordinateMetadata?.coordinateClass !== 'constraint') {
+      return;
+    }
+
+    const constraintIds = constraintIdsByEffectiveDate.get(effectiveDate);
+    if (!constraintIds?.has(coordinateMetadata.constraintId)) {
+      errors.push(
+        `${path}.constraintId ${coordinateMetadata.constraintId} does not exist in schematic map constraints for ${effectiveDate}`,
+      );
+    }
+  };
+
   const availableLayoutEngineIds = new Set<string>();
   const referencedLayoutEngineIds: Array<{ id: string; path: string }> = [];
 
@@ -599,6 +628,13 @@ async function validateSchematicMapReferences(
       );
     }
 
+    constraintIdsByEffectiveDate.set(
+      constraintSet.value.effectiveDate,
+      new Set(
+        constraintSet.value.constraints.map((constraint) => constraint.id),
+      ),
+    );
+
     for (const [
       index,
       constraint,
@@ -615,6 +651,7 @@ async function validateSchematicMapReferences(
           constraint.fromStationId,
           constraint.lineId,
           constraintSet.value.effectiveDate,
+          { requireActive: false },
         );
         requireStationId(`${prefix}.toStationId`, constraint.toStationId);
         requireStationLineId(
@@ -622,6 +659,7 @@ async function validateSchematicMapReferences(
           constraint.toStationId,
           constraint.lineId,
           constraintSet.value.effectiveDate,
+          { requireActive: false },
         );
       } else if (constraint.type === 'line_order') {
         constraint.lineIds.forEach((lineId, lineIndex) => {
@@ -729,6 +767,12 @@ async function validateSchematicMapReferences(
   }
 
   for (const snapshot of schematicMap.versionSnapshots) {
+    requireKnownConstraintCoordinateMetadata(
+      `${snapshot.path}: frame.coordinateMetadata`,
+      snapshot.value.frame.coordinateMetadata,
+      snapshot.value.effectiveDate,
+    );
+
     snapshot.value.lineGroups.forEach((lineGroup, index) => {
       requireLineId(
         `${snapshot.path}: lineGroups.${index}.lineId`,
@@ -739,6 +783,11 @@ async function validateSchematicMapReferences(
     snapshot.value.segments.forEach((segment, index) => {
       const prefix = `${snapshot.path}: segments.${index}`;
       requireLineId(`${prefix}.lineId`, segment.lineId);
+      requireKnownConstraintCoordinateMetadata(
+        `${prefix}.geometry.coordinateMetadata`,
+        segment.geometry.coordinateMetadata,
+        snapshot.value.effectiveDate,
+      );
 
       if (segment.topology.type === 'station_pair') {
         requireStationId(
@@ -813,13 +862,31 @@ async function validateSchematicMapReferences(
           snapshot.value.effectiveDate,
           { requireActive: node.displayStatus === 'operational' },
         );
+        requireKnownConstraintCoordinateMetadata(
+          `${prefix}.parts.${partIndex}.coordinateMetadata`,
+          part.coordinateMetadata,
+          snapshot.value.effectiveDate,
+        );
       });
+      requireKnownConstraintCoordinateMetadata(
+        `${prefix}.coordinateMetadata`,
+        node.coordinateMetadata,
+        snapshot.value.effectiveDate,
+      );
     });
 
     snapshot.value.labels.forEach((label, index) => {
-      requireStationId(
-        `${snapshot.path}: labels.${index}.stationId`,
-        label.stationId,
+      const prefix = `${snapshot.path}: labels.${index}`;
+      requireStationId(`${prefix}.stationId`, label.stationId);
+      requireKnownConstraintCoordinateMetadata(
+        `${prefix}.leaderLine.coordinateMetadata`,
+        label.leaderLine?.coordinateMetadata,
+        snapshot.value.effectiveDate,
+      );
+      requireKnownConstraintCoordinateMetadata(
+        `${prefix}.coordinateMetadata`,
+        label.coordinateMetadata,
+        snapshot.value.effectiveDate,
       );
     });
 
@@ -833,6 +900,11 @@ async function validateSchematicMapReferences(
         label.lineId,
         snapshot.value.effectiveDate,
         { requireActive: label.displayStatus === 'operational' },
+      );
+      requireKnownConstraintCoordinateMetadata(
+        `${prefix}.coordinateMetadata`,
+        label.coordinateMetadata,
+        snapshot.value.effectiveDate,
       );
     });
   }

--- a/packages/fs/src/validate.ts
+++ b/packages/fs/src/validate.ts
@@ -23,6 +23,7 @@ import {
   readSchematicMapManifest,
   type SchematicMapRecord,
   schematicSystemMapConstraintSetPath,
+  schematicSystemMapRuleSetPath,
   schematicSystemMapVersionSnapshotPath,
 } from './schematicMaps.js';
 
@@ -431,7 +432,11 @@ async function validateSchematicMapReferences(
   }
 
   const lineIds = await loadEntityIds(dataDir, records, 'line');
-  const stationIds = await loadEntityIds(dataDir, records, 'station');
+  const stationRecords = await loadEntityRecords(dataDir, records, 'station');
+  const stationById = new Map(
+    stationRecords.map((station) => [station.value.id, station]),
+  );
+  const stationIds = new Set(stationById.keys());
   const schematicMap = await loadSchematicMapRecords(dataDir, records);
   const errors: string[] = [];
 
@@ -447,7 +452,34 @@ async function validateSchematicMapReferences(
     }
   };
 
+  const requireStationLineId = (
+    path: string,
+    stationId: string,
+    lineId: string,
+  ) => {
+    const station = stationById.get(stationId);
+    if (!station) {
+      return;
+    }
+
+    if (!station.value.stationCodes.some((code) => code.lineId === lineId)) {
+      errors.push(
+        `${path} ${lineId} is not a station code line for station ${stationId}`,
+      );
+    }
+  };
+
   for (const ruleSet of schematicMap.ruleSets) {
+    const expectedPath = schematicSystemMapRuleSetPath(
+      ruleSet.value.layoutEngineId,
+    );
+
+    if (ruleSet.path !== expectedPath) {
+      errors.push(
+        `${ruleSet.path}: layoutEngineId ${ruleSet.value.layoutEngineId} does not match ${expectedPath}`,
+      );
+    }
+
     ruleSet.value.lineOrder.forEach((lineId, index) => {
       requireLineId(`${ruleSet.path}: lineOrder.${index}`, lineId);
     });
@@ -514,15 +546,9 @@ async function validateSchematicMapReferences(
       version,
     ] of schematicMap.manifest.value.versions.entries()) {
       const prefix = `${schematicMap.manifest.path}: versions.${index}`;
-      const expectedDataPath = schematicSystemMapVersionSnapshotPath(
-        version.effectiveDate,
-      );
       const expectedMapRelativePath = `version/${version.effectiveDate}.json`;
 
-      if (
-        version.path !== expectedDataPath &&
-        version.path !== expectedMapRelativePath
-      ) {
+      if (version.path !== expectedMapRelativePath) {
         errors.push(
           `${prefix}.path ${version.path} does not match ${expectedMapRelativePath}`,
         );
@@ -572,9 +598,19 @@ async function validateSchematicMapReferences(
       requireStationId(`${prefix}.stationId`, node.stationId);
       node.lineIds.forEach((lineId, lineIndex) => {
         requireLineId(`${prefix}.lineIds.${lineIndex}`, lineId);
+        requireStationLineId(
+          `${prefix}.lineIds.${lineIndex}`,
+          node.stationId,
+          lineId,
+        );
       });
       node.parts.forEach((part, partIndex) => {
         requireLineId(`${prefix}.parts.${partIndex}.lineId`, part.lineId);
+        requireStationLineId(
+          `${prefix}.parts.${partIndex}.lineId`,
+          node.stationId,
+          part.lineId,
+        );
       });
     });
 
@@ -589,6 +625,7 @@ async function validateSchematicMapReferences(
       const prefix = `${snapshot.path}: stationCodeLabels.${index}`;
       requireStationId(`${prefix}.stationId`, label.stationId);
       requireLineId(`${prefix}.lineId`, label.lineId);
+      requireStationLineId(`${prefix}.lineId`, label.stationId, label.lineId);
     });
   }
 

--- a/packages/fs/src/validate.ts
+++ b/packages/fs/src/validate.ts
@@ -18,10 +18,11 @@ import { type EntityRecord, listEntities } from './entities.js';
 import { listIssueBundles } from './issues.js';
 import {
   listSchematicMapConstraintSets,
+  listSchematicMapRuleSets,
   listSchematicMapVersionSnapshots,
   readSchematicMapManifest,
-  readSchematicMapRuleSet,
   type SchematicMapRecord,
+  schematicSystemMapConstraintSetPath,
   schematicSystemMapVersionSnapshotPath,
 } from './schematicMaps.js';
 
@@ -70,7 +71,7 @@ type ValidationRecords = Partial<{
 
 type SchematicMapValidationRecords = {
   manifest: SchematicMapRecord<SchematicMapManifest> | null;
-  ruleSet: SchematicMapRecord<SchematicMapRuleSet> | null;
+  ruleSets: SchematicMapRecord<SchematicMapRuleSet>[];
   constraintSets: SchematicMapRecord<SchematicMapConstraintSet>[];
   versionSnapshots: SchematicMapRecord<SchematicMapVersionSnapshot>[];
 };
@@ -136,9 +137,7 @@ async function loadSchematicMapRecords(
     manifest: await readOptionalSchematicMapRecord(() =>
       readSchematicMapManifest(dataDir),
     ),
-    ruleSet: await readOptionalSchematicMapRecord(() =>
-      readSchematicMapRuleSet(dataDir),
-    ),
+    ruleSets: await listSchematicMapRuleSets(dataDir),
     constraintSets: await listSchematicMapConstraintSets(dataDir),
     versionSnapshots: await listSchematicMapVersionSnapshots(dataDir),
   };
@@ -448,16 +447,23 @@ async function validateSchematicMapReferences(
     }
   };
 
-  if (schematicMap.ruleSet) {
-    schematicMap.ruleSet.value.lineOrder.forEach((lineId, index) => {
-      requireLineId(
-        `${schematicMap.ruleSet?.path}: lineOrder.${index}`,
-        lineId,
-      );
+  for (const ruleSet of schematicMap.ruleSets) {
+    ruleSet.value.lineOrder.forEach((lineId, index) => {
+      requireLineId(`${ruleSet.path}: lineOrder.${index}`, lineId);
     });
   }
 
   for (const constraintSet of schematicMap.constraintSets) {
+    const expectedPath = schematicSystemMapConstraintSetPath(
+      constraintSet.value.effectiveDate,
+    );
+
+    if (constraintSet.path !== expectedPath) {
+      errors.push(
+        `${constraintSet.path}: effectiveDate ${constraintSet.value.effectiveDate} does not match ${expectedPath}`,
+      );
+    }
+
     for (const [
       index,
       constraint,
@@ -485,11 +491,22 @@ async function validateSchematicMapReferences(
     }
   }
 
-  const snapshotEffectiveDates = new Set(
-    schematicMap.versionSnapshots.map(
-      (snapshot) => snapshot.value.effectiveDate,
-    ),
-  );
+  const validSnapshotEffectiveDates = new Set<string>();
+
+  for (const snapshot of schematicMap.versionSnapshots) {
+    const expectedPath = schematicSystemMapVersionSnapshotPath(
+      snapshot.value.effectiveDate,
+    );
+
+    if (snapshot.path !== expectedPath) {
+      errors.push(
+        `${snapshot.path}: effectiveDate ${snapshot.value.effectiveDate} does not match ${expectedPath}`,
+      );
+      continue;
+    }
+
+    validSnapshotEffectiveDates.add(snapshot.value.effectiveDate);
+  }
 
   if (schematicMap.manifest) {
     for (const [
@@ -511,7 +528,7 @@ async function validateSchematicMapReferences(
         );
       }
 
-      if (!snapshotEffectiveDates.has(version.effectiveDate)) {
+      if (!validSnapshotEffectiveDates.has(version.effectiveDate)) {
         errors.push(
           `${prefix}.effectiveDate ${version.effectiveDate} does not have a generated snapshot`,
         );
@@ -602,7 +619,7 @@ export async function validateDataRoot(
         const schematicMap = await loadSchematicMapRecords(dataDir, records);
         checked['schematic-map'] =
           (schematicMap.manifest ? 1 : 0) +
-          (schematicMap.ruleSet ? 1 : 0) +
+          schematicMap.ruleSets.length +
           schematicMap.constraintSets.length +
           schematicMap.versionSnapshots.length;
         continue;

--- a/packages/fs/src/validate.ts
+++ b/packages/fs/src/validate.ts
@@ -314,6 +314,10 @@ function stationCodeContainsRevision(
   return stationCodeStart <= revisionStart && revisionEnd <= stationCodeEnd;
 }
 
+function stationPairKey(fromStationId: string, toStationId: string): string {
+  return [fromStationId, toStationId].sort().join(':');
+}
+
 async function validateIssueReferences(
   dataDir: string,
   shouldValidate: boolean,
@@ -437,8 +441,27 @@ async function validateSchematicMapReferences(
     stationRecords.map((station) => [station.value.id, station]),
   );
   const stationIds = new Set(stationById.keys());
+  const serviceRecords = await loadEntityRecords(dataDir, records, 'service');
+  const serviceEdgesByLineId = new Map<string, Set<string>>();
   const schematicMap = await loadSchematicMapRecords(dataDir, records);
   const errors: string[] = [];
+
+  for (const service of serviceRecords) {
+    let serviceEdges = serviceEdgesByLineId.get(service.value.lineId);
+    if (!serviceEdges) {
+      serviceEdges = new Set();
+      serviceEdgesByLineId.set(service.value.lineId, serviceEdges);
+    }
+
+    for (const revision of service.value.revisions) {
+      const stations = revision.path.stations.map(
+        (station) => station.stationId,
+      );
+      for (let index = 0; index < stations.length - 1; index += 1) {
+        serviceEdges.add(stationPairKey(stations[index], stations[index + 1]));
+      }
+    }
+  }
 
   const requireLineId = (path: string, lineId: string) => {
     if (!lineIds.has(lineId)) {
@@ -518,6 +541,11 @@ async function validateSchematicMapReferences(
         requireStationId(`${prefix}.stationId`, constraint.stationId);
         constraint.lineIds.forEach((lineId, lineIndex) => {
           requireLineId(`${prefix}.lineIds.${lineIndex}`, lineId);
+          requireStationLineId(
+            `${prefix}.lineIds.${lineIndex}`,
+            constraint.stationId,
+            lineId,
+          );
         });
       }
     }
@@ -579,10 +607,32 @@ async function validateSchematicMapReferences(
           `${prefix}.topology.fromStationId`,
           segment.topology.fromStationId,
         );
+        requireStationLineId(
+          `${prefix}.topology.fromStationId`,
+          segment.topology.fromStationId,
+          segment.lineId,
+        );
         requireStationId(
           `${prefix}.topology.toStationId`,
           segment.topology.toStationId,
         );
+        requireStationLineId(
+          `${prefix}.topology.toStationId`,
+          segment.topology.toStationId,
+          segment.lineId,
+        );
+
+        const serviceEdges = serviceEdgesByLineId.get(segment.lineId);
+        const segmentPairKey = stationPairKey(
+          segment.topology.fromStationId,
+          segment.topology.toStationId,
+        );
+
+        if (!serviceEdges?.has(segmentPairKey)) {
+          errors.push(
+            `${prefix}.topology ${segment.topology.fromStationId}:${segment.topology.toStationId} is not an adjacent service edge for line ${segment.lineId}`,
+          );
+        }
       } else if (segment.topology.stationIds) {
         segment.topology.stationIds.forEach((stationId, stationIndex) => {
           requireStationId(

--- a/packages/fs/src/validate.ts
+++ b/packages/fs/src/validate.ts
@@ -676,6 +676,7 @@ async function validateSchematicMapReferences(
             constraint.stationId,
             lineId,
             constraintSet.value.effectiveDate,
+            { requireActive: false },
           );
         });
       }

--- a/packages/fs/src/validate.ts
+++ b/packages/fs/src/validate.ts
@@ -645,6 +645,7 @@ async function validateSchematicMapReferences(
   }
 
   const validSnapshotEffectiveDates = new Set<string>();
+  const snapshotLayoutEngineIds = new Map<string, string>();
 
   for (const snapshot of schematicMap.versionSnapshots) {
     referencedLayoutEngineIds.push({
@@ -664,6 +665,10 @@ async function validateSchematicMapReferences(
     }
 
     validSnapshotEffectiveDates.add(snapshot.value.effectiveDate);
+    snapshotLayoutEngineIds.set(
+      snapshot.value.effectiveDate,
+      snapshot.value.layoutEngineId,
+    );
   }
 
   const manifestEffectiveDates = new Set<string>();
@@ -690,6 +695,18 @@ async function validateSchematicMapReferences(
       if (!validSnapshotEffectiveDates.has(version.effectiveDate)) {
         errors.push(
           `${prefix}.effectiveDate ${version.effectiveDate} does not have a generated snapshot`,
+        );
+      }
+
+      const snapshotLayoutEngineId = snapshotLayoutEngineIds.get(
+        version.effectiveDate,
+      );
+      if (
+        snapshotLayoutEngineId &&
+        snapshotLayoutEngineId !== version.layoutEngineId
+      ) {
+        errors.push(
+          `${prefix}.layoutEngineId ${version.layoutEngineId} does not match version/${version.effectiveDate}.json (${snapshotLayoutEngineId})`,
         );
       }
     }

--- a/packages/fs/src/validate.ts
+++ b/packages/fs/src/validate.ts
@@ -1,4 +1,10 @@
-import type { IssueBundle } from '@mrtdown/core';
+import type {
+  IssueBundle,
+  SchematicMapConstraintSet,
+  SchematicMapManifest,
+  SchematicMapRuleSet,
+  SchematicMapVersionSnapshot,
+} from '@mrtdown/core';
 import type { z } from 'zod';
 import {
   type EntityCollection,
@@ -6,11 +12,20 @@ import {
   evidenceFileName,
   impactFileName,
   issueDirectory,
+  schematicMapDirectory,
 } from './constants.js';
 import { type EntityRecord, listEntities } from './entities.js';
 import { listIssueBundles } from './issues.js';
+import {
+  listSchematicMapConstraintSets,
+  listSchematicMapVersionSnapshots,
+  readSchematicMapManifest,
+  readSchematicMapRuleSet,
+  type SchematicMapRecord,
+  schematicSystemMapVersionSnapshotPath,
+} from './schematicMaps.js';
 
-export type ValidationScope = EntityCollection | 'issue';
+export type ValidationScope = EntityCollection | 'issue' | 'schematic-map';
 
 export type ValidationResult = {
   ok: boolean;
@@ -20,7 +35,9 @@ export type ValidationResult = {
 
 function emptyChecked(): Record<ValidationScope, number> {
   return Object.fromEntries(
-    [...entityCollections, issueDirectory].map((scope) => [scope, 0]),
+    [...entityCollections, issueDirectory, schematicMapDirectory].map(
+      (scope) => [scope, 0],
+    ),
   ) as Record<ValidationScope, number>;
 }
 
@@ -48,7 +65,15 @@ type ValidationRecords = Partial<{
   station: EntityRecord<'station'>[];
   town: EntityRecord<'town'>[];
   issue: IssueBundle[];
+  schematicMap: SchematicMapValidationRecords;
 }>;
+
+type SchematicMapValidationRecords = {
+  manifest: SchematicMapRecord<SchematicMapManifest> | null;
+  ruleSet: SchematicMapRecord<SchematicMapRuleSet> | null;
+  constraintSets: SchematicMapRecord<SchematicMapConstraintSet>[];
+  versionSnapshots: SchematicMapRecord<SchematicMapVersionSnapshot>[];
+};
 
 const generatedEvidenceIdPattern = /^ev_[0-9A-HJKMNP-TV-Z]{26}$/;
 
@@ -84,6 +109,40 @@ async function loadIssueRecords(
     records.issue = await listIssueBundles(dataDir);
   }
   return records.issue;
+}
+
+async function readOptionalSchematicMapRecord<T>(
+  read: () => Promise<SchematicMapRecord<T>>,
+): Promise<SchematicMapRecord<T> | null> {
+  try {
+    return await read();
+  } catch (error) {
+    if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
+      return null;
+    }
+    throw error;
+  }
+}
+
+async function loadSchematicMapRecords(
+  dataDir: string,
+  records: ValidationRecords,
+): Promise<SchematicMapValidationRecords> {
+  if (records.schematicMap) {
+    return records.schematicMap;
+  }
+
+  records.schematicMap = {
+    manifest: await readOptionalSchematicMapRecord(() =>
+      readSchematicMapManifest(dataDir),
+    ),
+    ruleSet: await readOptionalSchematicMapRecord(() =>
+      readSchematicMapRuleSet(dataDir),
+    ),
+    constraintSets: await listSchematicMapConstraintSets(dataDir),
+    versionSnapshots: await listSchematicMapVersionSnapshots(dataDir),
+  };
+  return records.schematicMap;
 }
 
 async function validateStationReferences(
@@ -363,9 +422,169 @@ async function validateIssueReferences(
   return errors;
 }
 
+async function validateSchematicMapReferences(
+  dataDir: string,
+  shouldValidate: boolean,
+  records: ValidationRecords,
+): Promise<string[]> {
+  if (!shouldValidate) {
+    return [];
+  }
+
+  const lineIds = await loadEntityIds(dataDir, records, 'line');
+  const stationIds = await loadEntityIds(dataDir, records, 'station');
+  const schematicMap = await loadSchematicMapRecords(dataDir, records);
+  const errors: string[] = [];
+
+  const requireLineId = (path: string, lineId: string) => {
+    if (!lineIds.has(lineId)) {
+      errors.push(`${path} ${lineId} does not exist in line/`);
+    }
+  };
+
+  const requireStationId = (path: string, stationId: string) => {
+    if (!stationIds.has(stationId)) {
+      errors.push(`${path} ${stationId} does not exist in station/`);
+    }
+  };
+
+  if (schematicMap.ruleSet) {
+    schematicMap.ruleSet.value.lineOrder.forEach((lineId, index) => {
+      requireLineId(
+        `${schematicMap.ruleSet?.path}: lineOrder.${index}`,
+        lineId,
+      );
+    });
+  }
+
+  for (const constraintSet of schematicMap.constraintSets) {
+    for (const [
+      index,
+      constraint,
+    ] of constraintSet.value.constraints.entries()) {
+      const prefix = `${constraintSet.path}: constraints.${index}`;
+
+      if (constraint.type === 'station_anchor') {
+        requireStationId(`${prefix}.stationId`, constraint.stationId);
+      } else if (constraint.type === 'segment_route_hint') {
+        requireLineId(`${prefix}.lineId`, constraint.lineId);
+        requireStationId(`${prefix}.fromStationId`, constraint.fromStationId);
+        requireStationId(`${prefix}.toStationId`, constraint.toStationId);
+      } else if (constraint.type === 'line_order') {
+        constraint.lineIds.forEach((lineId, lineIndex) => {
+          requireLineId(`${prefix}.lineIds.${lineIndex}`, lineId);
+        });
+      } else if (constraint.type === 'label_hint') {
+        requireStationId(`${prefix}.stationId`, constraint.stationId);
+      } else if (constraint.type === 'interchange_hint') {
+        requireStationId(`${prefix}.stationId`, constraint.stationId);
+        constraint.lineIds.forEach((lineId, lineIndex) => {
+          requireLineId(`${prefix}.lineIds.${lineIndex}`, lineId);
+        });
+      }
+    }
+  }
+
+  const snapshotEffectiveDates = new Set(
+    schematicMap.versionSnapshots.map(
+      (snapshot) => snapshot.value.effectiveDate,
+    ),
+  );
+
+  if (schematicMap.manifest) {
+    for (const [
+      index,
+      version,
+    ] of schematicMap.manifest.value.versions.entries()) {
+      const prefix = `${schematicMap.manifest.path}: versions.${index}`;
+      const expectedDataPath = schematicSystemMapVersionSnapshotPath(
+        version.effectiveDate,
+      );
+      const expectedMapRelativePath = `version/${version.effectiveDate}.json`;
+
+      if (
+        version.path !== expectedDataPath &&
+        version.path !== expectedMapRelativePath
+      ) {
+        errors.push(
+          `${prefix}.path ${version.path} does not match ${expectedMapRelativePath}`,
+        );
+      }
+
+      if (!snapshotEffectiveDates.has(version.effectiveDate)) {
+        errors.push(
+          `${prefix}.effectiveDate ${version.effectiveDate} does not have a generated snapshot`,
+        );
+      }
+    }
+  }
+
+  for (const snapshot of schematicMap.versionSnapshots) {
+    snapshot.value.lineGroups.forEach((lineGroup, index) => {
+      requireLineId(
+        `${snapshot.path}: lineGroups.${index}.lineId`,
+        lineGroup.lineId,
+      );
+    });
+
+    snapshot.value.segments.forEach((segment, index) => {
+      const prefix = `${snapshot.path}: segments.${index}`;
+      requireLineId(`${prefix}.lineId`, segment.lineId);
+
+      if (segment.topology.type === 'station_pair') {
+        requireStationId(
+          `${prefix}.topology.fromStationId`,
+          segment.topology.fromStationId,
+        );
+        requireStationId(
+          `${prefix}.topology.toStationId`,
+          segment.topology.toStationId,
+        );
+      } else if (segment.topology.stationIds) {
+        segment.topology.stationIds.forEach((stationId, stationIndex) => {
+          requireStationId(
+            `${prefix}.topology.stationIds.${stationIndex}`,
+            stationId,
+          );
+        });
+      }
+    });
+
+    snapshot.value.stationNodes.forEach((node, index) => {
+      const prefix = `${snapshot.path}: stationNodes.${index}`;
+      requireStationId(`${prefix}.stationId`, node.stationId);
+      node.lineIds.forEach((lineId, lineIndex) => {
+        requireLineId(`${prefix}.lineIds.${lineIndex}`, lineId);
+      });
+      node.parts.forEach((part, partIndex) => {
+        requireLineId(`${prefix}.parts.${partIndex}.lineId`, part.lineId);
+      });
+    });
+
+    snapshot.value.labels.forEach((label, index) => {
+      requireStationId(
+        `${snapshot.path}: labels.${index}.stationId`,
+        label.stationId,
+      );
+    });
+
+    snapshot.value.stationCodeLabels.forEach((label, index) => {
+      const prefix = `${snapshot.path}: stationCodeLabels.${index}`;
+      requireStationId(`${prefix}.stationId`, label.stationId);
+      requireLineId(`${prefix}.lineId`, label.lineId);
+    });
+  }
+
+  return errors;
+}
+
 export async function validateDataRoot(
   dataDir: string,
-  scopes: readonly ValidationScope[] = [...entityCollections, issueDirectory],
+  scopes: readonly ValidationScope[] = [
+    ...entityCollections,
+    issueDirectory,
+    schematicMapDirectory,
+  ],
 ): Promise<ValidationResult> {
   const checked = emptyChecked();
   const errors: string[] = [];
@@ -376,6 +595,16 @@ export async function validateDataRoot(
       if (scope === 'issue') {
         const bundles = await loadIssueRecords(dataDir, records);
         checked.issue = bundles.length;
+        continue;
+      }
+
+      if (scope === 'schematic-map') {
+        const schematicMap = await loadSchematicMapRecords(dataDir, records);
+        checked['schematic-map'] =
+          (schematicMap.manifest ? 1 : 0) +
+          (schematicMap.ruleSet ? 1 : 0) +
+          schematicMap.constraintSets.length +
+          schematicMap.versionSnapshots.length;
         continue;
       }
 
@@ -412,6 +641,13 @@ export async function validateDataRoot(
       ...(await validateIssueReferences(
         dataDir,
         shouldValidateScope(scopes, 'issue'),
+        records,
+      )),
+    );
+    errors.push(
+      ...(await validateSchematicMapReferences(
+        dataDir,
+        shouldValidateScope(scopes, 'schematic-map'),
         records,
       )),
     );

--- a/packages/fs/src/validate.ts
+++ b/packages/fs/src/validate.ts
@@ -318,6 +318,28 @@ function stationPairKey(fromStationId: string, toStationId: string): string {
   return [fromStationId, toStationId].sort().join(':');
 }
 
+function effectiveDateTimestampForValidation(effectiveDate: string): number {
+  return timestampForValidation(`${effectiveDate}-01T00:00:00Z`);
+}
+
+function intervalContainsEffectiveDate(
+  startedAt: string,
+  endedAt: string | null,
+  effectiveDate: string,
+): boolean {
+  const effectiveDateTimestamp =
+    effectiveDateTimestampForValidation(effectiveDate);
+  const startedAtTimestamp = timestampForValidation(startedAt);
+  const endedAtTimestamp = endedAt
+    ? timestampForValidation(endedAt)
+    : Number.POSITIVE_INFINITY;
+
+  return (
+    startedAtTimestamp <= effectiveDateTimestamp &&
+    effectiveDateTimestamp < endedAtTimestamp
+  );
+}
+
 async function validateIssueReferences(
   dataDir: string,
   shouldValidate: boolean,
@@ -442,26 +464,52 @@ async function validateSchematicMapReferences(
   );
   const stationIds = new Set(stationById.keys());
   const serviceRecords = await loadEntityRecords(dataDir, records, 'service');
-  const serviceEdgesByLineId = new Map<string, Set<string>>();
+  const serviceEdgesByLineAndEffectiveDate = new Map<string, Set<string>>();
   const schematicMap = await loadSchematicMapRecords(dataDir, records);
   const errors: string[] = [];
 
-  for (const service of serviceRecords) {
-    let serviceEdges = serviceEdgesByLineId.get(service.value.lineId);
-    if (!serviceEdges) {
-      serviceEdges = new Set();
-      serviceEdgesByLineId.set(service.value.lineId, serviceEdges);
+  const serviceEdgesForLineAtEffectiveDate = (
+    lineId: string,
+    effectiveDate: string,
+  ): Set<string> => {
+    const cacheKey = `${lineId}:${effectiveDate}`;
+    const cached = serviceEdgesByLineAndEffectiveDate.get(cacheKey);
+    if (cached) {
+      return cached;
     }
 
-    for (const revision of service.value.revisions) {
-      const stations = revision.path.stations.map(
-        (station) => station.stationId,
-      );
-      for (let index = 0; index < stations.length - 1; index += 1) {
-        serviceEdges.add(stationPairKey(stations[index], stations[index + 1]));
+    const serviceEdges = new Set<string>();
+
+    for (const service of serviceRecords) {
+      if (service.value.lineId !== lineId) {
+        continue;
+      }
+
+      for (const revision of service.value.revisions) {
+        if (
+          !intervalContainsEffectiveDate(
+            revision.startAt,
+            revision.endAt,
+            effectiveDate,
+          )
+        ) {
+          continue;
+        }
+
+        const stations = revision.path.stations.map(
+          (station) => station.stationId,
+        );
+        for (let index = 0; index < stations.length - 1; index += 1) {
+          serviceEdges.add(
+            stationPairKey(stations[index], stations[index + 1]),
+          );
+        }
       }
     }
-  }
+
+    serviceEdgesByLineAndEffectiveDate.set(cacheKey, serviceEdges);
+    return serviceEdges;
+  };
 
   const requireLineId = (path: string, lineId: string) => {
     if (!lineIds.has(lineId)) {
@@ -479,25 +527,41 @@ async function validateSchematicMapReferences(
     path: string,
     stationId: string,
     lineId: string,
+    effectiveDate: string,
   ) => {
     const station = stationById.get(stationId);
     if (!station) {
       return;
     }
 
-    if (!station.value.stationCodes.some((code) => code.lineId === lineId)) {
+    if (
+      !station.value.stationCodes.some(
+        (code) =>
+          code.lineId === lineId &&
+          intervalContainsEffectiveDate(
+            code.startedAt,
+            code.endedAt,
+            effectiveDate,
+          ),
+      )
+    ) {
       errors.push(
-        `${path} ${lineId} is not a station code line for station ${stationId}`,
+        `${path} ${lineId} is not an active station code line for station ${stationId} at ${effectiveDate}`,
       );
     }
   };
+
+  const availableLayoutEngineIds = new Set<string>();
+  const referencedLayoutEngineIds: Array<{ id: string; path: string }> = [];
 
   for (const ruleSet of schematicMap.ruleSets) {
     const expectedPath = schematicSystemMapRuleSetPath(
       ruleSet.value.layoutEngineId,
     );
 
-    if (ruleSet.path !== expectedPath) {
+    if (ruleSet.path === expectedPath) {
+      availableLayoutEngineIds.add(ruleSet.value.layoutEngineId);
+    } else {
       errors.push(
         `${ruleSet.path}: layoutEngineId ${ruleSet.value.layoutEngineId} does not match ${expectedPath}`,
       );
@@ -509,6 +573,11 @@ async function validateSchematicMapReferences(
   }
 
   for (const constraintSet of schematicMap.constraintSets) {
+    referencedLayoutEngineIds.push({
+      id: constraintSet.value.layoutEngineId,
+      path: `${constraintSet.path}: layoutEngineId`,
+    });
+
     const expectedPath = schematicSystemMapConstraintSetPath(
       constraintSet.value.effectiveDate,
     );
@@ -530,7 +599,19 @@ async function validateSchematicMapReferences(
       } else if (constraint.type === 'segment_route_hint') {
         requireLineId(`${prefix}.lineId`, constraint.lineId);
         requireStationId(`${prefix}.fromStationId`, constraint.fromStationId);
+        requireStationLineId(
+          `${prefix}.fromStationId`,
+          constraint.fromStationId,
+          constraint.lineId,
+          constraintSet.value.effectiveDate,
+        );
         requireStationId(`${prefix}.toStationId`, constraint.toStationId);
+        requireStationLineId(
+          `${prefix}.toStationId`,
+          constraint.toStationId,
+          constraint.lineId,
+          constraintSet.value.effectiveDate,
+        );
       } else if (constraint.type === 'line_order') {
         constraint.lineIds.forEach((lineId, lineIndex) => {
           requireLineId(`${prefix}.lineIds.${lineIndex}`, lineId);
@@ -545,6 +626,7 @@ async function validateSchematicMapReferences(
             `${prefix}.lineIds.${lineIndex}`,
             constraint.stationId,
             lineId,
+            constraintSet.value.effectiveDate,
           );
         });
       }
@@ -554,6 +636,11 @@ async function validateSchematicMapReferences(
   const validSnapshotEffectiveDates = new Set<string>();
 
   for (const snapshot of schematicMap.versionSnapshots) {
+    referencedLayoutEngineIds.push({
+      id: snapshot.value.layoutEngineId,
+      path: `${snapshot.path}: layoutEngineId`,
+    });
+
     const expectedPath = schematicSystemMapVersionSnapshotPath(
       snapshot.value.effectiveDate,
     );
@@ -575,6 +662,10 @@ async function validateSchematicMapReferences(
     ] of schematicMap.manifest.value.versions.entries()) {
       const prefix = `${schematicMap.manifest.path}: versions.${index}`;
       const expectedMapRelativePath = `version/${version.effectiveDate}.json`;
+      referencedLayoutEngineIds.push({
+        id: version.layoutEngineId,
+        path: `${prefix}.layoutEngineId`,
+      });
 
       if (version.path !== expectedMapRelativePath) {
         errors.push(
@@ -587,6 +678,14 @@ async function validateSchematicMapReferences(
           `${prefix}.effectiveDate ${version.effectiveDate} does not have a generated snapshot`,
         );
       }
+    }
+  }
+
+  for (const reference of referencedLayoutEngineIds) {
+    if (!availableLayoutEngineIds.has(reference.id)) {
+      errors.push(
+        `${reference.path} ${reference.id} does not have a schematic map rule set`,
+      );
     }
   }
 
@@ -611,6 +710,7 @@ async function validateSchematicMapReferences(
           `${prefix}.topology.fromStationId`,
           segment.topology.fromStationId,
           segment.lineId,
+          snapshot.value.effectiveDate,
         );
         requireStationId(
           `${prefix}.topology.toStationId`,
@@ -620,9 +720,13 @@ async function validateSchematicMapReferences(
           `${prefix}.topology.toStationId`,
           segment.topology.toStationId,
           segment.lineId,
+          snapshot.value.effectiveDate,
         );
 
-        const serviceEdges = serviceEdgesByLineId.get(segment.lineId);
+        const serviceEdges = serviceEdgesForLineAtEffectiveDate(
+          segment.lineId,
+          snapshot.value.effectiveDate,
+        );
         const segmentPairKey = stationPairKey(
           segment.topology.fromStationId,
           segment.topology.toStationId,
@@ -652,6 +756,7 @@ async function validateSchematicMapReferences(
           `${prefix}.lineIds.${lineIndex}`,
           node.stationId,
           lineId,
+          snapshot.value.effectiveDate,
         );
       });
       node.parts.forEach((part, partIndex) => {
@@ -660,6 +765,7 @@ async function validateSchematicMapReferences(
           `${prefix}.parts.${partIndex}.lineId`,
           node.stationId,
           part.lineId,
+          snapshot.value.effectiveDate,
         );
       });
     });
@@ -675,7 +781,12 @@ async function validateSchematicMapReferences(
       const prefix = `${snapshot.path}: stationCodeLabels.${index}`;
       requireStationId(`${prefix}.stationId`, label.stationId);
       requireLineId(`${prefix}.lineId`, label.lineId);
-      requireStationLineId(`${prefix}.lineId`, label.stationId, label.lineId);
+      requireStationLineId(
+        `${prefix}.lineId`,
+        label.stationId,
+        label.lineId,
+        snapshot.value.effectiveDate,
+      );
     });
   }
 

--- a/packages/fs/src/validate.ts
+++ b/packages/fs/src/validate.ts
@@ -528,21 +528,32 @@ async function validateSchematicMapReferences(
     stationId: string,
     lineId: string,
     effectiveDate: string,
+    options: { requireActive: boolean } = { requireActive: true },
   ) => {
     const station = stationById.get(stationId);
     if (!station) {
       return;
     }
 
+    const matchingCodes = station.value.stationCodes.filter(
+      (code) => code.lineId === lineId,
+    );
+
+    if (matchingCodes.length === 0) {
+      errors.push(
+        `${path} ${lineId} is not a station code line for station ${stationId}`,
+      );
+      return;
+    }
+
     if (
-      !station.value.stationCodes.some(
-        (code) =>
-          code.lineId === lineId &&
-          intervalContainsEffectiveDate(
-            code.startedAt,
-            code.endedAt,
-            effectiveDate,
-          ),
+      options.requireActive &&
+      !matchingCodes.some((code) =>
+        intervalContainsEffectiveDate(
+          code.startedAt,
+          code.endedAt,
+          effectiveDate,
+        ),
       )
     ) {
       errors.push(
@@ -655,6 +666,8 @@ async function validateSchematicMapReferences(
     validSnapshotEffectiveDates.add(snapshot.value.effectiveDate);
   }
 
+  const manifestEffectiveDates = new Set<string>();
+
   if (schematicMap.manifest) {
     for (const [
       index,
@@ -662,6 +675,7 @@ async function validateSchematicMapReferences(
     ] of schematicMap.manifest.value.versions.entries()) {
       const prefix = `${schematicMap.manifest.path}: versions.${index}`;
       const expectedMapRelativePath = `version/${version.effectiveDate}.json`;
+      manifestEffectiveDates.add(version.effectiveDate);
       referencedLayoutEngineIds.push({
         id: version.layoutEngineId,
         path: `${prefix}.layoutEngineId`,
@@ -678,6 +692,14 @@ async function validateSchematicMapReferences(
           `${prefix}.effectiveDate ${version.effectiveDate} does not have a generated snapshot`,
         );
       }
+    }
+  }
+
+  for (const snapshot of schematicMap.versionSnapshots) {
+    if (!manifestEffectiveDates.has(snapshot.value.effectiveDate)) {
+      errors.push(
+        `${snapshot.path}: effectiveDate ${snapshot.value.effectiveDate} is not listed in schematic map manifest`,
+      );
     }
   }
 
@@ -711,6 +733,7 @@ async function validateSchematicMapReferences(
           segment.topology.fromStationId,
           segment.lineId,
           snapshot.value.effectiveDate,
+          { requireActive: segment.displayStatus === 'operational' },
         );
         requireStationId(
           `${prefix}.topology.toStationId`,
@@ -721,6 +744,7 @@ async function validateSchematicMapReferences(
           segment.topology.toStationId,
           segment.lineId,
           snapshot.value.effectiveDate,
+          { requireActive: segment.displayStatus === 'operational' },
         );
 
         const serviceEdges = serviceEdgesForLineAtEffectiveDate(
@@ -732,7 +756,10 @@ async function validateSchematicMapReferences(
           segment.topology.toStationId,
         );
 
-        if (!serviceEdges?.has(segmentPairKey)) {
+        if (
+          segment.displayStatus === 'operational' &&
+          !serviceEdges?.has(segmentPairKey)
+        ) {
           errors.push(
             `${prefix}.topology ${segment.topology.fromStationId}:${segment.topology.toStationId} is not an adjacent service edge for line ${segment.lineId}`,
           );
@@ -757,6 +784,7 @@ async function validateSchematicMapReferences(
           node.stationId,
           lineId,
           snapshot.value.effectiveDate,
+          { requireActive: node.displayStatus === 'operational' },
         );
       });
       node.parts.forEach((part, partIndex) => {
@@ -766,6 +794,7 @@ async function validateSchematicMapReferences(
           node.stationId,
           part.lineId,
           snapshot.value.effectiveDate,
+          { requireActive: node.displayStatus === 'operational' },
         );
       });
     });
@@ -786,6 +815,7 @@ async function validateSchematicMapReferences(
         label.stationId,
         label.lineId,
         snapshot.value.effectiveDate,
+        { requireActive: label.displayStatus === 'operational' },
       );
     });
   }


### PR DESCRIPTION
## Summary

- Adds `schematic-map` as a first-class validation scope in `@mrtdown/fs`.
- Validates schematic map manifests, rule sets, constraints, and generated snapshots against canonical station and line ids.
- Adds CLI inspection commands for schematic map constraints, versions, manifests, and rules.
- Records the Phase 4 CLI and validation progress in the active schematic system map plan.

## Validation

- `npm run test:fs`
- `npm run test:cli`
- `npm run check`
- `npm run data:validate`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a schematic-map command with list/show subcommands to view versions, constraints, manifests, and rules.
  * Validation now includes a schematic-map scope with comprehensive reference integrity checks across schematic map data.

* **Documentation**
  * Roadmap updated to mark the start of Phase 4 and schematic-map CLI integration/inspection coverage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/foldaway/mrtdown-data/pull/273?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->