### PR TITLE
feat: add schematic map generator preview foundation

### DIFF
--- a/data/schematic-map/system/generator/constraint/2025-04.json
+++ b/data/schematic-map/system/generator/constraint/2025-04.json
@@ -1,0 +1,19 @@
+{
+  "schemaVersion": 1,
+  "mapId": "system",
+  "effectiveDate": "2025-04",
+  "layoutEngineId": "lta-system-map-2011",
+  "constraints": [
+    {
+      "id": "frame_2025_04",
+      "type": "map_frame",
+      "frame": {
+        "x": 0,
+        "y": 0,
+        "width": 3140,
+        "height": 2400
+      },
+      "reason": "Matches the established current mrtdown-site map frame for the 2025-04 baseline."
+    }
+  ]
+}

--- a/data/schematic-map/system/generator/engine/lta-system-map-2011.json
+++ b/data/schematic-map/system/generator/engine/lta-system-map-2011.json
@@ -1,0 +1,18 @@
+{
+  "schemaVersion": 1,
+  "mapId": "system",
+  "layoutEngineId": "lta-system-map-2011",
+  "lineOrder": [
+    "NSL",
+    "EWL",
+    "NEL",
+    "CCL",
+    "DTL",
+    "TEL",
+    "BPLRT",
+    "SKLRT",
+    "PGLRT",
+    "JRL",
+    "CRL"
+  ]
+}

--- a/docs/plans/active/schematic-system-map.md
+++ b/docs/plans/active/schematic-system-map.md
@@ -404,6 +404,15 @@ Exit criteria:
 - 2026-05-27: Extended Phase 4 CLI inspection with manifest version selection
   for a target date plus generated snapshot coordinate-class and constraint-type
   counts for schematic map review.
+- 2026-05-27: Began Phase 3 generator foundation with deterministic topology
+  snapshot generation from active service revisions, initial source-controlled
+  `lta-system-map-2011` rule configuration, a `2025-04` map-frame constraint,
+  and `schematic-map generate` CLI support for writing generated snapshots and
+  updating the schematic map manifest.
+- 2026-05-27: Added a lightweight `schematic-map preview` SVG renderer so
+  generated snapshots can be inspected locally before `mrtdown-site` has a
+  full data-driven renderer. This is review tooling, not the canonical public
+  renderer.
 
 ## Decision Log
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4460,13 +4460,15 @@
       "license": "UNLICENSED",
       "dependencies": {
         "@mrtdown/core": "2.0.0-alpha.23",
-        "@mrtdown/fs": "2.0.0-alpha.23"
+        "@mrtdown/fs": "2.0.0-alpha.23",
+        "hast-util-to-html": "^9.0.5"
       },
       "bin": {
         "mrtdown": "dist/index.js"
       },
       "devDependencies": {
         "@biomejs/biome": "2.3.14",
+        "@types/hast": "^3.0.4",
         "@types/node": "^22.13.4",
         "typescript": "^5.8.3",
         "vitest": "^3.0.9"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -35,10 +35,12 @@
   },
   "dependencies": {
     "@mrtdown/core": "2.0.0-alpha.24",
-    "@mrtdown/fs": "2.0.0-alpha.24"
+    "@mrtdown/fs": "2.0.0-alpha.24",
+    "hast-util-to-html": "^9.0.5"
   },
   "devDependencies": {
     "@biomejs/biome": "2.3.14",
+    "@types/hast": "^3.0.4",
     "@types/node": "^22.13.4",
     "typescript": "^5.8.3",
     "vitest": "^3.0.9"

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -441,4 +441,79 @@ describe('@mrtdown/cli', () => {
       },
     });
   });
+
+  it('generates and writes schematic map snapshots through the CLI', async () => {
+    const dataDir = await mkdtemp(join(tmpdir(), 'mrtdown-cli-'));
+    await cp(fixtureDataDir, dataDir, { recursive: true });
+    await writeSchematicMapRuleSet(dataDir, {
+      schemaVersion: 1,
+      mapId: 'system',
+      layoutEngineId: 'lta-system-map-2011',
+      lineOrder: ['ISL', 'TKL', 'TWL'],
+    });
+    await writeSchematicMapConstraintSet(dataDir, {
+      schemaVersion: 1,
+      mapId: 'system',
+      effectiveDate: '2026-05',
+      layoutEngineId: 'lta-system-map-2011',
+      constraints: [
+        {
+          id: 'frame_2026_05',
+          type: 'map_frame',
+          frame: { x: 0, y: 0, width: 1200, height: 600 },
+        },
+      ],
+    });
+    const { io, stdout } = createIo();
+
+    await expect(
+      runCli(
+        [
+          '--data-dir',
+          dataDir,
+          'schematic-map',
+          'generate',
+          '2026-05',
+          '--generated-at',
+          '2026-05-27T00:00:00.000Z',
+          '--write',
+        ],
+        io,
+      ),
+    ).resolves.toBe(0);
+    expect(JSON.parse(stdout[0] as string)).toEqual({
+      snapshot: 'schematic-map/system/version/2026-05.json',
+      manifest: 'schematic-map/system/manifest.json',
+    });
+
+    const validate = createIo();
+    await expect(
+      runCli(
+        ['--data-dir', dataDir, 'validate', '--scope', 'schematic-map'],
+        validate.io,
+      ),
+    ).resolves.toBe(0);
+    expect(JSON.parse(validate.stdout[0] as string)['schematic-map']).toBe(4);
+
+    const previewPath = join(dataDir, 'preview.svg');
+    const preview = createIo();
+    await expect(
+      runCli(
+        [
+          '--data-dir',
+          dataDir,
+          'schematic-map',
+          'preview',
+          '2026-05',
+          '--out',
+          previewPath,
+        ],
+        preview.io,
+      ),
+    ).resolves.toBe(0);
+    expect(preview.stdout).toEqual([previewPath]);
+    await expect(readFile(previewPath, 'utf8')).resolves.toContain(
+      'Kennedy Town',
+    );
+  });
 });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -8,6 +8,7 @@ import {
   type SchematicMapCoordinateMetadata,
   SchematicMapEffectiveDateSchema,
   SchematicMapLayoutEngineIdSchema,
+  type SchematicMapManifest,
   type SchematicMapManifestVersion,
   type SchematicMapVersionSnapshot,
 } from '@mrtdown/core';
@@ -17,6 +18,7 @@ import {
   createIssueBundle,
   type EntityCollection,
   entityCollections,
+  generateSchematicMapVersionSnapshot,
   listEntityIds,
   listIssueIds,
   listSchematicMapConstraintSetEffectiveDates,
@@ -30,6 +32,8 @@ import {
   renderPagesIndex,
   type ValidationScope,
   validateDataRoot,
+  writeSchematicMapManifest,
+  writeSchematicMapVersionSnapshot,
   writeUnknownEntity,
 } from '@mrtdown/fs';
 
@@ -61,6 +65,8 @@ const usage = `Usage:
   mrtdown [--data-dir <path>] schematic-map show <manifest|rules|constraint|version> [id]
   mrtdown [--data-dir <path>] schematic-map select <YYYY-MM|YYYY-MM-DD>
   mrtdown [--data-dir <path>] schematic-map stats <YYYY-MM>
+  mrtdown [--data-dir <path>] schematic-map generate <YYYY-MM> [--generated-at <timestamp>] [--write]
+  mrtdown [--data-dir <path>] schematic-map preview <YYYY-MM> [--out <path>]
   mrtdown [--data-dir <path>] create issue --date <YYYY-MM-DD> --title <title> [--slug <slug>] [--type <type>] [--source <source>]
   mrtdown [--data-dir <path>] create <station|line|service|operator|town|landmark> --file <path>
   mrtdown id issue --date <YYYY-MM-DD> --title <title>
@@ -250,6 +256,203 @@ function countConstraintTypes(
   );
 }
 
+const linePreviewColors: Record<string, string> = {
+  BPLRT: '#748477',
+  CCL: '#fa9e0d',
+  CRL: '#97c616',
+  DTL: '#005ec4',
+  EWL: '#009645',
+  JRL: '#0099aa',
+  NEL: '#9900aa',
+  NSL: '#d42e12',
+  PGLRT: '#748477',
+  SKLRT: '#748477',
+  TEL: '#9d5b25',
+};
+
+function xmlEscape(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;');
+}
+
+function previewColorForLine(lineId: string): string {
+  return linePreviewColors[lineId] ?? '#555555';
+}
+
+function pointAttrs(point: { x: number; y: number }): string {
+  return `x="${point.x}" y="${point.y}"`;
+}
+
+function renderGeometry(
+  geometry: SchematicMapVersionSnapshot['segments'][number]['geometry'],
+): string {
+  if (geometry.type === 'polyline') {
+    return geometry.points.map((point) => `${point.x},${point.y}`).join(' ');
+  }
+
+  return `M ${geometry.start.x},${geometry.start.y} C ${geometry.control1.x},${geometry.control1.y} ${geometry.control2.x},${geometry.control2.y} ${geometry.end.x},${geometry.end.y}`;
+}
+
+function textAnchorForSide(side: string): string {
+  if (side.endsWith('left') || side === 'left') {
+    return 'end';
+  }
+  if (side.endsWith('right') || side === 'right') {
+    return 'start';
+  }
+  return 'middle';
+}
+
+async function renderSchematicMapPreviewSvg(
+  dataDir: string,
+  snapshot: SchematicMapVersionSnapshot,
+): Promise<string> {
+  const stationNames = new Map<string, string>();
+  await Promise.all(
+    snapshot.stationNodes.map(async (node) => {
+      const station = await readEntity(dataDir, 'station', node.stationId);
+      stationNames.set(
+        node.stationId,
+        station.value.name['en-SG'] ?? node.stationId,
+      );
+    }),
+  );
+
+  const layerContent = snapshot.layers.map((layer) => {
+    const segments = snapshot.segments
+      .filter((segment) => segment.layerId === layer.id)
+      .map((segment) => {
+        const color = previewColorForLine(segment.lineId);
+        if (segment.geometry.type === 'polyline') {
+          return `<polyline id="${xmlEscape(segment.id)}" points="${renderGeometry(
+            segment.geometry,
+          )}" class="line-segment" stroke="${color}"><title>${xmlEscape(
+            `${segment.lineId} ${segment.id}`,
+          )}</title></polyline>`;
+        }
+
+        return `<path id="${xmlEscape(segment.id)}" d="${renderGeometry(
+          segment.geometry,
+        )}" class="line-segment" stroke="${color}"><title>${xmlEscape(
+          `${segment.lineId} ${segment.id}`,
+        )}</title></path>`;
+      })
+      .join('\n');
+
+    const nodes = snapshot.stationNodes
+      .filter((node) => node.layerId === layer.id)
+      .flatMap((node) =>
+        node.parts.map((part) => {
+          const color = previewColorForLine(part.lineId);
+          const title = xmlEscape(
+            `${stationNames.get(node.stationId) ?? node.stationId} (${part.lineId})`,
+          );
+
+          if (part.shape.type === 'pill') {
+            return `<rect id="${xmlEscape(part.id)}" x="${
+              part.shape.center.x - part.shape.width / 2
+            }" y="${part.shape.center.y - part.shape.height / 2}" width="${
+              part.shape.width
+            }" height="${part.shape.height}" rx="${
+              part.shape.radius
+            }" class="station-node" stroke="${color}"><title>${title}</title></rect>`;
+          }
+
+          return `<circle id="${xmlEscape(part.id)}" cx="${
+            part.shape.center.x
+          }" cy="${part.shape.center.y}" r="${
+            part.shape.radius
+          }" class="station-node" stroke="${color}"><title>${title}</title></circle>`;
+        }),
+      )
+      .join('\n');
+
+    const labels = snapshot.labels
+      .filter((label) => label.layerId === layer.id)
+      .map(
+        (label) =>
+          `<text id="${xmlEscape(label.id)}" ${pointAttrs(
+            label.anchor,
+          )} class="station-label" text-anchor="${textAnchorForSide(
+            label.side,
+          )}">${xmlEscape(stationNames.get(label.stationId) ?? label.stationId)}</text>`,
+      )
+      .join('\n');
+
+    const stationCodeLabels = snapshot.stationCodeLabels
+      .filter((label) => label.layerId === layer.id)
+      .map(
+        (label) =>
+          `<text id="${xmlEscape(label.id)}" ${pointAttrs(
+            label.anchor,
+          )} class="station-code" text-anchor="${textAnchorForSide(
+            label.side,
+          )}">${xmlEscape(label.id)}</text>`,
+      )
+      .join('\n');
+
+    return `<g id="${xmlEscape(layer.id)}" data-role="${xmlEscape(layer.role)}">
+${segments}
+${nodes}
+${labels}
+${stationCodeLabels}
+</g>`;
+  });
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="${snapshot.frame.x} ${snapshot.frame.y} ${snapshot.frame.width} ${snapshot.frame.height}" width="${snapshot.frame.width}" height="${snapshot.frame.height}" role="img" aria-label="MRTDown schematic map preview ${snapshot.effectiveDate}">
+<style>
+  svg { background: #f7f6f2; font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+  .line-segment { fill: none; stroke-width: 10; stroke-linecap: round; stroke-linejoin: round; }
+  .station-node { fill: #ffffff; stroke-width: 4; }
+  .station-label { fill: #1f2933; font-size: 20px; font-weight: 650; dominant-baseline: middle; }
+  .station-code { fill: #4b5563; font-size: 13px; font-weight: 700; dominant-baseline: middle; }
+</style>
+<rect x="${snapshot.frame.x}" y="${snapshot.frame.y}" width="${snapshot.frame.width}" height="${snapshot.frame.height}" fill="#f7f6f2"/>
+${layerContent.join('\n')}
+</svg>
+`;
+}
+
+async function readOptionalSchematicMapManifest(
+  dataDir: string,
+): Promise<SchematicMapManifest | undefined> {
+  try {
+    return (await readSchematicMapManifest(dataDir)).value;
+  } catch (error) {
+    if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
+      return undefined;
+    }
+    throw error;
+  }
+}
+
+async function updateSchematicMapManifest(
+  dataDir: string,
+  snapshot: SchematicMapVersionSnapshot,
+): Promise<string> {
+  const existing = await readOptionalSchematicMapManifest(dataDir);
+  const versions = [
+    ...(existing?.versions.filter(
+      (version) => version.effectiveDate !== snapshot.effectiveDate,
+    ) ?? []),
+    {
+      effectiveDate: snapshot.effectiveDate,
+      path: `version/${snapshot.effectiveDate}.json`,
+      layoutEngineId: snapshot.layoutEngineId,
+    },
+  ].sort((a, b) => a.effectiveDate.localeCompare(b.effectiveDate));
+
+  return writeSchematicMapManifest(dataDir, {
+    schemaVersion: 1,
+    mapId: 'system',
+    versions,
+  });
+}
+
 async function writeTextFile(path: string, text: string): Promise<void> {
   await mkdir(dirname(path), { recursive: true });
   await writeFile(path, text);
@@ -433,7 +636,71 @@ async function runSchematicMap(
     return 0;
   }
 
-  throw new Error('schematic-map requires list, show, select, or stats');
+  if (action === 'generate') {
+    const id = args.shift();
+    if (!id) {
+      throw new Error('schematic-map generate requires YYYY-MM');
+    }
+
+    const generatedAt = readOption(args, '--generated-at');
+    const shouldWrite = hasFlag(args, '--write');
+    const snapshot = await generateSchematicMapVersionSnapshot(
+      globals.dataDir,
+      {
+        effectiveDate: SchematicMapEffectiveDateSchema.parse(id),
+        generatedAt,
+      },
+    );
+
+    if (shouldWrite) {
+      const snapshotPath = await writeSchematicMapVersionSnapshot(
+        globals.dataDir,
+        snapshot,
+      );
+      const manifestPath = await updateSchematicMapManifest(
+        globals.dataDir,
+        snapshot,
+      );
+      io.stdout(
+        JSON.stringify({ snapshot: snapshotPath, manifest: manifestPath }),
+      );
+      return 0;
+    }
+
+    io.stdout(JSON.stringify(snapshot, null, 2));
+    return 0;
+  }
+
+  if (action === 'preview') {
+    const id = args.shift();
+    if (!id) {
+      throw new Error('schematic-map preview requires YYYY-MM');
+    }
+
+    const out = readOption(args, '--out');
+    const snapshot = await readSchematicMapVersionSnapshot(
+      globals.dataDir,
+      SchematicMapEffectiveDateSchema.parse(id),
+    );
+    const svg = await renderSchematicMapPreviewSvg(
+      globals.dataDir,
+      snapshot.value,
+    );
+
+    if (out) {
+      const outPath = resolve(globals.cwd, out);
+      await writeTextFile(outPath, svg);
+      io.stdout(outPath);
+      return 0;
+    }
+
+    io.stdout(svg.trimEnd());
+    return 0;
+  }
+
+  throw new Error(
+    'schematic-map requires list, show, select, stats, generate, or preview',
+  );
 }
 
 async function runCreate(

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -256,30 +256,12 @@ function countConstraintTypes(
   );
 }
 
-const linePreviewColors: Record<string, string> = {
-  BPLRT: '#748477',
-  CCL: '#fa9e0d',
-  CRL: '#97c616',
-  DTL: '#005ec4',
-  EWL: '#009645',
-  JRL: '#0099aa',
-  NEL: '#9900aa',
-  NSL: '#d42e12',
-  PGLRT: '#748477',
-  SKLRT: '#748477',
-  TEL: '#9d5b25',
-};
-
 function xmlEscape(value: string): string {
   return value
     .replaceAll('&', '&amp;')
     .replaceAll('<', '&lt;')
     .replaceAll('>', '&gt;')
     .replaceAll('"', '&quot;');
-}
-
-function previewColorForLine(lineId: string): string {
-  return linePreviewColors[lineId] ?? '#555555';
 }
 
 function pointAttrs(point: { x: number; y: number }): string {
@@ -311,21 +293,26 @@ async function renderSchematicMapPreviewSvg(
   snapshot: SchematicMapVersionSnapshot,
 ): Promise<string> {
   const stationNames = new Map<string, string>();
-  await Promise.all(
-    snapshot.stationNodes.map(async (node) => {
+  const lineColors = new Map<string, string>();
+  await Promise.all([
+    ...snapshot.stationNodes.map(async (node) => {
       const station = await readEntity(dataDir, 'station', node.stationId);
       stationNames.set(
         node.stationId,
         station.value.name['en-SG'] ?? node.stationId,
       );
     }),
-  );
+    ...snapshot.lineGroups.map(async (lineGroup) => {
+      const line = await readEntity(dataDir, 'line', lineGroup.lineId);
+      lineColors.set(lineGroup.lineId, line.value.color);
+    }),
+  ]);
 
   const layerContent = snapshot.layers.map((layer) => {
     const segments = snapshot.segments
       .filter((segment) => segment.layerId === layer.id)
       .map((segment) => {
-        const color = previewColorForLine(segment.lineId);
+        const color = lineColors.get(segment.lineId) ?? '#555555';
         if (segment.geometry.type === 'polyline') {
           return `<polyline id="${xmlEscape(segment.id)}" points="${renderGeometry(
             segment.geometry,
@@ -346,7 +333,7 @@ async function renderSchematicMapPreviewSvg(
       .filter((node) => node.layerId === layer.id)
       .flatMap((node) =>
         node.parts.map((part) => {
-          const color = previewColorForLine(part.lineId);
+          const color = lineColors.get(part.lineId) ?? '#555555';
           const title = xmlEscape(
             `${stationNames.get(node.stationId) ?? node.stationId} (${part.lineId})`,
           );

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -36,6 +36,8 @@ import {
   writeSchematicMapVersionSnapshot,
   writeUnknownEntity,
 } from '@mrtdown/fs';
+import type { Element, ElementContent, Root } from 'hast';
+import { toHtml } from 'hast-util-to-html';
 
 export type CliIO = {
   stdout: (text: string) => void;
@@ -256,18 +258,6 @@ function countConstraintTypes(
   );
 }
 
-function xmlEscape(value: string): string {
-  return value
-    .replaceAll('&', '&amp;')
-    .replaceAll('<', '&lt;')
-    .replaceAll('>', '&gt;')
-    .replaceAll('"', '&quot;');
-}
-
-function pointAttrs(point: { x: number; y: number }): string {
-  return `x="${point.x}" y="${point.y}"`;
-}
-
 function renderGeometry(
   geometry: SchematicMapVersionSnapshot['segments'][number]['geometry'],
 ): string {
@@ -286,6 +276,30 @@ function textAnchorForSide(side: string): string {
     return 'start';
   }
   return 'middle';
+}
+
+function svgElement(
+  tagName: string,
+  properties: Element['properties'] = {},
+  children: ElementContent[] = [],
+): Element {
+  return {
+    type: 'element',
+    tagName,
+    properties,
+    children,
+  };
+}
+
+function svgText(value: string): ElementContent {
+  return {
+    type: 'text',
+    value,
+  };
+}
+
+function svgTitle(value: string): Element {
+  return svgElement('title', {}, [svgText(value)]);
 }
 
 async function renderSchematicMapPreviewSvg(
@@ -308,100 +322,154 @@ async function renderSchematicMapPreviewSvg(
     }),
   ]);
 
-  const layerContent = snapshot.layers.map((layer) => {
+  const layerContent = snapshot.layers.map<Element>((layer) => {
     const segments = snapshot.segments
       .filter((segment) => segment.layerId === layer.id)
-      .map((segment) => {
+      .map<Element>((segment) => {
         const color = lineColors.get(segment.lineId) ?? '#555555';
         if (segment.geometry.type === 'polyline') {
-          return `<polyline id="${xmlEscape(segment.id)}" points="${renderGeometry(
-            segment.geometry,
-          )}" class="line-segment" stroke="${color}"><title>${xmlEscape(
-            `${segment.lineId} ${segment.id}`,
-          )}</title></polyline>`;
+          return svgElement(
+            'polyline',
+            {
+              id: segment.id,
+              points: renderGeometry(segment.geometry),
+              className: ['line-segment'],
+              stroke: color,
+            },
+            [svgTitle(`${segment.lineId} ${segment.id}`)],
+          );
         }
 
-        return `<path id="${xmlEscape(segment.id)}" d="${renderGeometry(
-          segment.geometry,
-        )}" class="line-segment" stroke="${color}"><title>${xmlEscape(
-          `${segment.lineId} ${segment.id}`,
-        )}</title></path>`;
-      })
-      .join('\n');
+        return svgElement(
+          'path',
+          {
+            id: segment.id,
+            d: renderGeometry(segment.geometry),
+            className: ['line-segment'],
+            stroke: color,
+          },
+          [svgTitle(`${segment.lineId} ${segment.id}`)],
+        );
+      });
 
     const nodes = snapshot.stationNodes
       .filter((node) => node.layerId === layer.id)
       .flatMap((node) =>
         node.parts.map((part) => {
           const color = lineColors.get(part.lineId) ?? '#555555';
-          const title = xmlEscape(
-            `${stationNames.get(node.stationId) ?? node.stationId} (${part.lineId})`,
-          );
+          const title = `${stationNames.get(node.stationId) ?? node.stationId} (${part.lineId})`;
 
           if (part.shape.type === 'pill') {
-            return `<rect id="${xmlEscape(part.id)}" x="${
-              part.shape.center.x - part.shape.width / 2
-            }" y="${part.shape.center.y - part.shape.height / 2}" width="${
-              part.shape.width
-            }" height="${part.shape.height}" rx="${
-              part.shape.radius
-            }" class="station-node" stroke="${color}"><title>${title}</title></rect>`;
+            return svgElement(
+              'rect',
+              {
+                id: part.id,
+                x: part.shape.center.x - part.shape.width / 2,
+                y: part.shape.center.y - part.shape.height / 2,
+                width: part.shape.width,
+                height: part.shape.height,
+                rx: part.shape.radius,
+                className: ['station-node'],
+                stroke: color,
+              },
+              [svgTitle(title)],
+            );
           }
 
-          return `<circle id="${xmlEscape(part.id)}" cx="${
-            part.shape.center.x
-          }" cy="${part.shape.center.y}" r="${
-            part.shape.radius
-          }" class="station-node" stroke="${color}"><title>${title}</title></circle>`;
+          return svgElement(
+            'circle',
+            {
+              id: part.id,
+              cx: part.shape.center.x,
+              cy: part.shape.center.y,
+              r: part.shape.radius,
+              className: ['station-node'],
+              stroke: color,
+            },
+            [svgTitle(title)],
+          );
         }),
-      )
-      .join('\n');
+      );
 
     const labels = snapshot.labels
       .filter((label) => label.layerId === layer.id)
-      .map(
-        (label) =>
-          `<text id="${xmlEscape(label.id)}" ${pointAttrs(
-            label.anchor,
-          )} class="station-label" text-anchor="${textAnchorForSide(
-            label.side,
-          )}">${xmlEscape(stationNames.get(label.stationId) ?? label.stationId)}</text>`,
-      )
-      .join('\n');
+      .map((label) =>
+        svgElement(
+          'text',
+          {
+            id: label.id,
+            x: label.anchor.x,
+            y: label.anchor.y,
+            className: ['station-label'],
+            textAnchor: textAnchorForSide(label.side),
+          },
+          [svgText(stationNames.get(label.stationId) ?? label.stationId)],
+        ),
+      );
 
     const stationCodeLabels = snapshot.stationCodeLabels
       .filter((label) => label.layerId === layer.id)
-      .map(
-        (label) =>
-          `<text id="${xmlEscape(label.id)}" ${pointAttrs(
-            label.anchor,
-          )} class="station-code" text-anchor="${textAnchorForSide(
-            label.side,
-          )}">${xmlEscape(label.id)}</text>`,
-      )
-      .join('\n');
+      .map((label) =>
+        svgElement(
+          'text',
+          {
+            id: label.id,
+            x: label.anchor.x,
+            y: label.anchor.y,
+            className: ['station-code'],
+            textAnchor: textAnchorForSide(label.side),
+          },
+          [svgText(label.id)],
+        ),
+      );
 
-    return `<g id="${xmlEscape(layer.id)}" data-role="${xmlEscape(layer.role)}">
-${segments}
-${nodes}
-${labels}
-${stationCodeLabels}
-</g>`;
+    return svgElement(
+      'g',
+      {
+        id: layer.id,
+        dataRole: layer.role,
+      },
+      [...segments, ...nodes, ...labels, ...stationCodeLabels],
+    );
   });
 
-  return `<?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="${snapshot.frame.x} ${snapshot.frame.y} ${snapshot.frame.width} ${snapshot.frame.height}" width="${snapshot.frame.width}" height="${snapshot.frame.height}" role="img" aria-label="MRTDown schematic map preview ${snapshot.effectiveDate}">
-<style>
+  const root: Root = {
+    type: 'root',
+    children: [
+      svgElement(
+        'svg',
+        {
+          xmlns: 'http://www.w3.org/2000/svg',
+          viewBox: `${snapshot.frame.x} ${snapshot.frame.y} ${snapshot.frame.width} ${snapshot.frame.height}`,
+          width: snapshot.frame.width,
+          height: snapshot.frame.height,
+          role: 'img',
+          ariaLabel: `MRTDown schematic map preview ${snapshot.effectiveDate}`,
+        },
+        [
+          svgElement('style', {}, [
+            svgText(`
   svg { background: #f7f6f2; font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
   .line-segment { fill: none; stroke-width: 10; stroke-linecap: round; stroke-linejoin: round; }
   .station-node { fill: #ffffff; stroke-width: 4; }
   .station-label { fill: #1f2933; font-size: 20px; font-weight: 650; dominant-baseline: middle; }
   .station-code { fill: #4b5563; font-size: 13px; font-weight: 700; dominant-baseline: middle; }
-</style>
-<rect x="${snapshot.frame.x}" y="${snapshot.frame.y}" width="${snapshot.frame.width}" height="${snapshot.frame.height}" fill="#f7f6f2"/>
-${layerContent.join('\n')}
-</svg>
-`;
+`),
+          ]),
+          svgElement('rect', {
+            x: snapshot.frame.x,
+            y: snapshot.frame.y,
+            width: snapshot.frame.width,
+            height: snapshot.frame.height,
+            fill: '#f7f6f2',
+          }),
+          ...layerContent,
+        ],
+      ),
+    ],
+  };
+
+  return `<?xml version="1.0" encoding="UTF-8"?>\n${toHtml(root)}\n`;
 }
 
 async function readOptionalSchematicMapManifest(

--- a/packages/fs/src/index.test.ts
+++ b/packages/fs/src/index.test.ts
@@ -19,6 +19,7 @@ import {
   createIssueBundle,
   FileStore,
   FileWriteStore,
+  generateSchematicMapVersionSnapshot,
   IdGenerator,
   issuePathFromId,
   listEntityIds,
@@ -393,6 +394,101 @@ describe('@mrtdown/fs', () => {
     ).resolves.toMatchObject({
       path: schematicSystemMapVersionSnapshotPath('2025-04'),
       value: { effectiveDate: '2025-04' },
+    });
+  });
+
+  it('generates a deterministic schematic map snapshot from active services', async () => {
+    const dataDir = await mkdtemp(join(tmpdir(), 'mrtdown-fs-'));
+    await cp(fixtureDataDir, dataDir, { recursive: true });
+    await writeSchematicMapRuleSet(dataDir, {
+      schemaVersion: 1,
+      mapId: 'system',
+      layoutEngineId: 'lta-system-map-2011',
+      lineOrder: ['ISL', 'TKL', 'TWL'],
+    });
+    await writeSchematicMapConstraintSet(dataDir, {
+      schemaVersion: 1,
+      mapId: 'system',
+      effectiveDate: '2026-05',
+      layoutEngineId: 'lta-system-map-2011',
+      constraints: [
+        {
+          id: 'frame_2026_05',
+          type: 'map_frame',
+          frame: { x: 0, y: 0, width: 1200, height: 600 },
+        },
+        {
+          id: 'anchor_ket',
+          type: 'station_anchor',
+          stationId: 'KET',
+          point: { x: 100, y: 100 },
+        },
+        {
+          id: 'label_ket',
+          type: 'label_hint',
+          stationId: 'KET',
+          side: 'left',
+          offset: { x: -30, y: 0 },
+        },
+      ],
+    });
+
+    const snapshot = await generateSchematicMapVersionSnapshot(dataDir, {
+      effectiveDate: '2026-05',
+      generatedAt: '2026-05-27T00:00:00.000Z',
+    });
+
+    expect(snapshot.lineGroups.map((lineGroup) => lineGroup.lineId)).toEqual([
+      'ISL',
+      'TKL',
+      'TWL',
+    ]);
+    expect(snapshot.segments).toContainEqual(
+      expect.objectContaining({
+        id: 'line_hku:ket',
+        lineId: 'ISL',
+        topology: {
+          type: 'station_pair',
+          fromStationId: 'KET',
+          toStationId: 'HKU',
+        },
+      }),
+    );
+    expect(
+      snapshot.stationNodes.find((node) => node.stationId === 'KET'),
+    ).toMatchObject({
+      center: { x: 100, y: 100 },
+      coordinateMetadata: {
+        coordinateClass: 'constraint',
+        constraintId: 'anchor_ket',
+      },
+    });
+    expect(
+      snapshot.labels.find((label) => label.stationId === 'KET'),
+    ).toMatchObject({
+      anchor: { x: 70, y: 100 },
+      coordinateMetadata: {
+        coordinateClass: 'constraint',
+        constraintId: 'label_ket',
+      },
+    });
+
+    await writeSchematicMapVersionSnapshot(dataDir, snapshot);
+    await writeSchematicMapManifest(dataDir, {
+      schemaVersion: 1,
+      mapId: 'system',
+      versions: [
+        {
+          effectiveDate: '2026-05',
+          path: 'version/2026-05.json',
+          layoutEngineId: 'lta-system-map-2011',
+        },
+      ],
+    });
+    await expect(
+      validateDataRoot(dataDir, ['schematic-map']),
+    ).resolves.toMatchObject({
+      ok: true,
     });
   });
 

--- a/packages/fs/src/index.test.ts
+++ b/packages/fs/src/index.test.ts
@@ -443,6 +443,11 @@ describe('@mrtdown/fs', () => {
       'TKL',
       'TWL',
     ]);
+    expect(snapshot.lineGroups.map((lineGroup) => lineGroup.id)).toEqual([
+      'line_isl',
+      'line_tkl',
+      'line_twl',
+    ]);
     expect(snapshot.segments).toContainEqual(
       expect.objectContaining({
         id: 'line_hku:ket',
@@ -490,6 +495,82 @@ describe('@mrtdown/fs', () => {
     ).resolves.toMatchObject({
       ok: true,
     });
+  });
+
+  it('uses Singapore month boundaries when selecting active schematic services', async () => {
+    const dataDir = await mkdtemp(join(tmpdir(), 'mrtdown-fs-'));
+    await cp(fixtureDataDir, dataDir, { recursive: true });
+    await writeSchematicMapRuleSet(dataDir, {
+      schemaVersion: 1,
+      mapId: 'system',
+      layoutEngineId: 'lta-system-map-2011',
+      lineOrder: ['ISL'],
+    });
+
+    const snapshot = await generateSchematicMapVersionSnapshot(dataDir, {
+      effectiveDate: '1979-09',
+      generatedAt: '2026-05-27T00:00:00.000Z',
+    });
+
+    expect(snapshot.lineGroups).toEqual([]);
+    expect(snapshot.stationNodes).toEqual([]);
+  });
+
+  it('derives line station order from line topology instead of service file order', async () => {
+    const dataDir = await mkdtemp(join(tmpdir(), 'mrtdown-fs-'));
+    await cp(fixtureDataDir, dataDir, { recursive: true });
+    await writeSchematicMapRuleSet(dataDir, {
+      schemaVersion: 1,
+      mapId: 'system',
+      layoutEngineId: 'lta-system-map-2011',
+      lineOrder: ['ISL'],
+    });
+    await writeFile(
+      join(dataDir, 'service/AAA_BRANCH.json'),
+      `${JSON.stringify(
+        {
+          id: 'AAA_BRANCH',
+          name: {
+            'en-SG': 'Fixture branch',
+            'zh-Hans': null,
+            ms: null,
+            ta: null,
+          },
+          lineId: 'ISL',
+          revisions: [
+            {
+              id: 'r_initial',
+              startAt: '1979-10-01',
+              endAt: null,
+              path: {
+                stations: [
+                  { stationId: 'ADM', displayCode: 'ISL6' },
+                  { stationId: 'TST', displayCode: '' },
+                ],
+              },
+              operatingHours: {
+                weekdays: { start: '05:30', end: '00:30' },
+                weekends: { start: '05:30', end: '00:30' },
+              },
+            },
+          ],
+        },
+        null,
+        2,
+      )}\n`,
+    );
+
+    const snapshot = await generateSchematicMapVersionSnapshot(dataDir, {
+      effectiveDate: '2026-05',
+      generatedAt: '2026-05-27T00:00:00.000Z',
+    });
+
+    const stationX = new Map(
+      snapshot.stationNodes.map((node) => [node.stationId, node.center.x]),
+    );
+    expect(stationX.get('KET')).toBe(80);
+    expect(stationX.get('ADM')).toBeGreaterThan(stationX.get('KET') ?? 0);
+    expect(stationX.get('TST')).toBeGreaterThan(stationX.get('ADM') ?? 0);
   });
 
   it('rejects schematic map references that are missing from canonical data', async () => {

--- a/packages/fs/src/index.ts
+++ b/packages/fs/src/index.ts
@@ -13,6 +13,7 @@ export * from './repo/common/store.js';
 export * from './repo/issue/IssueRepository.js';
 export * from './repo/MRTDownRepository.js';
 export * from './repo/schematicMap/SchematicMapRepository.js';
+export * from './schematicMapGenerator.js';
 export * from './schematicMaps.js';
 export * from './validate.js';
 export * from './write/common/FileWriteStore.js';

--- a/packages/fs/src/schematicMapGenerator.ts
+++ b/packages/fs/src/schematicMapGenerator.ts
@@ -1,0 +1,667 @@
+import {
+  type SchematicMapConstraint,
+  type SchematicMapConstraintSet,
+  type SchematicMapEffectiveDate,
+  SchematicMapEffectiveDateSchema,
+  type SchematicMapFrame,
+  type SchematicMapLabelSide,
+  type SchematicMapLayoutEngineId,
+  SchematicMapLayoutEngineIdSchema,
+  type SchematicMapPoint,
+  type SchematicMapRuleSet,
+  type SchematicMapSegment,
+  type SchematicMapStationCodeLabel,
+  type SchematicMapStationNode,
+  type SchematicMapVersionSnapshot,
+  SchematicMapVersionSnapshotSchema,
+  type Service,
+  type Station,
+} from '@mrtdown/core';
+import { listEntities } from './entities.js';
+import {
+  readSchematicMapConstraintSet,
+  readSchematicMapRuleSet,
+} from './schematicMaps.js';
+
+export type GenerateSchematicMapVersionSnapshotOptions = {
+  effectiveDate: SchematicMapEffectiveDate;
+  layoutEngineId?: SchematicMapLayoutEngineId;
+  generatedAt?: string;
+};
+
+type ActiveTopology = {
+  lineIds: string[];
+  lineStations: Map<string, string[]>;
+  lineSegments: Map<
+    string,
+    Map<
+      string,
+      {
+        fromStationId: string;
+        toStationId: string;
+      }
+    >
+  >;
+  stationLineIds: Map<string, Set<string>>;
+};
+
+function timestampForSchematicMapGenerator(value: string): number {
+  const normalized = /^\d{4}-\d{2}$/.test(value)
+    ? `${value}-01T00:00:00+08:00`
+    : /^\d{4}-\d{2}-\d{2}$/.test(value)
+      ? `${value}T00:00:00+08:00`
+      : value;
+  const timestamp = Date.parse(normalized);
+  if (Number.isNaN(timestamp)) {
+    throw new Error(`Invalid timestamp for schematic map generation: ${value}`);
+  }
+  return timestamp;
+}
+
+function effectiveMonthInterval(effectiveDate: SchematicMapEffectiveDate): {
+  start: number;
+  end: number;
+} {
+  const [year, month] = effectiveDate.split('-').map(Number);
+  return {
+    start: Date.UTC(year, month - 1, 1),
+    end: Date.UTC(year, month, 1),
+  };
+}
+
+function intervalOverlapsEffectiveMonth(
+  startAt: string,
+  endAt: string | null,
+  effectiveDate: SchematicMapEffectiveDate,
+): boolean {
+  const effectiveMonth = effectiveMonthInterval(effectiveDate);
+  const start = timestampForSchematicMapGenerator(startAt);
+  const end = endAt
+    ? timestampForSchematicMapGenerator(endAt)
+    : Number.POSITIVE_INFINITY;
+
+  return start < effectiveMonth.end && effectiveMonth.start < end;
+}
+
+function stationPairKey(fromStationId: string, toStationId: string): string {
+  return [fromStationId, toStationId]
+    .sort((a, b) => a.localeCompare(b))
+    .join(':');
+}
+
+function baseSegmentId(fromStationId: string, toStationId: string): string {
+  const [from, to] = [fromStationId, toStationId]
+    .map((stationId) => stationId.toLowerCase())
+    .sort((a, b) => a.localeCompare(b));
+  return `line_${from}:${to}`;
+}
+
+function segmentId(
+  fromStationId: string,
+  toStationId: string,
+  lineId: string,
+  pairLineCounts: Map<string, number>,
+): string {
+  const baseId = baseSegmentId(fromStationId, toStationId);
+  return (pairLineCounts.get(stationPairKey(fromStationId, toStationId)) ?? 0) >
+    1
+    ? `${baseId}_${lineIdPart(lineId)}`
+    : baseId;
+}
+
+function stationIdPart(stationId: string): string {
+  return stationId.toLowerCase();
+}
+
+function lineIdPart(lineId: string): string {
+  return lineId.toLowerCase();
+}
+
+function appendUnique(values: string[], value: string): void {
+  if (!values.includes(value)) {
+    values.push(value);
+  }
+}
+
+function compareByPreferredOrder(order: readonly string[]) {
+  const indexByValue = new Map(order.map((value, index) => [value, index]));
+  return (a: string, b: string): number => {
+    const aIndex = indexByValue.get(a) ?? Number.POSITIVE_INFINITY;
+    const bIndex = indexByValue.get(b) ?? Number.POSITIVE_INFINITY;
+    if (aIndex !== bIndex) {
+      return aIndex - bIndex;
+    }
+    return a.localeCompare(b);
+  };
+}
+
+async function readOptionalConstraintSet(
+  dataDir: string,
+  effectiveDate: SchematicMapEffectiveDate,
+): Promise<SchematicMapConstraintSet | undefined> {
+  try {
+    return (await readSchematicMapConstraintSet(dataDir, effectiveDate)).value;
+  } catch (error) {
+    if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
+      return undefined;
+    }
+    throw error;
+  }
+}
+
+function lineOrderFromInputs(
+  ruleSet: SchematicMapRuleSet,
+  constraintSet: SchematicMapConstraintSet | undefined,
+): string[] {
+  let lineOrderConstraint:
+    | Extract<SchematicMapConstraint, { type: 'line_order' }>
+    | undefined;
+
+  for (const constraint of constraintSet?.constraints ?? []) {
+    if (constraint.type === 'line_order') {
+      lineOrderConstraint = constraint;
+    }
+  }
+
+  return lineOrderConstraint?.lineIds ?? ruleSet.lineOrder;
+}
+
+function frameFromConstraints(
+  constraintSet: SchematicMapConstraintSet | undefined,
+): SchematicMapFrame {
+  let constraint:
+    | Extract<SchematicMapConstraint, { type: 'map_frame' }>
+    | undefined;
+
+  for (const entry of constraintSet?.constraints ?? []) {
+    if (entry.type === 'map_frame') {
+      constraint = entry;
+    }
+  }
+
+  if (!constraint) {
+    return {
+      x: 0,
+      y: 0,
+      width: 3140,
+      height: 2400,
+      coordinateMetadata: {
+        coordinateClass: 'generated',
+        ruleId: 'default-map-frame',
+      },
+    };
+  }
+
+  return {
+    ...constraint.frame,
+    coordinateMetadata: {
+      coordinateClass: 'constraint',
+      constraintId: constraint.id,
+    },
+  };
+}
+
+function buildActiveTopology(
+  services: readonly Service[],
+  effectiveDate: SchematicMapEffectiveDate,
+): ActiveTopology {
+  const lineIds = new Set<string>();
+  const lineStations = new Map<string, string[]>();
+  const lineSegments = new Map<
+    string,
+    Map<string, { fromStationId: string; toStationId: string }>
+  >();
+  const stationLineIds = new Map<string, Set<string>>();
+
+  for (const service of services) {
+    for (const revision of service.revisions) {
+      if (
+        !intervalOverlapsEffectiveMonth(
+          revision.startAt,
+          revision.endAt,
+          effectiveDate,
+        )
+      ) {
+        continue;
+      }
+
+      lineIds.add(service.lineId);
+      const stationsForLine = lineStations.get(service.lineId) ?? [];
+      lineStations.set(service.lineId, stationsForLine);
+      const segmentsForLine = lineSegments.get(service.lineId) ?? new Map();
+      lineSegments.set(service.lineId, segmentsForLine);
+
+      const stationIds = revision.path.stations.map(
+        (station) => station.stationId,
+      );
+
+      for (const stationId of stationIds) {
+        appendUnique(stationsForLine, stationId);
+        const lineIdsForStation = stationLineIds.get(stationId) ?? new Set();
+        lineIdsForStation.add(service.lineId);
+        stationLineIds.set(stationId, lineIdsForStation);
+      }
+
+      for (let index = 0; index < stationIds.length - 1; index += 1) {
+        const fromStationId = stationIds[index];
+        const toStationId = stationIds[index + 1];
+        const key = stationPairKey(fromStationId, toStationId);
+        if (!segmentsForLine.has(key)) {
+          segmentsForLine.set(key, { fromStationId, toStationId });
+        }
+      }
+    }
+  }
+
+  return {
+    lineIds: [...lineIds],
+    lineStations,
+    lineSegments,
+    stationLineIds,
+  };
+}
+
+function activeStationCodesByStationAndLine(
+  stations: readonly Station[],
+  effectiveDate: SchematicMapEffectiveDate,
+): Map<string, Map<string, string>> {
+  const codes = new Map<string, Map<string, string>>();
+
+  for (const station of stations) {
+    for (const stationCode of station.stationCodes) {
+      if (
+        !intervalOverlapsEffectiveMonth(
+          stationCode.startedAt,
+          stationCode.endedAt,
+          effectiveDate,
+        )
+      ) {
+        continue;
+      }
+
+      const codesByLine = codes.get(station.id) ?? new Map<string, string>();
+      if (!codesByLine.has(stationCode.lineId)) {
+        codesByLine.set(stationCode.lineId, stationCode.code);
+      }
+      codes.set(station.id, codesByLine);
+    }
+  }
+
+  return codes;
+}
+
+function stationAnchorConstraints(
+  constraintSet: SchematicMapConstraintSet | undefined,
+): Map<string, Extract<SchematicMapConstraint, { type: 'station_anchor' }>> {
+  const anchors = new Map<
+    string,
+    Extract<SchematicMapConstraint, { type: 'station_anchor' }>
+  >();
+
+  for (const constraint of constraintSet?.constraints ?? []) {
+    if (constraint.type === 'station_anchor') {
+      anchors.set(constraint.stationId, constraint);
+    }
+  }
+
+  return anchors;
+}
+
+function labelHintConstraints(
+  constraintSet: SchematicMapConstraintSet | undefined,
+): Map<string, Extract<SchematicMapConstraint, { type: 'label_hint' }>> {
+  const hints = new Map<
+    string,
+    Extract<SchematicMapConstraint, { type: 'label_hint' }>
+  >();
+
+  for (const constraint of constraintSet?.constraints ?? []) {
+    if (constraint.type === 'label_hint') {
+      hints.set(constraint.stationId, constraint);
+    }
+  }
+
+  return hints;
+}
+
+function segmentRouteHintConstraints(
+  constraintSet: SchematicMapConstraintSet | undefined,
+): Map<
+  string,
+  Extract<SchematicMapConstraint, { type: 'segment_route_hint' }>
+> {
+  const hints = new Map<
+    string,
+    Extract<SchematicMapConstraint, { type: 'segment_route_hint' }>
+  >();
+
+  for (const constraint of constraintSet?.constraints ?? []) {
+    if (constraint.type === 'segment_route_hint') {
+      hints.set(
+        `${constraint.lineId}:${stationPairKey(
+          constraint.fromStationId,
+          constraint.toStationId,
+        )}`,
+        constraint,
+      );
+    }
+  }
+
+  return hints;
+}
+
+function pointWithOffset(
+  point: SchematicMapPoint,
+  offset: SchematicMapPoint,
+): SchematicMapPoint {
+  return {
+    x: point.x + offset.x,
+    y: point.y + offset.y,
+  };
+}
+
+function defaultLabelOffset(side: SchematicMapLabelSide): SchematicMapPoint {
+  switch (side) {
+    case 'right':
+      return { x: 24, y: 0 };
+    case 'bottom':
+      return { x: 0, y: 24 };
+    case 'left':
+      return { x: -24, y: 0 };
+    case 'top_right':
+      return { x: 18, y: -18 };
+    case 'bottom_right':
+      return { x: 18, y: 18 };
+    case 'bottom_left':
+      return { x: -18, y: 18 };
+    case 'top_left':
+      return { x: -18, y: -18 };
+    case 'center':
+      return { x: 0, y: 0 };
+    default:
+      return { x: 0, y: -24 };
+  }
+}
+
+function lineIdsForStation(
+  stationLineIds: Set<string>,
+  lineOrder: readonly string[],
+): string[] {
+  return [...stationLineIds].sort(compareByPreferredOrder(lineOrder));
+}
+
+export async function generateSchematicMapVersionSnapshot(
+  dataDir: string,
+  options: GenerateSchematicMapVersionSnapshotOptions,
+): Promise<SchematicMapVersionSnapshot> {
+  const effectiveDate = SchematicMapEffectiveDateSchema.parse(
+    options.effectiveDate,
+  );
+  const layoutEngineId = SchematicMapLayoutEngineIdSchema.parse(
+    options.layoutEngineId ?? 'lta-system-map-2011',
+  );
+  const [stations, services, ruleSetRecord, constraintSet] = await Promise.all([
+    listEntities(dataDir, 'station'),
+    listEntities(dataDir, 'service'),
+    readSchematicMapRuleSet(dataDir, layoutEngineId),
+    readOptionalConstraintSet(dataDir, effectiveDate),
+  ]);
+
+  const ruleSet = ruleSetRecord.value;
+  const topology = buildActiveTopology(
+    services.map((record) => record.value),
+    effectiveDate,
+  );
+  const baseLineOrder = lineOrderFromInputs(ruleSet, constraintSet);
+  const lineOrder = [
+    ...baseLineOrder.filter((lineId) => topology.lineIds.includes(lineId)),
+    ...topology.lineIds
+      .filter((lineId) => !baseLineOrder.includes(lineId))
+      .sort((a, b) => a.localeCompare(b)),
+  ];
+  const frame = frameFromConstraints(constraintSet);
+  const anchors = stationAnchorConstraints(constraintSet);
+  const labelHints = labelHintConstraints(constraintSet);
+  const segmentRouteHints = segmentRouteHintConstraints(constraintSet);
+  const activeStationCodes = activeStationCodesByStationAndLine(
+    stations.map((record) => record.value),
+    effectiveDate,
+  );
+  const stationPositions = new Map<string, SchematicMapPoint>();
+  const stationCoordinateMetadata = new Map<
+    string,
+    SchematicMapStationNode['coordinateMetadata']
+  >();
+  const lineSpacing =
+    lineOrder.length <= 1
+      ? 0
+      : Math.min(140, (frame.height - 240) / (lineOrder.length - 1));
+
+  lineOrder.forEach((lineId, lineIndex) => {
+    const stationsForLine = topology.lineStations.get(lineId) ?? [];
+    const stationSpacing =
+      stationsForLine.length <= 1
+        ? 0
+        : (frame.width - 160) / (stationsForLine.length - 1);
+    const y = frame.y + 120 + lineIndex * lineSpacing;
+
+    stationsForLine.forEach((stationId, stationIndex) => {
+      if (stationPositions.has(stationId)) {
+        return;
+      }
+
+      const anchor = anchors.get(stationId);
+      if (anchor) {
+        stationPositions.set(stationId, anchor.point);
+        stationCoordinateMetadata.set(stationId, {
+          coordinateClass: 'constraint',
+          constraintId: anchor.id,
+        });
+        return;
+      }
+
+      stationPositions.set(stationId, {
+        x: frame.x + 80 + stationIndex * stationSpacing,
+        y,
+      });
+      stationCoordinateMetadata.set(stationId, {
+        coordinateClass: 'generated',
+        ruleId: 'service-order-grid',
+      });
+    });
+  });
+
+  const segments: SchematicMapSegment[] = [];
+  const segmentPairLineCounts = new Map<string, number>();
+
+  for (const segmentsForLine of topology.lineSegments.values()) {
+    for (const key of segmentsForLine.keys()) {
+      segmentPairLineCounts.set(key, (segmentPairLineCounts.get(key) ?? 0) + 1);
+    }
+  }
+
+  const lineGroups = lineOrder.map((lineId) => {
+    const segmentsForLine = topology.lineSegments.get(lineId) ?? new Map();
+    const segmentIds: string[] = [];
+
+    for (const [key, segment] of [...segmentsForLine.entries()].sort(
+      ([a], [b]) => a.localeCompare(b),
+    )) {
+      const from = stationPositions.get(segment.fromStationId);
+      const to = stationPositions.get(segment.toStationId);
+      if (!from || !to) {
+        continue;
+      }
+
+      const id = segmentId(
+        segment.fromStationId,
+        segment.toStationId,
+        lineId,
+        segmentPairLineCounts,
+      );
+      const routeHint = segmentRouteHints.get(`${lineId}:${key}`);
+      const via = routeHint
+        ? routeHint.fromStationId === segment.toStationId
+          ? [...routeHint.via].reverse()
+          : routeHint.via
+        : [];
+
+      segmentIds.push(id);
+      segments.push({
+        id,
+        lineId,
+        displayStatus: 'operational',
+        layerId: 'lines',
+        topology: {
+          type: 'station_pair',
+          fromStationId: segment.fromStationId,
+          toStationId: segment.toStationId,
+        },
+        geometry: {
+          type: 'polyline',
+          points: [from, ...via, to],
+          coordinateMetadata: routeHint
+            ? {
+                coordinateClass: 'constraint',
+                constraintId: routeHint.id,
+              }
+            : {
+                coordinateClass: 'generated',
+                ruleId: 'service-adjacency-polyline',
+              },
+        },
+      });
+    }
+
+    return {
+      id: `line_${lineId}`,
+      lineId,
+      displayStatus: 'operational' as const,
+      layerId: 'lines',
+      segmentIds,
+    };
+  });
+
+  const stationNodes: SchematicMapStationNode[] = [
+    ...topology.stationLineIds.entries(),
+  ]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .flatMap(([stationId, stationLineIdSet]) => {
+      const center = stationPositions.get(stationId);
+      if (!center) {
+        return [];
+      }
+
+      const lineIds = lineIdsForStation(stationLineIdSet, lineOrder);
+      return [
+        {
+          id: `node_${stationIdPart(stationId)}`,
+          stationId,
+          displayStatus: 'operational',
+          layerId: 'nodes',
+          center,
+          lineIds,
+          parts: lineIds.map((lineId, index) => ({
+            id: `node_${stationIdPart(stationId)}_${lineIdPart(lineId)}`,
+            lineId,
+            shape: {
+              type: 'circle' as const,
+              center:
+                lineIds.length === 1
+                  ? center
+                  : {
+                      x: center.x + (index - (lineIds.length - 1) / 2) * 9,
+                      y: center.y,
+                    },
+              radius: 7,
+            },
+            coordinateMetadata: {
+              coordinateClass: 'artifact' as const,
+              generatedFrom: `node_${stationIdPart(stationId)}`,
+            },
+          })),
+          coordinateMetadata: stationCoordinateMetadata.get(stationId) ?? {
+            coordinateClass: 'generated',
+            ruleId: 'service-order-grid',
+          },
+        },
+      ];
+    });
+
+  const labels = stationNodes.map((node) => {
+    const hint = labelHints.get(node.stationId);
+    const side = hint?.side ?? 'top';
+    const offset = hint?.offset ?? defaultLabelOffset(side);
+
+    return {
+      id: `label_${stationIdPart(node.stationId)}`,
+      stationId: node.stationId,
+      displayStatus: 'operational' as const,
+      layerId: 'labels',
+      anchor: pointWithOffset(node.center, offset),
+      side,
+      coordinateMetadata: hint
+        ? {
+            coordinateClass: 'constraint' as const,
+            constraintId: hint.id,
+          }
+        : {
+            coordinateClass: 'generated' as const,
+            ruleId: 'default-station-label',
+          },
+    };
+  });
+
+  const stationCodeLabels: SchematicMapStationCodeLabel[] =
+    stationNodes.flatMap((node) => {
+      const codesByLine = activeStationCodes.get(node.stationId);
+      if (!codesByLine) {
+        return [];
+      }
+
+      return node.lineIds.flatMap((lineId, index) => {
+        const code = codesByLine.get(lineId);
+        if (!code) {
+          return [];
+        }
+
+        return [
+          {
+            id: code,
+            stationId: node.stationId,
+            lineId,
+            displayStatus: 'operational' as const,
+            layerId: 'labels',
+            anchor: {
+              x: node.center.x + index * 18,
+              y: node.center.y + 18,
+            },
+            side: 'bottom' as const,
+            coordinateMetadata: {
+              coordinateClass: 'generated' as const,
+              ruleId: 'default-station-code-label',
+            },
+          },
+        ];
+      });
+    });
+
+  return SchematicMapVersionSnapshotSchema.parse({
+    schemaVersion: 1,
+    mapId: 'system',
+    effectiveDate,
+    layoutEngineId,
+    generatedAt: options.generatedAt ?? new Date().toISOString(),
+    frame,
+    layers: [
+      { id: 'lines', role: 'line' },
+      { id: 'nodes', role: 'node' },
+      { id: 'labels', role: 'label' },
+    ],
+    lineGroups,
+    segments,
+    stationNodes,
+    labels,
+    stationCodeLabels,
+  });
+}

--- a/packages/fs/src/schematicMapGenerator.ts
+++ b/packages/fs/src/schematicMapGenerator.ts
@@ -63,9 +63,17 @@ function effectiveMonthInterval(effectiveDate: SchematicMapEffectiveDate): {
   end: number;
 } {
   const [year, month] = effectiveDate.split('-').map(Number);
+  const endYear = month === 12 ? year + 1 : year;
+  const endMonth = month === 12 ? 1 : month + 1;
+  const formatMonth = (value: number) => value.toString().padStart(2, '0');
+
   return {
-    start: Date.UTC(year, month - 1, 1),
-    end: Date.UTC(year, month, 1),
+    start: timestampForSchematicMapGenerator(
+      `${year}-${formatMonth(month)}-01`,
+    ),
+    end: timestampForSchematicMapGenerator(
+      `${endYear}-${formatMonth(endMonth)}-01`,
+    ),
   };
 }
 
@@ -117,10 +125,186 @@ function lineIdPart(lineId: string): string {
   return lineId.toLowerCase();
 }
 
-function appendUnique(values: string[], value: string): void {
-  if (!values.includes(value)) {
-    values.push(value);
+function compareStationPaths(
+  a: readonly string[],
+  b: readonly string[],
+): number {
+  return a.join('\0').localeCompare(b.join('\0'));
+}
+
+function buildAdjacency(
+  segments: Map<string, { fromStationId: string; toStationId: string }>,
+): Map<string, Set<string>> {
+  const adjacency = new Map<string, Set<string>>();
+  const add = (from: string, to: string) => {
+    const neighbors = adjacency.get(from) ?? new Set<string>();
+    neighbors.add(to);
+    adjacency.set(from, neighbors);
+  };
+
+  for (const segment of segments.values()) {
+    add(segment.fromStationId, segment.toStationId);
+    add(segment.toStationId, segment.fromStationId);
   }
+
+  return adjacency;
+}
+
+function shortestStationPath(
+  adjacency: Map<string, Set<string>>,
+  start: string,
+  end: string,
+): string[] | undefined {
+  const queue = [start];
+  const previous = new Map<string, string | null>([[start, null]]);
+
+  for (let index = 0; index < queue.length; index += 1) {
+    const stationId = queue[index];
+    if (stationId === end) {
+      break;
+    }
+
+    const neighbors = [...(adjacency.get(stationId) ?? [])].sort((a, b) =>
+      a.localeCompare(b),
+    );
+    for (const neighbor of neighbors) {
+      if (previous.has(neighbor)) {
+        continue;
+      }
+      previous.set(neighbor, stationId);
+      queue.push(neighbor);
+    }
+  }
+
+  if (!previous.has(end)) {
+    return undefined;
+  }
+
+  const path: string[] = [];
+  for (
+    let stationId: string | null = end;
+    stationId != null;
+    stationId = previous.get(stationId) ?? null
+  ) {
+    path.unshift(stationId);
+  }
+
+  return path;
+}
+
+function longestStationPath(
+  adjacency: Map<string, Set<string>>,
+  candidates: readonly string[],
+): string[] {
+  const sortedCandidates = [...candidates].sort((a, b) => a.localeCompare(b));
+  let bestPath: string[] = [];
+
+  for (
+    let startIndex = 0;
+    startIndex < sortedCandidates.length;
+    startIndex += 1
+  ) {
+    for (
+      let endIndex = startIndex + 1;
+      endIndex < sortedCandidates.length;
+      endIndex += 1
+    ) {
+      const path = shortestStationPath(
+        adjacency,
+        sortedCandidates[startIndex],
+        sortedCandidates[endIndex],
+      );
+      if (!path) {
+        continue;
+      }
+
+      if (
+        path.length > bestPath.length ||
+        (path.length === bestPath.length &&
+          compareStationPaths(path, bestPath) < 0)
+      ) {
+        bestPath = path;
+      }
+    }
+  }
+
+  return bestPath.length > 0 ? bestPath : sortedCandidates.slice(0, 1);
+}
+
+function appendBranchStations(
+  stationId: string,
+  adjacency: Map<string, Set<string>>,
+  seen: Set<string>,
+  output: string[],
+): void {
+  const neighbors = [...(adjacency.get(stationId) ?? [])].sort((a, b) =>
+    a.localeCompare(b),
+  );
+
+  for (const neighbor of neighbors) {
+    if (seen.has(neighbor)) {
+      continue;
+    }
+
+    seen.add(neighbor);
+    output.push(neighbor);
+    appendBranchStations(neighbor, adjacency, seen, output);
+  }
+}
+
+function deriveLineStationOrder(
+  segments: Map<string, { fromStationId: string; toStationId: string }>,
+  referencePaths: readonly string[][],
+): string[] {
+  const adjacency = buildAdjacency(segments);
+  const stationIds = [...adjacency.keys()].sort((a, b) => a.localeCompare(b));
+  if (stationIds.length <= 1) {
+    return stationIds;
+  }
+
+  const terminals = stationIds.filter(
+    (stationId) => (adjacency.get(stationId)?.size ?? 0) <= 1,
+  );
+  const trunk = longestStationPath(
+    adjacency,
+    terminals.length >= 2 ? terminals : stationIds,
+  );
+  const orientedTrunk = orientStationPath(trunk, referencePaths);
+  const seen = new Set(orientedTrunk);
+  const ordered = [...orientedTrunk];
+
+  for (const stationId of orientedTrunk) {
+    appendBranchStations(stationId, adjacency, seen, ordered);
+  }
+
+  return ordered;
+}
+
+function orientStationPath(
+  path: readonly string[],
+  referencePaths: readonly string[][],
+): string[] {
+  if (path.length <= 1) {
+    return [...path];
+  }
+
+  const firstStationId = path[0];
+  const lastStationId = path[path.length - 1];
+  const sortedReferencePaths = [...referencePaths].sort(
+    (a, b) => b.length - a.length,
+  );
+
+  for (const referencePath of sortedReferencePaths) {
+    const firstIndex = referencePath.indexOf(firstStationId);
+    const lastIndex = referencePath.indexOf(lastStationId);
+    if (firstIndex === -1 || lastIndex === -1) {
+      continue;
+    }
+
+    return firstIndex <= lastIndex ? [...path] : [...path].reverse();
+  }
+
+  return [...path];
 }
 
 function compareByPreferredOrder(order: readonly string[]) {
@@ -211,6 +395,7 @@ function buildActiveTopology(
     string,
     Map<string, { fromStationId: string; toStationId: string }>
   >();
+  const lineRevisionPaths = new Map<string, string[][]>();
   const stationLineIds = new Map<string, Set<string>>();
 
   for (const service of services) {
@@ -226,17 +411,17 @@ function buildActiveTopology(
       }
 
       lineIds.add(service.lineId);
-      const stationsForLine = lineStations.get(service.lineId) ?? [];
-      lineStations.set(service.lineId, stationsForLine);
       const segmentsForLine = lineSegments.get(service.lineId) ?? new Map();
       lineSegments.set(service.lineId, segmentsForLine);
 
       const stationIds = revision.path.stations.map(
         (station) => station.stationId,
       );
+      const revisionPathsForLine = lineRevisionPaths.get(service.lineId) ?? [];
+      revisionPathsForLine.push(stationIds);
+      lineRevisionPaths.set(service.lineId, revisionPathsForLine);
 
       for (const stationId of stationIds) {
-        appendUnique(stationsForLine, stationId);
         const lineIdsForStation = stationLineIds.get(stationId) ?? new Set();
         lineIdsForStation.add(service.lineId);
         stationLineIds.set(stationId, lineIdsForStation);
@@ -251,6 +436,13 @@ function buildActiveTopology(
         }
       }
     }
+  }
+
+  for (const [lineId, segments] of lineSegments) {
+    lineStations.set(
+      lineId,
+      deriveLineStationOrder(segments, lineRevisionPaths.get(lineId) ?? []),
+    );
   }
 
   return {
@@ -534,7 +726,7 @@ export async function generateSchematicMapVersionSnapshot(
     }
 
     return {
-      id: `line_${lineId}`,
+      id: `line_${lineIdPart(lineId)}`,
       lineId,
       displayStatus: 'operational' as const,
       layerId: 'lines',


### PR DESCRIPTION
## Summary

- Add a deterministic schematic map snapshot generator that derives operational topology from active service revisions and applies initial rule/constraint inputs.
- Add `schematic-map generate` and `schematic-map preview` CLI commands so generated snapshots can be written and inspected locally as SVG.
- Render the preview through a HAST/unist tree serialized with `hast-util-to-html`, and source preview line colors from canonical `line.color` data.
- Seed the first `lta-system-map-2011` rule file and `2025-04` map-frame constraint, and document the Phase 3/preview progress.

## Notes

This is a foundation and reviewability PR. The generated preview is intentionally not layout-parity quality yet; it exposes the current generator output so the next PR can focus on 2025-04 layout parity.

Generated snapshot artifacts such as `schematic-map/system/manifest.json`, `schematic-map/system/version/*.json`, and local `preview.svg` files are not included in this commit.

## Validation

- `npm run check`
- `npm run test:fs`
- `npm run test:cli`
- `npm run build:cli`
- `npm run data:validate`
- `npm test`
- Temp real-data generation plus `schematic-map preview 2025-04 --out <tmp>/preview.svg`