### PR TITLE
docs: plan station data extensions

### DIFF
--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -13,6 +13,10 @@ plan.
   evidence ingest boundaries.
 - [Schematic system map generation](active/schematic-system-map.md): canonical
   schematic map generator, rule schema, validation, and publication.
+- [Station first and last train data](active/station-first-last-train-data.md):
+  embedded station timing data keyed by full scheduled service patterns.
+- [Station layout data](active/station-layout-data.md): embedded current-state
+  station layout, platform, door-anchor, and transfer path data.
 
 ## Completed
 

--- a/docs/plans/active/station-first-last-train-data.md
+++ b/docs/plans/active/station-first-last-train-data.md
@@ -1,0 +1,234 @@
+# Station First And Last Train Data Plan
+
+## Context
+
+Station records currently do not store published first and last train timings.
+Service records already describe ordered station paths and operating windows,
+but the service catalog is intentionally incomplete: it does not yet include
+every full scheduled stopping pattern, including short workings that appear in
+first and last train tables.
+
+This plan adds current first/last train timing data directly to
+`data/station/*.json`. Timing rows reference `serviceId`, where a service is the
+full scheduled stopping pattern. A last-train short working should therefore be
+represented as a distinct service rather than as a destination override on the
+timing row.
+
+Related references:
+
+- `packages/core/src/schema/Station.ts`
+- `packages/core/src/schema/Service.ts`
+- `packages/fs/src/validate.ts`
+- `docs/plans/active/station-layout-data.md`
+- `docs/plans/active/gtfs-static-realtime.md`
+
+## Goals
+
+- Store current published first and last train timings in station records.
+- Reference full scheduled stopping patterns through `serviceId`.
+- Support rows that have only a first train, only a last train, or both.
+- Support calendar categories used by operator timing tables.
+- Validate that the station appears in every referenced service path.
+- Validate platform coverage when station layout data exists.
+- Keep the shape compatible with later GTFS timetable or frequency generation.
+
+## Non-Goals
+
+- This plan does not store source or provenance fields on timing data.
+- This plan does not introduce timing revision history in the first
+  implementation.
+- This plan does not model temporary early closures, late openings, or holiday
+  extensions as baseline first/last train data.
+- This plan does not require the full scheduled service catalog to be completed
+  before one station or one line slice can be seeded.
+- This plan does not generate complete stop-by-stop timetables.
+
+## Service Semantics
+
+For first/last train data, `serviceId` must mean a full scheduled stopping
+pattern:
+
+- direction;
+- branch;
+- stopping sequence;
+- terminal;
+- recurring public short working, when relevant.
+
+Do not add `terminatingAtStationId` to timing rows. If a first or last train
+terminates before the normal line terminal, add or reference a service whose
+path ends at that station.
+
+Example services:
+
+- `TEL_MAIN_N`: northbound main TEL stopping pattern to the normal terminal.
+- `TEL_MAIN_N_TO_ORC`: northbound short-working pattern ending at Orchard.
+
+The exact naming convention can be settled when the expanded service catalog is
+implemented, but the semantic boundary should be documented before timing data
+lands.
+
+## Station Record Shape
+
+Add an optional `firstLastTrain` object to `StationSchema`:
+
+```json
+{
+  "firstLastTrain": {
+    "entries": [
+      {
+        "serviceId": "TEL_MAIN_N",
+        "calendar": "weekday",
+        "firstTrain": "06:07",
+        "lastTrain": "00:07"
+      },
+      {
+        "serviceId": "TEL_MAIN_N_TO_ORC",
+        "calendar": "weekday",
+        "firstTrain": null,
+        "lastTrain": "00:25"
+      }
+    ]
+  }
+}
+```
+
+Rules:
+
+- `serviceId` is required.
+- `calendar` is required.
+- `firstTrain` and `lastTrain` are nullable, but at least one must be present.
+- Times are local operating-day times in Singapore time. Values after midnight
+  should use the displayed clock time, such as `00:25`, unless GTFS generation
+  later needs a derived service-day offset.
+
+## Calendar Categories
+
+Start with the categories used by published operator tables:
+
+- `weekday`
+- `saturday`
+- `sunday_public_holiday`
+- `weekday_saturday`
+- `daily`
+
+Add more categories only when a published table requires them. Candidate future
+categories:
+
+- `friday_saturday_eve_public_holiday`
+- `school_holiday`
+- `special`
+
+Calendar categories should be data categories first. Any mapping to GTFS
+`calendar.txt` or `calendar_dates.txt` can happen in generator metadata later.
+
+## Platform Relationship
+
+When a station also has `layout.platforms`, first/last train validation should
+check whether each timing `serviceId` is served by at least one platform in the
+same station.
+
+This keeps timing rows simple:
+
+```json
+{
+  "serviceId": "TEL_MAIN_N",
+  "calendar": "weekday",
+  "firstTrain": "06:07",
+  "lastTrain": "00:07"
+}
+```
+
+The platform can be derived from:
+
+```json
+{
+  "id": "OTP_TEL_E",
+  "serviceIds": ["TEL_MAIN_N"]
+}
+```
+
+If later data proves that the same service uses different platforms by time of
+day, the exception should be represented in the service catalog or a narrowly
+scoped timing-platform override, not added prematurely.
+
+## Validation
+
+Add validation that catches:
+
+- timing `serviceId` values that do not exist;
+- timing rows where the station is not in the referenced service path;
+- rows with both `firstTrain` and `lastTrain` set to `null`;
+- invalid local time values;
+- duplicate rows for the same `serviceId` and `calendar`;
+- timing rows whose `serviceId` is not present on any station layout platform
+  when layout data exists;
+- stations with no `firstLastTrain` continuing to validate.
+
+## Phases
+
+### Phase 1: Schema
+
+- Add `firstLastTrain` schemas to `packages/core/src/schema/Station.ts`.
+- Add a reusable enum or schema for first/last train calendar categories.
+- Keep the field optional so existing station data validates unchanged.
+
+Exit criteria:
+
+- Existing station JSON validates unchanged.
+- Fixture station records can include first-only, last-only, and first-plus-last
+  rows.
+
+### Phase 2: Service Catalog Semantics
+
+- Document that service records represent full scheduled stopping patterns.
+- Add naming guidance for short workings and branch-specific patterns.
+- Add fixture services for at least one normal through service and one short
+  working.
+
+Exit criteria:
+
+- First/last timing examples do not need destination fields.
+- Validation can derive terminal and direction from the referenced service.
+
+### Phase 3: Repository Validation
+
+- Add timing validation in `packages/fs/src/validate.ts`.
+- Validate service existence and station membership.
+- Add cross-validation with `layout.platforms[].serviceIds` when layout exists.
+- Add deterministic tests for invalid references, invalid time rows, duplicate
+  rows, and missing platform coverage.
+
+Exit criteria:
+
+- Broken first/last train rows fail `npm run data:validate`.
+- Stations without timing data remain valid.
+
+### Phase 4: Seed One Slice
+
+- Seed one small reviewed slice first, such as one station across all current
+  services or one line across several representative stations.
+- Include at least one short-working service if the published table has a
+  last-train row for it.
+- Keep the first data PR small enough for manual timetable review.
+
+Exit criteria:
+
+- The seeded slice demonstrates normal through service and short-working timing
+  rows.
+- The service catalog contains the stopping patterns needed by that slice.
+
+### Phase 5: GTFS And Publication
+
+- Decide whether first/last train data feeds timetable-like GTFS trips, a
+  validation report, or both.
+- Keep baseline first/last timings separate from temporary service-change issue
+  evidence.
+- Include timing coverage in generated Pages metadata once enough stations are
+  populated for consumers.
+
+Exit criteria:
+
+- Downstream consumers can discover which station records include first/last
+  train data.
+- GTFS generation can use timing data without inventing destination semantics
+  outside `serviceId`.

--- a/docs/plans/active/station-layout-data.md
+++ b/docs/plans/active/station-layout-data.md
@@ -1,0 +1,291 @@
+# Station Layout Data Plan
+
+## Context
+
+Station records currently contain identity, translated names, coordinates,
+station codes, landmarks, and town membership. They do not yet describe the
+current physical station layout: levels, platforms, platform-to-service
+mapping, doors, vertical circulation, or interchange movement inside the paid
+area.
+
+This plan adds current-state station layout data directly to
+`data/station/*.json`. Layout is station-owned data for authoring purposes, so
+it should stay embedded with the station record instead of moving to a separate
+collection.
+
+Related references:
+
+- `packages/core/src/schema/Station.ts`
+- `packages/core/src/schema/Service.ts`
+- `packages/fs/src/validate.ts`
+- `docs/plans/active/gtfs-static-realtime.md`
+
+## Goals
+
+- Model current station levels and public platforms inside station records.
+- Map each platform to the full scheduled service patterns that normally board
+  from it.
+- Record useful door-level anchors without enumerating every door by default.
+- Record stairs, escalators, lifts, travellators, and other access points near
+  platform doors.
+- Record interchange and transfer paths between platforms or access points.
+- Keep the shape compatible with later GTFS `stops.txt`, `levels.txt`,
+  `pathways.txt`, and `transfers.txt` generation.
+- Add deterministic validation for references and common authoring mistakes.
+
+## Non-Goals
+
+- This plan does not track historical station layout revisions.
+- This plan does not store source or provenance fields on station layout data.
+- This plan does not require every platform door to be enumerated when a door
+  count and nearest-door anchors are enough.
+- This plan does not attempt detailed CAD geometry or public wayfinding map
+  rendering.
+- This plan does not model temporary works, temporary platform closures, or
+  incident-specific access restrictions as static station layout.
+
+## Station Record Shape
+
+Add an optional `layout` object to `StationSchema`:
+
+```json
+{
+  "layout": {
+    "levels": [],
+    "platforms": [],
+    "transferPaths": []
+  }
+}
+```
+
+Layout data is current state. If a station changes, update the embedded layout
+to the new current state in the same way the canonical station record is
+updated.
+
+## Levels
+
+Levels identify station floors for platforms and access points.
+
+```json
+{
+  "id": "B2",
+  "index": -2,
+  "name": {
+    "en-SG": "EWL and TEL platforms",
+    "zh-Hans": null,
+    "ms": null,
+    "ta": null
+  }
+}
+```
+
+Rules:
+
+- `id` is station-local and stable enough for references inside the station
+  record.
+- `index` is relative floor order: street level can be `0` or `1`, underground
+  levels are negative, elevated levels are positive.
+- `name` uses the existing translations shape.
+
+## Platforms
+
+Platforms represent public boarding areas. They should reference full scheduled
+service patterns through `serviceIds`.
+
+```json
+{
+  "id": "OTP_EWL_A",
+  "label": "A",
+  "lineId": "EWL",
+  "levelId": "B2",
+  "serviceIds": ["EWL_MAIN_E"],
+  "doorCount": 24,
+  "accessPoints": []
+}
+```
+
+Rules:
+
+- Use `serviceIds`, not `towardsStationId`. The service path is the source of
+  truth for direction, stopping pattern, and terminal.
+- Use an array because platforms can host multiple scheduled patterns.
+- `doorCount` is preferred over enumerating every door when doors have no
+  individual metadata.
+- Keep `lineId` for simple validation and authoring, even though it can be
+  derived from services.
+
+## Access Points
+
+Access points describe useful platform features for passenger routing and
+wayfinding. They are anchored to doors when possible.
+
+```json
+{
+  "id": "OTP_EWL_A_ESC_01",
+  "kind": "escalator",
+  "nearestDoor": "12",
+  "position": "middle",
+  "connectsToLevelId": "B1",
+  "direction": "up"
+}
+```
+
+Initial `kind` values:
+
+- `stairs`
+- `escalator`
+- `lift`
+- `travellator`
+- `ramp`
+- `gate`
+- `concourse_link`
+- `other`
+
+Initial `position` values:
+
+- `front`
+- `middle`
+- `rear`
+- `unknown`
+
+Rules:
+
+- `nearestDoor` is a string because public door labels may not always be plain
+  numbers.
+- `direction` is optional and should be used only where it is stable and
+  meaningful: `up`, `down`, `bidirectional`, or `unknown`.
+- Full `doors` arrays can be added later if doors need individual metadata.
+
+## Transfer Paths
+
+Transfer paths describe public movement between platforms or access points.
+
+```json
+{
+  "id": "OTP_EWL_TEL_PAID_LINK",
+  "from": {
+    "kind": "platform",
+    "id": "OTP_EWL_A"
+  },
+  "to": {
+    "kind": "platform",
+    "id": "OTP_TEL_E"
+  },
+  "paidArea": true,
+  "modes": ["walk", "escalator"],
+  "levelChange": 0,
+  "classification": "short",
+  "estimatedTraversalSeconds": null,
+  "distanceMeters": null
+}
+```
+
+Initial endpoint `kind` values:
+
+- `platform`
+- `access_point`
+- `level`
+
+Initial `modes` values:
+
+- `walk`
+- `stairs`
+- `escalator`
+- `lift`
+- `travellator`
+- `ramp`
+
+Initial `classification` values:
+
+- `same_platform`: same platform or cross-platform transfer.
+- `short`: expected to be under 2 minutes.
+- `medium`: expected to be 2 to 5 minutes.
+- `long`: expected to be 5 to 10 minutes.
+- `out_of_station`: public out-of-station interchange.
+- `not_recommended`: physically possible but poor passenger routing.
+- `restricted`: not normally available to the public.
+- `unknown`: usable when the path is known but distance is not.
+
+The classification is intentionally coarse. It is useful for routing and user
+interfaces without pretending that all stations have measured distance data.
+
+## Validation
+
+Add validation that catches:
+
+- duplicate level, platform, access point, and transfer path ids within a
+  station;
+- platform `lineId` values that do not exist;
+- platform `levelId` values that do not exist in `layout.levels`;
+- platform `serviceIds` values that do not exist;
+- services whose `lineId` differs from the platform `lineId`;
+- transfer endpoints that do not reference an existing level, platform, or
+  access point;
+- access point `connectsToLevelId` values that do not exist;
+- invalid `nearestDoor` values when `doorCount` is present and the door label
+  is numeric;
+- stations with no `layout` continuing to validate.
+
+## Phases
+
+### Phase 1: Schema
+
+- Add layout schemas to `packages/core/src/schema/Station.ts`.
+- Keep all new station fields optional to avoid a full-network migration.
+- Export inferred TypeScript types from the core package.
+
+Exit criteria:
+
+- Existing station JSON validates unchanged.
+- New fixture station records can exercise levels, platforms, access points,
+  and transfer paths.
+
+### Phase 2: Repository Validation
+
+- Add layout reference validation in `packages/fs/src/validate.ts`.
+- Add tests for missing references, duplicate ids, service-line mismatches, and
+  numeric door bounds.
+- Keep validation deterministic and offline.
+
+Exit criteria:
+
+- Broken layout references fail `npm run data:validate`.
+- Stations without layout data remain valid.
+
+### Phase 3: Fixtures
+
+- Extend generated fixture data with:
+  - a simple non-interchange station;
+  - a same-platform or cross-platform interchange;
+  - a complex interchange with multiple levels and access-point anchored
+    transfer paths.
+
+Exit criteria:
+
+- Package and CLI tests cover representative layout shapes.
+
+### Phase 4: Seed Real Data
+
+- Seed one reviewed station first, preferably `OTP`, because it covers three
+  lines, multiple platform levels, door-anchored access points, and multiple
+  transfer path classifications.
+- Keep the first data PR small enough for manual review.
+
+Exit criteria:
+
+- One real station has useful current-state layout data.
+- Validation catches intentional broken edits in tests.
+
+### Phase 5: GTFS Mapping
+
+- Map station-level stops and platform child stops without changing existing
+  station ids.
+- Map levels to GTFS `levels.txt`.
+- Map access points and transfer paths to GTFS `pathways.txt` where useful.
+- Map coarse transfer rules to GTFS `transfers.txt` where they have a clear
+  consumer-facing meaning.
+
+Exit criteria:
+
+- GTFS export can include platform and pathway data for stations that have
+  layout data while omitting it for stations that do not.


### PR DESCRIPTION
## Summary
- add an active plan for embedded current-state station layout data
- add an active plan for embedded first/last train timing data keyed by full scheduled service patterns
- link both plans from the plans index

## Testing
- npm run check:docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added planning documentation for upcoming station data features, including management of first and last train timings and station layout information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/foldaway/mrtdown-data/pull/277?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->