### PR TITLE
fix: publish generated schematic map artifacts

### DIFF
--- a/docs/plans/active/schematic-system-map.md
+++ b/docs/plans/active/schematic-system-map.md
@@ -413,6 +413,10 @@ Exit criteria:
   generated snapshots can be inspected locally before `mrtdown-site` has a
   full data-driven renderer. This is review tooling, not the canonical public
   renderer.
+- 2026-05-27: Added archive publication foundation by generating schematic map
+  manifests and version snapshots inside `pages:build` from tracked generator
+  constraints, without treating generated version files as source-controlled
+  canonical data.
 
 ## Decision Log
 

--- a/packages/fs/src/index.test.ts
+++ b/packages/fs/src/index.test.ts
@@ -19,6 +19,7 @@ import {
   createIssueBundle,
   FileStore,
   FileWriteStore,
+  generateSchematicMapPublishedArtifacts,
   generateSchematicMapVersionSnapshot,
   IdGenerator,
   issuePathFromId,
@@ -489,6 +490,63 @@ describe('@mrtdown/fs', () => {
           layoutEngineId: 'lta-system-map-2011',
         },
       ],
+    });
+    await expect(
+      validateDataRoot(dataDir, ['schematic-map']),
+    ).resolves.toMatchObject({
+      ok: true,
+    });
+  });
+
+  it('generates published schematic map artifacts from constraint versions', async () => {
+    const dataDir = await mkdtemp(join(tmpdir(), 'mrtdown-fs-'));
+    await cp(fixtureDataDir, dataDir, { recursive: true });
+    await writeSchematicMapRuleSet(dataDir, {
+      schemaVersion: 1,
+      mapId: 'system',
+      layoutEngineId: 'lta-system-map-2011',
+      lineOrder: ['ISL', 'TKL', 'TWL'],
+    });
+    await writeSchematicMapConstraintSet(dataDir, {
+      schemaVersion: 1,
+      mapId: 'system',
+      effectiveDate: '2026-05',
+      layoutEngineId: 'lta-system-map-2011',
+      constraints: [
+        {
+          id: 'frame_2026_05',
+          type: 'map_frame',
+          frame: { x: 0, y: 0, width: 1200, height: 600 },
+        },
+      ],
+    });
+
+    await expect(
+      generateSchematicMapPublishedArtifacts(dataDir, {
+        generatedAt: '2026-05-27T00:00:00.000Z',
+      }),
+    ).resolves.toEqual({
+      manifest: 'schematic-map/system/manifest.json',
+      snapshots: ['schematic-map/system/version/2026-05.json'],
+    });
+    await expect(readSchematicMapManifest(dataDir)).resolves.toMatchObject({
+      value: {
+        versions: [
+          {
+            effectiveDate: '2026-05',
+            path: 'version/2026-05.json',
+            layoutEngineId: 'lta-system-map-2011',
+          },
+        ],
+      },
+    });
+    await expect(
+      readSchematicMapVersionSnapshot(dataDir, '2026-05'),
+    ).resolves.toMatchObject({
+      value: {
+        effectiveDate: '2026-05',
+        generatedAt: '2026-05-27T00:00:00.000Z',
+      },
     });
     await expect(
       validateDataRoot(dataDir, ['schematic-map']),

--- a/packages/fs/src/schematicMapGenerator.ts
+++ b/packages/fs/src/schematicMapGenerator.ts
@@ -7,6 +7,7 @@ import {
   type SchematicMapLabelSide,
   type SchematicMapLayoutEngineId,
   SchematicMapLayoutEngineIdSchema,
+  type SchematicMapManifestVersion,
   type SchematicMapPoint,
   type SchematicMapRuleSet,
   type SchematicMapSegment,
@@ -19,14 +20,26 @@ import {
 } from '@mrtdown/core';
 import { listEntities } from './entities.js';
 import {
+  listSchematicMapConstraintSetEffectiveDates,
   readSchematicMapConstraintSet,
   readSchematicMapRuleSet,
+  writeSchematicMapManifest,
+  writeSchematicMapVersionSnapshot,
 } from './schematicMaps.js';
 
 export type GenerateSchematicMapVersionSnapshotOptions = {
   effectiveDate: SchematicMapEffectiveDate;
   layoutEngineId?: SchematicMapLayoutEngineId;
   generatedAt?: string;
+};
+
+export type GenerateSchematicMapPublishedArtifactsOptions = {
+  generatedAt?: string;
+};
+
+export type GenerateSchematicMapPublishedArtifactsResult = {
+  manifest: string | null;
+  snapshots: string[];
 };
 
 type ActiveTopology = {
@@ -856,4 +869,48 @@ export async function generateSchematicMapVersionSnapshot(
     labels,
     stationCodeLabels,
   });
+}
+
+export async function generateSchematicMapPublishedArtifacts(
+  dataDir: string,
+  options: GenerateSchematicMapPublishedArtifactsOptions = {},
+): Promise<GenerateSchematicMapPublishedArtifactsResult> {
+  const effectiveDates =
+    await listSchematicMapConstraintSetEffectiveDates(dataDir);
+  if (effectiveDates.length === 0) {
+    return {
+      manifest: null,
+      snapshots: [],
+    };
+  }
+
+  const generatedAt = options.generatedAt ?? new Date().toISOString();
+  const snapshots: string[] = [];
+  const versions: SchematicMapManifestVersion[] = [];
+
+  for (const effectiveDate of effectiveDates) {
+    const snapshot = await generateSchematicMapVersionSnapshot(dataDir, {
+      effectiveDate,
+      generatedAt,
+    });
+    snapshots.push(await writeSchematicMapVersionSnapshot(dataDir, snapshot));
+    versions.push({
+      effectiveDate: snapshot.effectiveDate,
+      path: `version/${snapshot.effectiveDate}.json`,
+      layoutEngineId: snapshot.layoutEngineId,
+    });
+  }
+
+  const manifest = await writeSchematicMapManifest(dataDir, {
+    schemaVersion: 1,
+    mapId: 'system',
+    versions: versions.sort((a, b) =>
+      a.effectiveDate.localeCompare(b.effectiveDate),
+    ),
+  });
+
+  return {
+    manifest,
+    snapshots,
+  };
 }

--- a/scripts/build-pages-artifact.mjs
+++ b/scripts/build-pages-artifact.mjs
@@ -113,6 +113,15 @@ function isExcludedDataSourcePath(sourceDataDir, source) {
   return firstSegment === 'source';
 }
 
+function isGeneratedSchematicMapArtifactPath(sourceDataDir, source) {
+  const relativeSource = relative(sourceDataDir, source);
+  const pathSegments = relativeSource.split(/[\\/]/);
+  return (
+    pathSegments.join('/') === 'schematic-map/system/manifest.json' ||
+    pathSegments.slice(0, 3).join('/') === 'schematic-map/system/version'
+  );
+}
+
 async function buildDataExport(
   sourceDataDir,
   exportDir,
@@ -121,18 +130,20 @@ async function buildDataExport(
 ) {
   assertOutputPath(sourceDataDir, exportDir);
 
-  const validation = await fsPackage.validateDataRoot(sourceDataDir);
-  if (!validation.ok) {
-    throw new Error(validation.errors.join('\n'));
-  }
-
   await mkdir(exportDir, { recursive: true });
   await cp(sourceDataDir, exportDir, {
     recursive: true,
     filter: (source) =>
       !generatedIndexPattern.test(source) &&
-      !isExcludedDataSourcePath(sourceDataDir, source),
+      !isExcludedDataSourcePath(sourceDataDir, source) &&
+      !isGeneratedSchematicMapArtifactPath(sourceDataDir, source),
   });
+
+  await fsPackage.generateSchematicMapPublishedArtifacts(exportDir);
+  const validation = await fsPackage.validateDataRoot(exportDir);
+  if (!validation.ok) {
+    throw new Error(validation.errors.join('\n'));
+  }
 
   const manifest = await fsPackage.buildManifest(exportDir);
   await writeFile(


### PR DESCRIPTION
## Summary

- Generate schematic map manifests and version snapshots during `pages:build` from tracked generator constraints.
- Exclude copied generated schematic artifacts from the Pages export so local untracked snapshots do not become the publication source.
- Add fs coverage for publishing generated schematic map artifacts and log the archive publication foundation in the schematic maps plan.

## Impact

The Pages/archive artifact now publishes validated schematic map data deterministically without requiring generated `data/schematic-map/system/version/*.json` files to be committed.

## Plan alignment

This is a narrow publication-foundation slice, not a declaration that Phase 8 is complete or that later Phase 7/8 coordination work is done. It follows the plan decision that generated snapshots are publication artifacts produced from generator inputs rather than source-controlled canonical data.

## Validation

- `npm run test:fs`
- `npm run build:fs`
- `npm run pages:build`
- `npm run data:validate`
- `npm run check`