### PR TITLE
feat: model JRL service revisions

### DIFF
--- a/data/line/JRL.json
+++ b/data/line/JRL.json
@@ -8,7 +8,7 @@
   },
   "type": "mrt.medium",
   "color": "#0099aa",
-  "startedAt": "2027-12-31",
+  "startedAt": "2028-06-30",
   "operatingHours": {
     "weekdays": {
       "start": "05:30",

--- a/data/service/JRL_WEST.json
+++ b/data/service/JRL_WEST.json
@@ -9,8 +9,8 @@
     },
     "revisions": [
         {
-            "id": "r_2027_stage_1",
-            "startAt": "2027-12-31",
+            "id": "r_2028_stage_1",
+            "startAt": "2028-06-30",
             "endAt": "2029-12-31",
             "path": {
                 "stations": [
@@ -106,7 +106,7 @@
         {
             "id": "r_2029_stage_3",
             "startAt": "2029-12-31",
-            "endAt": null,
+            "endAt": "2035-01-01",
             "path": {
                 "stations": [
                     {
@@ -232,6 +232,165 @@
                     {
                         "stationId": "TGH",
                         "displayCode": "JS3"
+                    },
+                    {
+                        "stationId": "CKW",
+                        "displayCode": "JS2"
+                    },
+                    {
+                        "stationId": "CCK",
+                        "displayCode": "JS1"
+                    }
+                ]
+            },
+            "operatingHours": {
+                "weekdays": {
+                    "start": "05:30",
+                    "end": "00:00"
+                },
+                "weekends": {
+                    "start": "05:30",
+                    "end": "00:00"
+                }
+            }
+        },
+        {
+            "id": "r_2035_js2a_infill",
+            "startAt": "2035-01-01",
+            "endAt": null,
+            "path": {
+                "stations": [
+                    {
+                        "stationId": "CCK",
+                        "displayCode": "JS1"
+                    },
+                    {
+                        "stationId": "CKW",
+                        "displayCode": "JS2"
+                    },
+                    {
+                        "stationId": "JS2A",
+                        "displayCode": "JS2A"
+                    },
+                    {
+                        "stationId": "TGH",
+                        "displayCode": "JS3"
+                    },
+                    {
+                        "stationId": "HGK",
+                        "displayCode": "JS4"
+                    },
+                    {
+                        "stationId": "CPN",
+                        "displayCode": "JS5"
+                    },
+                    {
+                        "stationId": "JRW",
+                        "displayCode": "JS6"
+                    },
+                    {
+                        "stationId": "BHJ",
+                        "displayCode": "JS7"
+                    },
+                    {
+                        "stationId": "BNL",
+                        "displayCode": "JS8"
+                    },
+                    {
+                        "stationId": "ETP",
+                        "displayCode": "JS9"
+                    },
+                    {
+                        "stationId": "TKN",
+                        "displayCode": "JS10"
+                    },
+                    {
+                        "stationId": "JRH",
+                        "displayCode": "JS11"
+                    },
+                    {
+                        "stationId": "JRP",
+                        "displayCode": "JS12"
+                    },
+                    {
+                        "stationId": "JRH",
+                        "displayCode": "JS11"
+                    },
+                    {
+                        "stationId": "TKN",
+                        "displayCode": "JS10"
+                    },
+                    {
+                        "stationId": "ETP",
+                        "displayCode": "JS9"
+                    },
+                    {
+                        "stationId": "BNL",
+                        "displayCode": "JS8"
+                    },
+                    {
+                        "stationId": "BHJ",
+                        "displayCode": "JS7"
+                    },
+                    {
+                        "stationId": "GKP",
+                        "displayCode": "JW1"
+                    },
+                    {
+                        "stationId": "TWS",
+                        "displayCode": "JW2"
+                    },
+                    {
+                        "stationId": "NYG",
+                        "displayCode": "JW3"
+                    },
+                    {
+                        "stationId": "NYC",
+                        "displayCode": "JW4"
+                    },
+                    {
+                        "stationId": "PKH",
+                        "displayCode": "JW5"
+                    },
+                    {
+                        "stationId": "NYC",
+                        "displayCode": "JW4"
+                    },
+                    {
+                        "stationId": "NYG",
+                        "displayCode": "JW3"
+                    },
+                    {
+                        "stationId": "TWS",
+                        "displayCode": "JW2"
+                    },
+                    {
+                        "stationId": "GKP",
+                        "displayCode": "JW1"
+                    },
+                    {
+                        "stationId": "BHJ",
+                        "displayCode": "JS7"
+                    },
+                    {
+                        "stationId": "JRW",
+                        "displayCode": "JS6"
+                    },
+                    {
+                        "stationId": "CPN",
+                        "displayCode": "JS5"
+                    },
+                    {
+                        "stationId": "HGK",
+                        "displayCode": "JS4"
+                    },
+                    {
+                        "stationId": "TGH",
+                        "displayCode": "JS3"
+                    },
+                    {
+                        "stationId": "JS2A",
+                        "displayCode": "JS2A"
                     },
                     {
                         "stationId": "CKW",

--- a/data/station/BHJ.json
+++ b/data/station/BHJ.json
@@ -14,7 +14,7 @@
     {
       "lineId": "JRL",
       "code": "JS7",
-      "startedAt": "2027-12-31T00:00:00Z",
+      "startedAt": "2028-06-30T00:00:00Z",
       "endedAt": null,
       "structureType": "elevated"
     }

--- a/data/station/BNL.json
+++ b/data/station/BNL.json
@@ -21,7 +21,7 @@
     {
       "lineId": "JRL",
       "code": "JS8",
-      "startedAt": "2027-12-31T00:00:00Z",
+      "startedAt": "2028-06-30T00:00:00Z",
       "endedAt": null,
       "structureType": "elevated"
     }

--- a/data/station/CCK.json
+++ b/data/station/CCK.json
@@ -28,7 +28,7 @@
     {
       "lineId": "JRL",
       "code": "JS1",
-      "startedAt": "2027-12-31T00:00:00Z",
+      "startedAt": "2028-06-30T00:00:00Z",
       "endedAt": null,
       "structureType": "elevated"
     }

--- a/data/station/CKW.json
+++ b/data/station/CKW.json
@@ -14,7 +14,7 @@
     {
       "lineId": "JRL",
       "code": "JS2",
-      "startedAt": "2027-12-31T00:00:00Z",
+      "startedAt": "2028-06-30T00:00:00Z",
       "endedAt": null,
       "structureType": "elevated"
     }

--- a/data/station/CPN.json
+++ b/data/station/CPN.json
@@ -14,7 +14,7 @@
     {
       "lineId": "JRL",
       "code": "JS5",
-      "startedAt": "2027-12-31T00:00:00Z",
+      "startedAt": "2028-06-30T00:00:00Z",
       "endedAt": null,
       "structureType": "elevated"
     }

--- a/data/station/GKP.json
+++ b/data/station/GKP.json
@@ -14,7 +14,7 @@
     {
       "lineId": "JRL",
       "code": "JW1",
-      "startedAt": "2027-12-31T00:00:00Z",
+      "startedAt": "2028-06-30T00:00:00Z",
       "endedAt": null,
       "structureType": "elevated"
     }

--- a/data/station/HGK.json
+++ b/data/station/HGK.json
@@ -14,7 +14,7 @@
     {
       "lineId": "JRL",
       "code": "JS4",
-      "startedAt": "2027-12-31T00:00:00Z",
+      "startedAt": "2028-06-30T00:00:00Z",
       "endedAt": null,
       "structureType": "elevated"
     }

--- a/data/station/JRW.json
+++ b/data/station/JRW.json
@@ -14,7 +14,7 @@
     {
       "lineId": "JRL",
       "code": "JS6",
-      "startedAt": "2027-12-31T00:00:00Z",
+      "startedAt": "2028-06-30T00:00:00Z",
       "endedAt": null,
       "structureType": "elevated"
     }

--- a/data/station/JS2A.json
+++ b/data/station/JS2A.json
@@ -1,0 +1,26 @@
+{
+  "id": "JS2A",
+  "name": {
+    "en-SG": "JS2A",
+    "zh-Hans": null,
+    "ms": null,
+    "ta": null
+  },
+  "geo": {
+    "latitude": 1.37272,
+    "longitude": 103.735046
+  },
+  "stationCodes": [
+    {
+      "lineId": "JRL",
+      "code": "JS2A",
+      "startedAt": "2035-01-01T00:00:00Z",
+      "endedAt": null,
+      "structureType": "elevated"
+    }
+  ],
+  "landmarkIds": [
+    "tengah-forest-town"
+  ],
+  "townId": "tengah"
+}

--- a/data/station/JUR.json
+++ b/data/station/JUR.json
@@ -28,7 +28,7 @@
     {
       "lineId": "JRL",
       "code": "JE5",
-      "startedAt": "2027-12-31T00:00:00Z",
+      "startedAt": "2028-12-31T00:00:00Z",
       "endedAt": null,
       "structureType": "elevated"
     }

--- a/data/station/TGH.json
+++ b/data/station/TGH.json
@@ -14,7 +14,7 @@
     {
       "lineId": "JRL",
       "code": "JS3",
-      "startedAt": "2027-12-31T00:00:00Z",
+      "startedAt": "2028-06-30T00:00:00Z",
       "endedAt": null,
       "structureType": "elevated"
     }

--- a/data/station/TWS.json
+++ b/data/station/TWS.json
@@ -14,7 +14,7 @@
     {
       "lineId": "JRL",
       "code": "JW2",
-      "startedAt": "2027-12-31T00:00:00Z",
+      "startedAt": "2028-06-30T00:00:00Z",
       "endedAt": null,
       "structureType": "elevated"
     }


### PR DESCRIPTION
## Summary

- update JRL Stage 1 line, service, and station activation dates to the LTA-announced mid-2028 target
- add a JS2A station placeholder record for the mid-2030s infill station
- add a post-infill JRL West service revision that inserts JS2A between JS2 and JS3

## Notes

LTA has announced the JRL staging and JS2A infill timing, but not exact scheduled train working patterns. This PR models the announced topology and service revision timeline in the existing canonical data format.

## Validation

- `npm run data:validate`