### PR TITLE
feat: add schematic map constraint copy-forward CLI

### DIFF
--- a/docs/plans/active/schematic-system-map.md
+++ b/docs/plans/active/schematic-system-map.md
@@ -424,6 +424,10 @@ Exit criteria:
   `schematic-map generator-diff` for comparing source generator inputs across
   two constraint effective dates, including rule-set identity, line-order
   changes, added/removed/changed constraints, and constraint-type deltas.
+- 2026-05-31: Added Phase 5 copy-forward authoring support with
+  `schematic-map copy-constraints`, allowing reviewers to preview or write a
+  new effective-date constraint set from an existing one while keeping generated
+  snapshots artifact-only.
 
 ## Decision Log
 

--- a/packages/cli/src/commands/schematicMap.ts
+++ b/packages/cli/src/commands/schematicMap.ts
@@ -19,6 +19,7 @@ import {
   readSchematicMapManifest,
   readSchematicMapRuleSet,
   readSchematicMapVersionSnapshot,
+  writeSchematicMapConstraintSet,
   writeSchematicMapManifest,
   writeSchematicMapVersionSnapshot,
 } from '@mrtdown/fs';
@@ -145,6 +146,41 @@ type SchematicMapGeneratorDiff = {
     };
   };
 };
+
+function effectiveDateIdPart(effectiveDate: string): string {
+  return effectiveDate.replace('-', '_');
+}
+
+function copyConstraintIdForEffectiveDate(
+  id: string,
+  fromEffectiveDate: string,
+  toEffectiveDate: string,
+): string {
+  return id
+    .replaceAll(fromEffectiveDate, toEffectiveDate)
+    .replaceAll(
+      effectiveDateIdPart(fromEffectiveDate),
+      effectiveDateIdPart(toEffectiveDate),
+    );
+}
+
+function copySchematicMapConstraintSet(
+  constraintSet: SchematicMapConstraintSet,
+  toEffectiveDate: string,
+): SchematicMapConstraintSet {
+  return {
+    ...constraintSet,
+    effectiveDate: SchematicMapEffectiveDateSchema.parse(toEffectiveDate),
+    constraints: constraintSet.constraints.map((constraint) => ({
+      ...constraint,
+      id: copyConstraintIdForEffectiveDate(
+        constraint.id,
+        constraintSet.effectiveDate,
+        toEffectiveDate,
+      ),
+    })),
+  };
+}
 
 function createCoordinateClassCounts(): CoordinateClassCounts {
   return {
@@ -1069,6 +1105,50 @@ export async function runSchematicMap(
     return 0;
   }
 
+  if (action === 'copy-constraints') {
+    const fromId = args.shift();
+    const toId = args.shift();
+    if (!fromId || !toId) {
+      throw new Error(
+        'schematic-map copy-constraints requires from YYYY-MM and to YYYY-MM',
+      );
+    }
+
+    const fromEffectiveDate = SchematicMapEffectiveDateSchema.parse(fromId);
+    const toEffectiveDate = SchematicMapEffectiveDateSchema.parse(toId);
+    const shouldWrite = hasFlag(args, '--write');
+    const shouldForce = hasFlag(args, '--force');
+
+    const fromConstraintSet = await readSchematicMapConstraintSet(
+      globals.dataDir,
+      fromEffectiveDate,
+    );
+    const copiedConstraintSet = copySchematicMapConstraintSet(
+      fromConstraintSet.value,
+      toEffectiveDate,
+    );
+
+    if (shouldWrite) {
+      const existingEffectiveDates =
+        await listSchematicMapConstraintSetEffectiveDates(globals.dataDir);
+      if (existingEffectiveDates.includes(toEffectiveDate) && !shouldForce) {
+        throw new Error(
+          `Schematic map constraint set already exists for ${toEffectiveDate}; pass --force to overwrite`,
+        );
+      }
+
+      const path = await writeSchematicMapConstraintSet(
+        globals.dataDir,
+        copiedConstraintSet,
+      );
+      io.stdout(JSON.stringify({ constraint: path }));
+      return 0;
+    }
+
+    io.stdout(JSON.stringify(copiedConstraintSet, null, 2));
+    return 0;
+  }
+
   if (action === 'generate') {
     const id = args.shift();
     if (!id) {
@@ -1132,6 +1212,6 @@ export async function runSchematicMap(
   }
 
   throw new Error(
-    'schematic-map requires list, show, select, stats, diff, generator-diff, generate, or preview',
+    'schematic-map requires list, show, select, stats, diff, generator-diff, copy-constraints, generate, or preview',
   );
 }

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -803,6 +803,95 @@ describe('@mrtdown/cli', () => {
     });
   });
 
+  it('copies schematic map constraints forward for a new version', async () => {
+    const dataDir = await mkdtemp(join(tmpdir(), 'mrtdown-cli-'));
+    await cp(fixtureDataDir, dataDir, { recursive: true });
+    await seedSchematicMap(dataDir);
+
+    const preview = createIo();
+    await expect(
+      runCli(
+        [
+          '--data-dir',
+          dataDir,
+          'schematic-map',
+          'copy-constraints',
+          '2025-04',
+          '2025-06',
+        ],
+        preview.io,
+      ),
+    ).resolves.toBe(0);
+    expect(JSON.parse(preview.stdout[0] as string)).toMatchObject({
+      effectiveDate: '2025-06',
+      constraints: [
+        {
+          id: 'frame_2025_06',
+          type: 'map_frame',
+        },
+        {
+          id: 'anchor_ket',
+          type: 'station_anchor',
+        },
+      ],
+    });
+
+    const listBeforeWrite = createIo();
+    await expect(
+      runCli(
+        ['--data-dir', dataDir, 'schematic-map', 'list', 'constraint'],
+        listBeforeWrite.io,
+      ),
+    ).resolves.toBe(0);
+    expect(listBeforeWrite.stdout).toEqual(['2025-04']);
+
+    const write = createIo();
+    await expect(
+      runCli(
+        [
+          '--data-dir',
+          dataDir,
+          'schematic-map',
+          'copy-constraints',
+          '2025-04',
+          '2025-06',
+          '--write',
+        ],
+        write.io,
+      ),
+    ).resolves.toBe(0);
+    expect(JSON.parse(write.stdout[0] as string)).toEqual({
+      constraint: 'schematic-map/system/generator/constraint/2025-06.json',
+    });
+
+    const overwrite = createIo();
+    await expect(
+      runCli(
+        [
+          '--data-dir',
+          dataDir,
+          'schematic-map',
+          'copy-constraints',
+          '2025-04',
+          '2025-06',
+          '--write',
+        ],
+        overwrite.io,
+      ),
+    ).resolves.toBe(1);
+    expect(overwrite.stderr).toEqual([
+      'Schematic map constraint set already exists for 2025-06; pass --force to overwrite',
+    ]);
+
+    const validate = createIo();
+    await expect(
+      runCli(
+        ['--data-dir', dataDir, 'validate', '--scope', 'schematic-map'],
+        validate.io,
+      ),
+    ).resolves.toBe(0);
+  });
+
   it('generates and writes schematic map snapshots through the CLI', async () => {
     const dataDir = await mkdtemp(join(tmpdir(), 'mrtdown-cli-'));
     await cp(fixtureDataDir, dataDir, { recursive: true });

--- a/packages/cli/src/usage.ts
+++ b/packages/cli/src/usage.ts
@@ -9,6 +9,7 @@ export const usage = `Usage:
   mrtdown [--data-dir <path>] schematic-map stats <YYYY-MM>
   mrtdown [--data-dir <path>] schematic-map diff <from YYYY-MM> <to YYYY-MM>
   mrtdown [--data-dir <path>] schematic-map generator-diff <from YYYY-MM> <to YYYY-MM>
+  mrtdown [--data-dir <path>] schematic-map copy-constraints <from YYYY-MM> <to YYYY-MM> [--write] [--force]
   mrtdown [--data-dir <path>] schematic-map generate <YYYY-MM> [--generated-at <timestamp>] [--write]
   mrtdown [--data-dir <path>] schematic-map preview <YYYY-MM> [--out <path>]
   mrtdown [--data-dir <path>] create issue --date <YYYY-MM-DD> --title <title> [--slug <slug>] [--type <type>] [--source <source>]


### PR DESCRIPTION
## Summary

Adds Phase 5 schematic-map copy-forward authoring support with a new `schematic-map copy-constraints` CLI command.

## Changes

- Adds preview and write flows for copying an existing schematic map constraint set to a new effective date.
- Rewrites date-stamped constraint IDs such as `frame_2025_04` when targeting a new month.
- Refuses overwrites unless `--force` is provided.
- Updates CLI usage, regression tests, and the active schematic system map plan progress log.

## Validation

- `npm run test:cli`
- `npm run typecheck`
- `npm run check`
- `npm run data:validate`