### PR TITLE
feat: add station first and last train schema

### DIFF
--- a/.changeset/station-first-last-trains.md
+++ b/.changeset/station-first-last-trains.md
@@ -1,0 +1,6 @@
+---
+"@mrtdown/core": patch
+"@mrtdown/fs": patch
+---
+
+Add station first/last train schemas and validate timing service references.

--- a/packages/core/src/schema/Station.test.ts
+++ b/packages/core/src/schema/Station.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import { StationSchema } from './Station.js';
+
+function minimalStation() {
+  return {
+    id: 'KET',
+    name: {
+      'en-SG': 'Kennedy Town',
+      'zh-Hans': null,
+      ms: null,
+      ta: null,
+    },
+    geo: {
+      latitude: 22.2813,
+      longitude: 114.1286,
+    },
+    stationCodes: [
+      {
+        lineId: 'ISL',
+        code: 'ISL1',
+        startedAt: '1979-10-01T00:00:00Z',
+        endedAt: null,
+        structureType: 'underground',
+      },
+    ],
+    landmarkIds: [],
+    townId: 'central-western',
+  };
+}
+
+describe('StationSchema', () => {
+  it('accepts first and last train entries with nullable halves', () => {
+    expect(() =>
+      StationSchema.parse({
+        ...minimalStation(),
+        firstLastTrain: {
+          entries: [
+            {
+              serviceId: 'ISL_MAIN_E',
+              calendar: 'weekday',
+              firstTrain: '06:00',
+              lastTrain: '00:50',
+            },
+            {
+              serviceId: 'ISL_MAIN_E',
+              calendar: 'saturday',
+              firstTrain: '06:05',
+              lastTrain: null,
+            },
+            {
+              serviceId: 'ISL_MAIN_W',
+              calendar: 'weekday',
+              firstTrain: null,
+              lastTrain: '00:35',
+            },
+          ],
+        },
+      }),
+    ).not.toThrow();
+  });
+
+  it('rejects timing rows without a first or last train time', () => {
+    const result = StationSchema.safeParse({
+      ...minimalStation(),
+      firstLastTrain: {
+        entries: [
+          {
+            serviceId: 'ISL_MAIN_E',
+            calendar: 'weekday',
+            firstTrain: null,
+            lastTrain: null,
+          },
+        ],
+      },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0]?.message).toBe(
+      'At least one of firstTrain or lastTrain must be set',
+    );
+  });
+
+  it('rejects invalid timing clocks and calendar categories', () => {
+    const result = StationSchema.safeParse({
+      ...minimalStation(),
+      firstLastTrain: {
+        entries: [
+          {
+            serviceId: 'ISL_MAIN_E',
+            calendar: 'holiday',
+            firstTrain: '25:00',
+            lastTrain: '00:50',
+          },
+        ],
+      },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.issues.map((issue) => issue.path.join('.'))).toEqual(
+      expect.arrayContaining([
+        'firstLastTrain.entries.0.calendar',
+        'firstLastTrain.entries.0.firstTrain',
+      ]),
+    );
+  });
+});

--- a/packages/core/src/schema/Station.ts
+++ b/packages/core/src/schema/Station.ts
@@ -1,6 +1,37 @@
 import z from 'zod';
 import { TranslationsSchema } from './common.js';
 
+export const StationFirstLastTrainCalendarSchema = z.enum([
+  'weekday',
+  'saturday',
+  'sunday_public_holiday',
+  'weekday_saturday',
+  'daily',
+]);
+export type StationFirstLastTrainCalendar = z.infer<
+  typeof StationFirstLastTrainCalendarSchema
+>;
+
+export const StationFirstLastTrainEntrySchema = z
+  .object({
+    serviceId: z.string(),
+    calendar: StationFirstLastTrainCalendarSchema,
+    firstTrain: z.iso.time().nullable(),
+    lastTrain: z.iso.time().nullable(),
+  })
+  .refine(
+    (entry) => entry.firstTrain !== null || entry.lastTrain !== null,
+    'At least one of firstTrain or lastTrain must be set',
+  );
+export type StationFirstLastTrainEntry = z.infer<
+  typeof StationFirstLastTrainEntrySchema
+>;
+
+export const StationFirstLastTrainSchema = z.object({
+  entries: z.array(StationFirstLastTrainEntrySchema),
+});
+export type StationFirstLastTrain = z.infer<typeof StationFirstLastTrainSchema>;
+
 export const StationStructureTypeSchema = z.enum([
   'elevated',
   'underground',
@@ -27,5 +58,6 @@ export const StationSchema = z.object({
   ),
   landmarkIds: z.array(z.string()),
   townId: z.string(),
+  firstLastTrain: StationFirstLastTrainSchema.optional(),
 });
 export type Station = z.infer<typeof StationSchema>;

--- a/packages/fs/src/index.test.ts
+++ b/packages/fs/src/index.test.ts
@@ -2440,6 +2440,18 @@ describe('@mrtdown/fs', () => {
                 firstTrain: '06:10',
                 lastTrain: null,
               },
+              {
+                serviceId: 'ISL_FUTURE_ENDED',
+                calendar: 'daily',
+                firstTrain: '06:15',
+                lastTrain: null,
+              },
+              {
+                serviceId: 'ISL_MULTI_CURRENT',
+                calendar: 'sunday_public_holiday',
+                firstTrain: null,
+                lastTrain: '00:45',
+              },
             ],
           },
         },
@@ -2489,6 +2501,113 @@ describe('@mrtdown/fs', () => {
         2,
       )}\n`,
     );
+    await writeFile(
+      join(dataDir, 'service/ISL_FUTURE_ENDED.json'),
+      `${JSON.stringify(
+        {
+          id: 'ISL_FUTURE_ENDED',
+          name: {
+            'en-SG': 'Island Line Future Ended',
+            'zh-Hans': null,
+            ms: null,
+            ta: null,
+          },
+          lineId: 'ISL',
+          revisions: [
+            {
+              id: 'r_current',
+              startAt: '1979-10-01',
+              endAt: '2999-01-01',
+              path: {
+                stations: [
+                  {
+                    stationId: 'KET',
+                    displayCode: 'ISL1',
+                  },
+                ],
+              },
+              operatingHours: {
+                weekdays: {
+                  start: '05:30',
+                  end: '00:30',
+                },
+                weekends: {
+                  start: '05:30',
+                  end: '00:30',
+                },
+              },
+            },
+          ],
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    await writeFile(
+      join(dataDir, 'service/ISL_MULTI_CURRENT.json'),
+      `${JSON.stringify(
+        {
+          id: 'ISL_MULTI_CURRENT',
+          name: {
+            'en-SG': 'Island Line Multiple Current',
+            'zh-Hans': null,
+            ms: null,
+            ta: null,
+          },
+          lineId: 'ISL',
+          revisions: [
+            {
+              id: 'r_ket',
+              startAt: '1979-10-01',
+              endAt: null,
+              path: {
+                stations: [
+                  {
+                    stationId: 'KET',
+                    displayCode: 'ISL1',
+                  },
+                ],
+              },
+              operatingHours: {
+                weekdays: {
+                  start: '05:30',
+                  end: '00:30',
+                },
+                weekends: {
+                  start: '05:30',
+                  end: '00:30',
+                },
+              },
+            },
+            {
+              id: 'r_hku',
+              startAt: '1979-10-01',
+              endAt: null,
+              path: {
+                stations: [
+                  {
+                    stationId: 'HKU',
+                    displayCode: 'ISL2',
+                  },
+                ],
+              },
+              operatingHours: {
+                weekdays: {
+                  start: '05:30',
+                  end: '00:30',
+                },
+                weekends: {
+                  start: '05:30',
+                  end: '00:30',
+                },
+              },
+            },
+          ],
+        },
+        null,
+        2,
+      )}\n`,
+    );
 
     const result = await validateDataRoot(dataDir, ['station']);
 
@@ -2497,8 +2616,14 @@ describe('@mrtdown/fs', () => {
       expect.arrayContaining([
         'station/KET.json: firstLastTrain.entries.1 duplicates serviceId/calendar ISL_MAIN_E:weekday (first seen at firstLastTrain.entries.0)',
         'station/KET.json: firstLastTrain.entries.2.serviceId MISSING does not exist in service/',
-        'station/KET.json: firstLastTrain.entries.3.serviceId TWL_MAIN_N does not include station KET in its current service path',
+        'station/KET.json: firstLastTrain.entries.3.serviceId TWL_MAIN_N revision r_initial does not include station KET in its current service path',
         'station/KET.json: firstLastTrain.entries.4.serviceId ISL_ENDED does not have a current service revision',
+        'station/KET.json: firstLastTrain.entries.6.serviceId ISL_MULTI_CURRENT revision r_hku does not include station KET in its current service path',
+      ]),
+    );
+    expect(result.errors).not.toEqual(
+      expect.arrayContaining([
+        'station/KET.json: firstLastTrain.entries.5.serviceId ISL_FUTURE_ENDED does not have a current service revision',
       ]),
     );
   });

--- a/packages/fs/src/index.test.ts
+++ b/packages/fs/src/index.test.ts
@@ -2434,8 +2434,56 @@ describe('@mrtdown/fs', () => {
                 firstTrain: null,
                 lastTrain: '00:35',
               },
+              {
+                serviceId: 'ISL_ENDED',
+                calendar: 'weekday',
+                firstTrain: '06:10',
+                lastTrain: null,
+              },
             ],
           },
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    await writeFile(
+      join(dataDir, 'service/ISL_ENDED.json'),
+      `${JSON.stringify(
+        {
+          id: 'ISL_ENDED',
+          name: {
+            'en-SG': 'Island Line Ended',
+            'zh-Hans': null,
+            ms: null,
+            ta: null,
+          },
+          lineId: 'ISL',
+          revisions: [
+            {
+              id: 'r_initial',
+              startAt: '1979-10-01',
+              endAt: '1980-01-01',
+              path: {
+                stations: [
+                  {
+                    stationId: 'KET',
+                    displayCode: 'ISL1',
+                  },
+                ],
+              },
+              operatingHours: {
+                weekdays: {
+                  start: '05:30',
+                  end: '00:30',
+                },
+                weekends: {
+                  start: '05:30',
+                  end: '00:30',
+                },
+              },
+            },
+          ],
         },
         null,
         2,
@@ -2450,6 +2498,7 @@ describe('@mrtdown/fs', () => {
         'station/KET.json: firstLastTrain.entries.1 duplicates serviceId/calendar ISL_MAIN_E:weekday (first seen at firstLastTrain.entries.0)',
         'station/KET.json: firstLastTrain.entries.2.serviceId MISSING does not exist in service/',
         'station/KET.json: firstLastTrain.entries.3.serviceId TWL_MAIN_N does not include station KET in its current service path',
+        'station/KET.json: firstLastTrain.entries.4.serviceId ISL_ENDED does not have a current service revision',
       ]),
     );
   });

--- a/packages/fs/src/index.test.ts
+++ b/packages/fs/src/index.test.ts
@@ -2379,6 +2379,81 @@ describe('@mrtdown/fs', () => {
     );
   });
 
+  it('rejects invalid station first and last train relationships', async () => {
+    const dataDir = await mkdtemp(join(tmpdir(), 'mrtdown-fs-'));
+    await cp(fixtureDataDir, dataDir, { recursive: true });
+    await writeFile(
+      join(dataDir, 'station/KET.json'),
+      `${JSON.stringify(
+        {
+          id: 'KET',
+          name: {
+            'en-SG': 'Kennedy Town',
+            'zh-Hans': null,
+            ms: null,
+            ta: null,
+          },
+          geo: {
+            latitude: 22.2813,
+            longitude: 114.1286,
+          },
+          stationCodes: [
+            {
+              lineId: 'ISL',
+              code: 'ISL1',
+              startedAt: '1979-10-01T00:00:00Z',
+              endedAt: null,
+              structureType: 'underground',
+            },
+          ],
+          landmarkIds: [],
+          townId: 'central-western',
+          firstLastTrain: {
+            entries: [
+              {
+                serviceId: 'ISL_MAIN_E',
+                calendar: 'weekday',
+                firstTrain: '06:00',
+                lastTrain: '00:50',
+              },
+              {
+                serviceId: 'ISL_MAIN_E',
+                calendar: 'weekday',
+                firstTrain: '06:05',
+                lastTrain: null,
+              },
+              {
+                serviceId: 'MISSING',
+                calendar: 'weekday',
+                firstTrain: null,
+                lastTrain: '00:30',
+              },
+              {
+                serviceId: 'TWL_MAIN_N',
+                calendar: 'weekday',
+                firstTrain: null,
+                lastTrain: '00:35',
+              },
+            ],
+          },
+        },
+        null,
+        2,
+      )}\n`,
+    );
+
+    const result = await validateDataRoot(dataDir, ['station']);
+
+    expect(result.ok).toBe(false);
+    expect(result.errors).toEqual(
+      expect.arrayContaining([
+        'station/KET.json: firstLastTrain.entries.1 duplicates serviceId/calendar ISL_MAIN_E:weekday (first seen at firstLastTrain.entries.0)',
+        'station/KET.json: firstLastTrain.entries.2.serviceId MISSING does not exist in service/',
+        'station/KET.json: firstLastTrain.entries.3.serviceId TWL_MAIN_N does not include station KET in its current service path',
+      ]),
+    );
+  });
+
   it('rejects service revisions outside station code active windows', async () => {
     const dataDir = await mkdtemp(join(tmpdir(), 'mrtdown-fs-'));
     await mkdir(join(dataDir, 'line'), { recursive: true });

--- a/packages/fs/src/validate.ts
+++ b/packages/fs/src/validate.ts
@@ -173,6 +173,10 @@ async function validateStationReferences(
 
   const lineIds = await loadEntityIds(dataDir, records, 'line');
   const landmarkIds = await loadEntityIds(dataDir, records, 'landmark');
+  const serviceRecords = await loadEntityRecords(dataDir, records, 'service');
+  const serviceById = new Map(
+    serviceRecords.map((service) => [service.value.id, service]),
+  );
   const townIds = await loadEntityIds(dataDir, records, 'town');
   const errors: string[] = [];
 
@@ -195,6 +199,50 @@ async function validateStationReferences(
       if (!lineIds.has(stationCode.lineId)) {
         errors.push(
           `${station.path}: stationCodes.${index}.lineId ${stationCode.lineId} does not exist in line/`,
+        );
+      }
+    }
+
+    const seenFirstLastTrainEntries = new Map<string, number>();
+    for (const [index, entry] of (
+      station.value.firstLastTrain?.entries ?? []
+    ).entries()) {
+      const key = `${entry.serviceId}:${entry.calendar}`;
+      const previousIndex = seenFirstLastTrainEntries.get(key);
+      if (previousIndex != null) {
+        errors.push(
+          `${station.path}: firstLastTrain.entries.${index} duplicates serviceId/calendar ${key} (first seen at firstLastTrain.entries.${previousIndex})`,
+        );
+      } else {
+        seenFirstLastTrainEntries.set(key, index);
+      }
+
+      const service = serviceById.get(entry.serviceId);
+      if (!service) {
+        errors.push(
+          `${station.path}: firstLastTrain.entries.${index}.serviceId ${entry.serviceId} does not exist in service/`,
+        );
+        continue;
+      }
+
+      const currentRevisions = service.value.revisions.filter(
+        (revision) => revision.endAt === null,
+      );
+      const revisionsToValidate =
+        currentRevisions.length > 0
+          ? currentRevisions
+          : service.value.revisions;
+      const stationIds = new Set(
+        revisionsToValidate.flatMap((revision) =>
+          revision.path.stations.map(
+            (serviceStation) => serviceStation.stationId,
+          ),
+        ),
+      );
+
+      if (!stationIds.has(station.value.id)) {
+        errors.push(
+          `${station.path}: firstLastTrain.entries.${index}.serviceId ${entry.serviceId} does not include station ${station.value.id} in its current service path`,
         );
       }
     }

--- a/packages/fs/src/validate.ts
+++ b/packages/fs/src/validate.ts
@@ -228,12 +228,15 @@ async function validateStationReferences(
       const currentRevisions = service.value.revisions.filter(
         (revision) => revision.endAt === null,
       );
-      const revisionsToValidate =
-        currentRevisions.length > 0
-          ? currentRevisions
-          : service.value.revisions;
+      if (currentRevisions.length === 0) {
+        errors.push(
+          `${station.path}: firstLastTrain.entries.${index}.serviceId ${entry.serviceId} does not have a current service revision`,
+        );
+        continue;
+      }
+
       const stationIds = new Set(
-        revisionsToValidate.flatMap((revision) =>
+        currentRevisions.flatMap((revision) =>
           revision.path.stations.map(
             (serviceStation) => serviceStation.stationId,
           ),

--- a/packages/fs/src/validate.ts
+++ b/packages/fs/src/validate.ts
@@ -179,6 +179,7 @@ async function validateStationReferences(
   );
   const townIds = await loadEntityIds(dataDir, records, 'town');
   const errors: string[] = [];
+  const validationTimestamp = Date.now();
 
   for (const station of await loadEntityRecords(dataDir, records, 'station')) {
     if (!townIds.has(station.value.townId)) {
@@ -225,8 +226,8 @@ async function validateStationReferences(
         continue;
       }
 
-      const currentRevisions = service.value.revisions.filter(
-        (revision) => revision.endAt === null,
+      const currentRevisions = service.value.revisions.filter((revision) =>
+        revisionContainsTimestamp(revision, validationTimestamp),
       );
       if (currentRevisions.length === 0) {
         errors.push(
@@ -235,23 +236,35 @@ async function validateStationReferences(
         continue;
       }
 
-      const stationIds = new Set(
-        currentRevisions.flatMap((revision) =>
+      for (const revision of currentRevisions) {
+        const stationIds = new Set(
           revision.path.stations.map(
             (serviceStation) => serviceStation.stationId,
           ),
-        ),
-      );
-
-      if (!stationIds.has(station.value.id)) {
-        errors.push(
-          `${station.path}: firstLastTrain.entries.${index}.serviceId ${entry.serviceId} does not include station ${station.value.id} in its current service path`,
         );
+
+        if (!stationIds.has(station.value.id)) {
+          errors.push(
+            `${station.path}: firstLastTrain.entries.${index}.serviceId ${entry.serviceId} revision ${revision.id} does not include station ${station.value.id} in its current service path`,
+          );
+        }
       }
     }
   }
 
   return errors;
+}
+
+function revisionContainsTimestamp(
+  revision: { startAt: string; endAt: string | null },
+  timestamp: number,
+): boolean {
+  const start = timestampForValidation(revision.startAt);
+  const end = revision.endAt
+    ? timestampForValidation(revision.endAt)
+    : Number.POSITIVE_INFINITY;
+
+  return start <= timestamp && timestamp < end;
 }
 
 async function validateLineReferences(

--- a/scripts/generate-fixtures.mjs
+++ b/scripts/generate-fixtures.mjs
@@ -129,6 +129,7 @@ function station(
   longitude,
   townId,
   landmarkIds = [],
+  firstLastTrain = undefined,
 ) {
   return {
     id,
@@ -145,6 +146,7 @@ function station(
     ),
     landmarkIds,
     townId,
+    ...(firstLastTrain ? { firstLastTrain } : {}),
   };
 }
 
@@ -292,6 +294,29 @@ function buildStaticEntities() {
       22.2813,
       114.1286,
       'central-western',
+      [],
+      {
+        entries: [
+          {
+            serviceId: 'ISL_MAIN_E',
+            calendar: 'weekday',
+            firstTrain: '06:00',
+            lastTrain: '00:50',
+          },
+          {
+            serviceId: 'ISL_MAIN_E',
+            calendar: 'saturday',
+            firstTrain: '06:05',
+            lastTrain: null,
+          },
+          {
+            serviceId: 'ISL_MAIN_W',
+            calendar: 'weekday',
+            firstTrain: null,
+            lastTrain: '00:35',
+          },
+        ],
+      },
     ),
     station(
       'HKU',


### PR DESCRIPTION
## Summary

- Add optional station `firstLastTrain` data with published calendar categories and nullable first/last timing rows.
- Validate station timing entries against known services, duplicate service/calendar rows, and current service path membership.
- Extend generated fixtures and package tests to cover first-plus-last, first-only, and last-only timing rows.

## Validation

- `npm run test:core`
- `npm run test:fs`
- `npm run fixtures:validate`
- `npm run data:validate`
- `npm run check`