### PR TITLE
feat: add schematic map generator diff

### DIFF
--- a/docs/plans/active/schematic-system-map.md
+++ b/docs/plans/active/schematic-system-map.md
@@ -420,6 +420,10 @@ Exit criteria:
 - 2026-05-28: Began Phase 5 review tooling with `schematic-map diff` for
   semantic snapshot comparison across layers, line groups, stations, segments,
   labels, station-code labels, and coordinate-class deltas.
+- 2026-05-30: Extended Phase 5 review tooling with
+  `schematic-map generator-diff` for comparing source generator inputs across
+  two constraint effective dates, including rule-set identity, line-order
+  changes, added/removed/changed constraints, and constraint-type deltas.
 
 ## Decision Log
 

--- a/packages/cli/src/commands/schematicMap.ts
+++ b/packages/cli/src/commands/schematicMap.ts
@@ -237,6 +237,21 @@ function constraintTypeDelta(
   };
 }
 
+function effectiveLineOrderFromInputs(
+  ruleSet: SchematicMapRuleSet,
+  constraintSet: SchematicMapConstraintSet,
+): string[] {
+  let lineOrder: string[] | undefined;
+
+  for (const constraint of constraintSet.constraints) {
+    if (constraint.type === 'line_order') {
+      lineOrder = constraint.lineIds;
+    }
+  }
+
+  return lineOrder ?? ruleSet.lineOrder;
+}
+
 function mapById<T extends { id: string }>(
   items: readonly T[],
 ): Map<string, T> {
@@ -571,6 +586,11 @@ function diffSchematicMapGeneratorInputs(
   const toConstraintTypeCounts = countConstraintTypes(
     toConstraintSet.constraints,
   );
+  const fromLineOrder = effectiveLineOrderFromInputs(
+    fromRuleSet,
+    fromConstraintSet,
+  );
+  const toLineOrder = effectiveLineOrderFromInputs(toRuleSet, toConstraintSet);
 
   return {
     from: fromConstraintSet.effectiveDate,
@@ -583,10 +603,9 @@ function diffSchematicMapGeneratorInputs(
     },
     rules: {
       changed: stableJson(fromRuleSet) !== stableJson(toRuleSet),
-      lineOrderChanged:
-        stableJson(fromRuleSet.lineOrder) !== stableJson(toRuleSet.lineOrder),
-      fromLineOrder: fromRuleSet.lineOrder,
-      toLineOrder: toRuleSet.lineOrder,
+      lineOrderChanged: stableJson(fromLineOrder) !== stableJson(toLineOrder),
+      fromLineOrder,
+      toLineOrder,
     },
     constraints: {
       added: constraintIds.added,

--- a/packages/cli/src/commands/schematicMap.ts
+++ b/packages/cli/src/commands/schematicMap.ts
@@ -1,11 +1,13 @@
 import { resolve } from 'node:path';
 import {
   type SchematicMapConstraint,
+  type SchematicMapConstraintSet,
   type SchematicMapCoordinateMetadata,
   SchematicMapEffectiveDateSchema,
   SchematicMapLayoutEngineIdSchema,
   type SchematicMapManifest,
   type SchematicMapManifestVersion,
+  type SchematicMapRuleSet,
   type SchematicMapVersionSnapshot,
 } from '@mrtdown/core';
 import {
@@ -120,6 +122,30 @@ type SchematicMapSemanticDiff = {
   };
 };
 
+type SchematicMapGeneratorDiff = {
+  from: string;
+  to: string;
+  layoutEngine: {
+    changed: boolean;
+    from: string;
+    to: string;
+  };
+  rules: {
+    changed: boolean;
+    lineOrderChanged: boolean;
+    fromLineOrder: string[];
+    toLineOrder: string[];
+  };
+  constraints: IdDiff & {
+    changed: string[];
+    byType: {
+      from: ConstraintTypeCounts;
+      to: ConstraintTypeCounts;
+      delta: ConstraintTypeCounts;
+    };
+  };
+};
+
 function createCoordinateClassCounts(): CoordinateClassCounts {
   return {
     artifact: 0,
@@ -195,6 +221,20 @@ function countConstraintTypes(
       station_anchor: 0,
     },
   );
+}
+
+function constraintTypeDelta(
+  from: ConstraintTypeCounts,
+  to: ConstraintTypeCounts,
+): ConstraintTypeCounts {
+  return {
+    interchange_hint: to.interchange_hint - from.interchange_hint,
+    label_hint: to.label_hint - from.label_hint,
+    line_order: to.line_order - from.line_order,
+    map_frame: to.map_frame - from.map_frame,
+    segment_route_hint: to.segment_route_hint - from.segment_route_hint,
+    station_anchor: to.station_anchor - from.station_anchor,
+  };
 }
 
 function mapById<T extends { id: string }>(
@@ -512,6 +552,58 @@ function diffSchematicMapSnapshots(
       from: fromCoordinateCounts,
       to: toCoordinateCounts,
       delta: coordinateClassDelta(fromCoordinateCounts, toCoordinateCounts),
+    },
+  };
+}
+
+function diffSchematicMapGeneratorInputs(
+  fromConstraintSet: SchematicMapConstraintSet,
+  toConstraintSet: SchematicMapConstraintSet,
+  fromRuleSet: SchematicMapRuleSet,
+  toRuleSet: SchematicMapRuleSet,
+): SchematicMapGeneratorDiff {
+  const fromConstraints = mapById(fromConstraintSet.constraints);
+  const toConstraints = mapById(toConstraintSet.constraints);
+  const constraintIds = diffIds(fromConstraints.keys(), toConstraints.keys());
+  const fromConstraintTypeCounts = countConstraintTypes(
+    fromConstraintSet.constraints,
+  );
+  const toConstraintTypeCounts = countConstraintTypes(
+    toConstraintSet.constraints,
+  );
+
+  return {
+    from: fromConstraintSet.effectiveDate,
+    to: toConstraintSet.effectiveDate,
+    layoutEngine: {
+      changed:
+        fromConstraintSet.layoutEngineId !== toConstraintSet.layoutEngineId,
+      from: fromConstraintSet.layoutEngineId,
+      to: toConstraintSet.layoutEngineId,
+    },
+    rules: {
+      changed: stableJson(fromRuleSet) !== stableJson(toRuleSet),
+      lineOrderChanged:
+        stableJson(fromRuleSet.lineOrder) !== stableJson(toRuleSet.lineOrder),
+      fromLineOrder: fromRuleSet.lineOrder,
+      toLineOrder: toRuleSet.lineOrder,
+    },
+    constraints: {
+      added: constraintIds.added,
+      removed: constraintIds.removed,
+      changed: constraintIds.shared.filter(
+        (id) =>
+          stableJson(fromConstraints.get(id)) !==
+          stableJson(toConstraints.get(id)),
+      ),
+      byType: {
+        from: fromConstraintTypeCounts,
+        to: toConstraintTypeCounts,
+        delta: constraintTypeDelta(
+          fromConstraintTypeCounts,
+          toConstraintTypeCounts,
+        ),
+      },
     },
   };
 }
@@ -913,6 +1005,51 @@ export async function runSchematicMap(
     return 0;
   }
 
+  if (action === 'generator-diff') {
+    const fromId = args.shift();
+    const toId = args.shift();
+    if (!fromId || !toId) {
+      throw new Error(
+        'schematic-map generator-diff requires from YYYY-MM and to YYYY-MM',
+      );
+    }
+
+    const [fromConstraintSet, toConstraintSet] = await Promise.all([
+      readSchematicMapConstraintSet(
+        globals.dataDir,
+        SchematicMapEffectiveDateSchema.parse(fromId),
+      ),
+      readSchematicMapConstraintSet(
+        globals.dataDir,
+        SchematicMapEffectiveDateSchema.parse(toId),
+      ),
+    ]);
+    const [fromRuleSet, toRuleSet] = await Promise.all([
+      readSchematicMapRuleSet(
+        globals.dataDir,
+        fromConstraintSet.value.layoutEngineId,
+      ),
+      readSchematicMapRuleSet(
+        globals.dataDir,
+        toConstraintSet.value.layoutEngineId,
+      ),
+    ]);
+
+    io.stdout(
+      JSON.stringify(
+        diffSchematicMapGeneratorInputs(
+          fromConstraintSet.value,
+          toConstraintSet.value,
+          fromRuleSet.value,
+          toRuleSet.value,
+        ),
+        null,
+        2,
+      ),
+    );
+    return 0;
+  }
+
   if (action === 'generate') {
     const id = args.shift();
     if (!id) {
@@ -976,6 +1113,6 @@ export async function runSchematicMap(
   }
 
   throw new Error(
-    'schematic-map requires list, show, select, stats, diff, generate, or preview',
+    'schematic-map requires list, show, select, stats, diff, generator-diff, generate, or preview',
   );
 }

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -725,6 +725,11 @@ describe('@mrtdown/cli', () => {
           side: 'bottom',
         },
         {
+          id: 'line_order_2025_05',
+          type: 'line_order',
+          lineIds: ['TKL', 'ISL'],
+        },
+        {
           id: 'segment_ket_hku',
           type: 'segment_route_hint',
           lineId: 'ISL',
@@ -760,12 +765,12 @@ describe('@mrtdown/cli', () => {
       },
       rules: {
         changed: false,
-        lineOrderChanged: false,
+        lineOrderChanged: true,
         fromLineOrder: ['ISL'],
-        toLineOrder: ['ISL'],
+        toLineOrder: ['TKL', 'ISL'],
       },
       constraints: {
-        added: ['label_ket', 'segment_ket_hku'],
+        added: ['label_ket', 'line_order_2025_05', 'segment_ket_hku'],
         removed: ['anchor_ket'],
         changed: ['frame_2025_04'],
         byType: {
@@ -780,7 +785,7 @@ describe('@mrtdown/cli', () => {
           to: {
             interchange_hint: 0,
             label_hint: 1,
-            line_order: 0,
+            line_order: 1,
             map_frame: 1,
             segment_route_hint: 1,
             station_anchor: 0,
@@ -788,7 +793,7 @@ describe('@mrtdown/cli', () => {
           delta: {
             interchange_hint: 0,
             label_hint: 1,
-            line_order: 0,
+            line_order: 1,
             map_frame: 0,
             segment_route_hint: 1,
             station_anchor: -1,

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -702,6 +702,102 @@ describe('@mrtdown/cli', () => {
     });
   });
 
+  it('reports schematic map generator input diffs for reviewers', async () => {
+    const dataDir = await mkdtemp(join(tmpdir(), 'mrtdown-cli-'));
+    await cp(fixtureDataDir, dataDir, { recursive: true });
+    await seedSchematicMap(dataDir);
+    await writeSchematicMapConstraintSet(dataDir, {
+      schemaVersion: 1,
+      mapId: 'system',
+      effectiveDate: '2025-05',
+      layoutEngineId: 'lta-system-map-2011',
+      constraints: [
+        {
+          id: 'frame_2025_04',
+          type: 'map_frame',
+          frame: { x: 0, y: 0, width: 3596, height: 2400 },
+          reason: 'Fixture frame changed.',
+        },
+        {
+          id: 'label_ket',
+          type: 'label_hint',
+          stationId: 'KET',
+          side: 'bottom',
+        },
+        {
+          id: 'segment_ket_hku',
+          type: 'segment_route_hint',
+          lineId: 'ISL',
+          fromStationId: 'KET',
+          toStationId: 'HKU',
+          via: [{ x: 150, y: 140 }],
+        },
+      ],
+    });
+
+    const diff = createIo();
+    await expect(
+      runCli(
+        [
+          '--data-dir',
+          dataDir,
+          'schematic-map',
+          'generator-diff',
+          '2025-04',
+          '2025-05',
+        ],
+        diff.io,
+      ),
+    ).resolves.toBe(0);
+
+    expect(JSON.parse(diff.stdout[0] as string)).toEqual({
+      from: '2025-04',
+      to: '2025-05',
+      layoutEngine: {
+        changed: false,
+        from: 'lta-system-map-2011',
+        to: 'lta-system-map-2011',
+      },
+      rules: {
+        changed: false,
+        lineOrderChanged: false,
+        fromLineOrder: ['ISL'],
+        toLineOrder: ['ISL'],
+      },
+      constraints: {
+        added: ['label_ket', 'segment_ket_hku'],
+        removed: ['anchor_ket'],
+        changed: ['frame_2025_04'],
+        byType: {
+          from: {
+            interchange_hint: 0,
+            label_hint: 0,
+            line_order: 0,
+            map_frame: 1,
+            segment_route_hint: 0,
+            station_anchor: 1,
+          },
+          to: {
+            interchange_hint: 0,
+            label_hint: 1,
+            line_order: 0,
+            map_frame: 1,
+            segment_route_hint: 1,
+            station_anchor: 0,
+          },
+          delta: {
+            interchange_hint: 0,
+            label_hint: 1,
+            line_order: 0,
+            map_frame: 0,
+            segment_route_hint: 1,
+            station_anchor: -1,
+          },
+        },
+      },
+    });
+  });
+
   it('generates and writes schematic map snapshots through the CLI', async () => {
     const dataDir = await mkdtemp(join(tmpdir(), 'mrtdown-cli-'));
     await cp(fixtureDataDir, dataDir, { recursive: true });

--- a/packages/cli/src/usage.ts
+++ b/packages/cli/src/usage.ts
@@ -8,6 +8,7 @@ export const usage = `Usage:
   mrtdown [--data-dir <path>] schematic-map select <YYYY-MM|YYYY-MM-DD>
   mrtdown [--data-dir <path>] schematic-map stats <YYYY-MM>
   mrtdown [--data-dir <path>] schematic-map diff <from YYYY-MM> <to YYYY-MM>
+  mrtdown [--data-dir <path>] schematic-map generator-diff <from YYYY-MM> <to YYYY-MM>
   mrtdown [--data-dir <path>] schematic-map generate <YYYY-MM> [--generated-at <timestamp>] [--write]
   mrtdown [--data-dir <path>] schematic-map preview <YYYY-MM> [--out <path>]
   mrtdown [--data-dir <path>] create issue --date <YYYY-MM-DD> --title <title> [--slug <slug>] [--type <type>] [--source <source>]


### PR DESCRIPTION
## Summary

- Add `schematic-map generator-diff` to compare generator inputs across two schematic map constraint effective dates.
- Report layout engine identity, rule and line-order changes, added/removed/changed constraints, and constraint-type deltas.
- Document the Phase 5 progress update in the active schematic system map plan.

## Validation

- `npm run build:cli`
- `npm run test:cli`
- `npm run check`