### PR TITLE
feat: add schematic map designer submission validation

### DIFF
--- a/docs/plans/active/schematic-system-map.md
+++ b/docs/plans/active/schematic-system-map.md
@@ -308,6 +308,9 @@ Define how trusted authoring clients submit schematic map edits back to this
 repository. The first expected client is a protected `mrtdown-site` map designer
 that uses the site renderer for visual editing and preview.
 
+Submission bundle details are documented in
+`docs/schematic-map-designer-submissions.md`.
+
 - Define an edit bundle or branch layout that contains updated generator
   constraints, generator validation output or semantic diffs, and metadata about
   the source version and intended target version.
@@ -428,6 +431,11 @@ Exit criteria:
   `schematic-map copy-constraints`, allowing reviewers to preview or write a
   new effective-date constraint set from an existing one while keeping generated
   snapshots artifact-only.
+- 2026-05-31: Began Phase 6 designer submission support with
+  `docs/schematic-map-designer-submissions.md` and
+  `schematic-map validate-submission`, so trusted designer output can be
+  validated against canonical constraints and reviewer-facing diffs before PR
+  review.
 
 ## Decision Log
 

--- a/docs/schematic-map-designer-submissions.md
+++ b/docs/schematic-map-designer-submissions.md
@@ -1,0 +1,81 @@
+# Schematic Map Designer Submissions
+
+Trusted visual authoring clients, such as a protected `mrtdown-site` map
+designer, should submit schematic map edits as normal reviewable branches in
+this repository. The designer is a helper for authoring constraints and review
+artifacts; the canonical source remains `mrtdown-data`.
+
+## Branch Contents
+
+A designer-originated branch should contain:
+
+- updated generator constraints under
+  `data/schematic-map/system/generator/constraint/<YYYY-MM>.json`;
+- a submission metadata file, usually `artifacts/schematic-map/submission.json`;
+- generated review artifacts, such as semantic diff JSON, generator diff JSON,
+  and a preview SVG, under an ignored `artifacts/` directory;
+- no committed generated version snapshot unless a reviewer explicitly asks for
+  a fixture.
+
+The committed constraint set must pass the same validation as hand-authored
+changes. Generated snapshots stay publication artifacts produced by the
+deterministic generator.
+
+## Submission Metadata
+
+The submission metadata file is JSON:
+
+```json
+{
+  "schemaVersion": 1,
+  "type": "schematic-map-designer-submission",
+  "mapId": "system",
+  "sourceEffectiveDate": "2025-04",
+  "targetEffectiveDate": "2025-06",
+  "layoutEngineId": "lta-system-map-2011",
+  "source": {
+    "tool": "mrtdown-site-map-designer",
+    "url": "https://example.invalid/designer-session"
+  },
+  "summary": "Move selected labels and route hints for the target version.",
+  "files": {
+    "constraint": "schematic-map/system/generator/constraint/2025-06.json",
+    "semanticDiff": "artifacts/schematic-map/2025-04..2025-06.json",
+    "generatorDiff": "artifacts/schematic-map/2025-04..2025-06.generator.json",
+    "preview": "artifacts/schematic-map/2025-06.svg"
+  },
+  "notes": ["Optional reviewer notes."]
+}
+```
+
+Required fields are `schemaVersion`, `type`, `mapId`, `sourceEffectiveDate`,
+`targetEffectiveDate`, `layoutEngineId`, `source.tool`, `summary`, and
+`files.constraint`.
+
+`files.constraint` must point to the canonical target constraint path for
+`targetEffectiveDate`. Optional diff and preview paths are review aids; they do
+not replace canonical validation.
+
+## Validation
+
+Run:
+
+```sh
+npm run build:cli
+node packages/cli/dist/index.js --data-dir data schematic-map validate-submission --file artifacts/schematic-map/submission.json
+```
+
+The command validates the metadata shape, confirms the target constraint set is
+written at the expected canonical path, regenerates source and target snapshots,
+and prints reviewer-facing constraint counts, coordinate counts, generator diff,
+and semantic diff.
+
+Before opening a PR, also run:
+
+```sh
+npm run data:validate
+```
+
+Reviewers should reject submissions that add unnecessary fixed coordinates or
+exceptions when reusable rules or narrower constraints would explain the layout
+change better.

--- a/packages/cli/src/commands/schematicMap.ts
+++ b/packages/cli/src/commands/schematicMap.ts
@@ -21,6 +21,7 @@ import {
   readSchematicMapRuleSet,
   readSchematicMapVersionSnapshot,
   schematicSystemMapConstraintSetPath,
+  validateDataRoot,
   writeSchematicMapConstraintSet,
   writeSchematicMapManifest,
   writeSchematicMapVersionSnapshot,
@@ -1086,6 +1087,15 @@ async function validateSchematicMapDesignerSubmission(
     );
   }
 
+  const canonicalValidation = await validateDataRoot(dataDir, [
+    'schematic-map',
+  ]);
+  if (!canonicalValidation.ok) {
+    throw new Error(
+      `Schematic map validation failed:\n${canonicalValidation.errors.join('\n')}`,
+    );
+  }
+
   const [sourceRuleSet, targetRuleSet, sourceSnapshot, targetSnapshot] =
     await Promise.all([
       readSchematicMapRuleSet(
@@ -1121,6 +1131,7 @@ async function validateSchematicMapDesignerSubmission(
       total: targetConstraintSet.value.constraints.length,
       byType: countConstraintTypes(targetConstraintSet.value.constraints),
     },
+    validation: canonicalValidation.checked,
     generatedSnapshot: {
       effectiveDate: targetSnapshot.effectiveDate,
       stations: targetSnapshot.stationNodes.length,

--- a/packages/cli/src/commands/schematicMap.ts
+++ b/packages/cli/src/commands/schematicMap.ts
@@ -1,3 +1,4 @@
+import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import {
   type SchematicMapConstraint,
@@ -19,6 +20,7 @@ import {
   readSchematicMapManifest,
   readSchematicMapRuleSet,
   readSchematicMapVersionSnapshot,
+  schematicSystemMapConstraintSetPath,
   writeSchematicMapConstraintSet,
   writeSchematicMapManifest,
   writeSchematicMapVersionSnapshot,
@@ -147,6 +149,27 @@ type SchematicMapGeneratorDiff = {
   };
 };
 
+type SchematicMapDesignerSubmissionBundle = {
+  schemaVersion: 1;
+  type: 'schematic-map-designer-submission';
+  mapId: 'system';
+  sourceEffectiveDate: string;
+  targetEffectiveDate: string;
+  layoutEngineId: string;
+  source: {
+    tool: string;
+    url?: string;
+  };
+  summary: string;
+  files: {
+    constraint: string;
+    semanticDiff?: string;
+    generatorDiff?: string;
+    preview?: string;
+  };
+  notes?: string[];
+};
+
 function effectiveDateIdPart(effectiveDate: string): string {
   return effectiveDate.replace('-', '_');
 }
@@ -257,6 +280,114 @@ function countConstraintTypes(
       station_anchor: 0,
     },
   );
+}
+
+function assertRecord(value: unknown, path: string): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${path} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function requiredString(
+  record: Record<string, unknown>,
+  key: string,
+  path: string,
+): string {
+  const value = record[key];
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new Error(`${path}.${key} must be a non-empty string`);
+  }
+  return value;
+}
+
+function optionalString(
+  record: Record<string, unknown>,
+  key: string,
+  path: string,
+): string | undefined {
+  const value = record[key];
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new Error(`${path}.${key} must be a non-empty string when present`);
+  }
+  return value;
+}
+
+function optionalStringArray(
+  record: Record<string, unknown>,
+  key: string,
+  path: string,
+): string[] | undefined {
+  const value = record[key];
+  if (value === undefined) {
+    return undefined;
+  }
+  if (
+    !Array.isArray(value) ||
+    value.some((item) => typeof item !== 'string' || item.trim() === '')
+  ) {
+    throw new Error(`${path}.${key} must be an array of non-empty strings`);
+  }
+  return value;
+}
+
+function parseSchematicMapDesignerSubmissionBundle(
+  value: unknown,
+): SchematicMapDesignerSubmissionBundle {
+  const root = assertRecord(value, 'submission');
+  if (root.schemaVersion !== 1) {
+    throw new Error('submission.schemaVersion must be 1');
+  }
+  if (root.type !== 'schematic-map-designer-submission') {
+    throw new Error(
+      'submission.type must be schematic-map-designer-submission',
+    );
+  }
+  if (root.mapId !== 'system') {
+    throw new Error('submission.mapId must be system');
+  }
+
+  const source = assertRecord(root.source, 'submission.source');
+  const files = assertRecord(root.files, 'submission.files');
+  const sourceEffectiveDate = SchematicMapEffectiveDateSchema.parse(
+    requiredString(root, 'sourceEffectiveDate', 'submission'),
+  );
+  const targetEffectiveDate = SchematicMapEffectiveDateSchema.parse(
+    requiredString(root, 'targetEffectiveDate', 'submission'),
+  );
+  const layoutEngineId = SchematicMapLayoutEngineIdSchema.parse(
+    requiredString(root, 'layoutEngineId', 'submission'),
+  );
+
+  if (sourceEffectiveDate === targetEffectiveDate) {
+    throw new Error(
+      'submission.sourceEffectiveDate and submission.targetEffectiveDate must differ',
+    );
+  }
+
+  return {
+    schemaVersion: 1,
+    type: 'schematic-map-designer-submission',
+    mapId: 'system',
+    sourceEffectiveDate,
+    targetEffectiveDate,
+    layoutEngineId,
+    source: {
+      tool: requiredString(source, 'tool', 'submission.source'),
+      url: optionalString(source, 'url', 'submission.source'),
+    },
+    summary: requiredString(root, 'summary', 'submission'),
+    files: {
+      constraint: requiredString(files, 'constraint', 'submission.files'),
+      semanticDiff: optionalString(files, 'semanticDiff', 'submission.files'),
+      generatorDiff: optionalString(files, 'generatorDiff', 'submission.files'),
+      preview: optionalString(files, 'preview', 'submission.files'),
+    },
+    notes: optionalStringArray(root, 'notes', 'submission'),
+  };
 }
 
 function constraintTypeDelta(
@@ -913,6 +1044,108 @@ async function updateSchematicMapManifest(
   });
 }
 
+async function validateSchematicMapDesignerSubmission(
+  dataDir: string,
+  bundlePath: string,
+): Promise<unknown> {
+  const bundle = parseSchematicMapDesignerSubmissionBundle(
+    JSON.parse(await readFile(bundlePath, 'utf8')),
+  );
+  const expectedConstraintPath = schematicSystemMapConstraintSetPath(
+    bundle.targetEffectiveDate,
+  );
+
+  if (bundle.files.constraint !== expectedConstraintPath) {
+    throw new Error(
+      `submission.files.constraint must be ${expectedConstraintPath}`,
+    );
+  }
+
+  const [sourceConstraintSet, targetConstraintSet] = await Promise.all([
+    readSchematicMapConstraintSet(
+      dataDir,
+      SchematicMapEffectiveDateSchema.parse(bundle.sourceEffectiveDate),
+    ),
+    readSchematicMapConstraintSet(
+      dataDir,
+      SchematicMapEffectiveDateSchema.parse(bundle.targetEffectiveDate),
+    ),
+  ]);
+
+  if (targetConstraintSet.value.layoutEngineId !== bundle.layoutEngineId) {
+    throw new Error(
+      `submission.layoutEngineId ${bundle.layoutEngineId} does not match target constraint layoutEngineId ${targetConstraintSet.value.layoutEngineId}`,
+    );
+  }
+  if (
+    targetConstraintSet.path !== bundle.files.constraint ||
+    targetConstraintSet.value.effectiveDate !== bundle.targetEffectiveDate
+  ) {
+    throw new Error(
+      `Target constraint set must be written at ${expectedConstraintPath} for ${bundle.targetEffectiveDate}`,
+    );
+  }
+
+  const [sourceRuleSet, targetRuleSet, sourceSnapshot, targetSnapshot] =
+    await Promise.all([
+      readSchematicMapRuleSet(
+        dataDir,
+        sourceConstraintSet.value.layoutEngineId,
+      ),
+      readSchematicMapRuleSet(
+        dataDir,
+        targetConstraintSet.value.layoutEngineId,
+      ),
+      generateSchematicMapVersionSnapshot(dataDir, {
+        effectiveDate: sourceConstraintSet.value.effectiveDate,
+        generatedAt: '1970-01-01T00:00:00.000Z',
+      }),
+      generateSchematicMapVersionSnapshot(dataDir, {
+        effectiveDate: targetConstraintSet.value.effectiveDate,
+        generatedAt: '1970-01-01T00:00:00.000Z',
+      }),
+    ]);
+  const coordinateClasses =
+    countSchematicMapSnapshotCoordinates(targetSnapshot);
+
+  return {
+    type: bundle.type,
+    source: bundle.source,
+    summary: bundle.summary,
+    sourceEffectiveDate: bundle.sourceEffectiveDate,
+    targetEffectiveDate: bundle.targetEffectiveDate,
+    layoutEngineId: bundle.layoutEngineId,
+    files: bundle.files,
+    constraints: {
+      path: targetConstraintSet.path,
+      total: targetConstraintSet.value.constraints.length,
+      byType: countConstraintTypes(targetConstraintSet.value.constraints),
+    },
+    generatedSnapshot: {
+      effectiveDate: targetSnapshot.effectiveDate,
+      stations: targetSnapshot.stationNodes.length,
+      segments: targetSnapshot.segments.length,
+      labels: targetSnapshot.labels.length,
+      stationCodeLabels: targetSnapshot.stationCodeLabels.length,
+      coordinates: {
+        total: Object.values(coordinateClasses).reduce(
+          (sum, value) => sum + value,
+          0,
+        ),
+        byClass: coordinateClasses,
+      },
+    },
+    generatorDiff: diffSchematicMapGeneratorInputs(
+      sourceConstraintSet.value,
+      targetConstraintSet.value,
+      sourceRuleSet.value,
+      targetRuleSet.value,
+    ),
+    semanticDiff: diffSchematicMapSnapshots(sourceSnapshot, targetSnapshot),
+    notes: bundle.notes ?? [],
+  };
+}
+
 export async function runSchematicMap(
   args: string[],
   globals: GlobalOptions,
@@ -1149,6 +1382,20 @@ export async function runSchematicMap(
     return 0;
   }
 
+  if (action === 'validate-submission') {
+    const file = readOption(args, '--file', { required: true });
+    if (!file) {
+      throw new Error('--file is required');
+    }
+    const result = await validateSchematicMapDesignerSubmission(
+      globals.dataDir,
+      resolve(globals.cwd, file),
+    );
+
+    io.stdout(JSON.stringify(result, null, 2));
+    return 0;
+  }
+
   if (action === 'generate') {
     const id = args.shift();
     if (!id) {
@@ -1212,6 +1459,6 @@ export async function runSchematicMap(
   }
 
   throw new Error(
-    'schematic-map requires list, show, select, stats, diff, generator-diff, copy-constraints, generate, or preview',
+    'schematic-map requires list, show, select, stats, diff, generator-diff, copy-constraints, validate-submission, generate, or preview',
   );
 }

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -892,6 +892,138 @@ describe('@mrtdown/cli', () => {
     ).resolves.toBe(0);
   });
 
+  it('validates schematic map designer submission bundles', async () => {
+    const dataDir = await mkdtemp(join(tmpdir(), 'mrtdown-cli-'));
+    await cp(fixtureDataDir, dataDir, { recursive: true });
+    await seedSchematicMap(dataDir);
+    await writeSchematicMapConstraintSet(dataDir, {
+      schemaVersion: 1,
+      mapId: 'system',
+      effectiveDate: '2025-06',
+      layoutEngineId: 'lta-system-map-2011',
+      constraints: [
+        {
+          id: 'frame_2025_06',
+          type: 'map_frame',
+          frame: { x: 0, y: 0, width: 1200, height: 600 },
+          reason: 'Fixture designer submission frame.',
+        },
+        {
+          id: 'label_ket',
+          type: 'label_hint',
+          stationId: 'KET',
+          side: 'bottom',
+        },
+      ],
+    });
+    const bundlePath = join(dataDir, 'submission.json');
+    await writeFile(
+      bundlePath,
+      JSON.stringify(
+        {
+          schemaVersion: 1,
+          type: 'schematic-map-designer-submission',
+          mapId: 'system',
+          sourceEffectiveDate: '2025-04',
+          targetEffectiveDate: '2025-06',
+          layoutEngineId: 'lta-system-map-2011',
+          source: {
+            tool: 'mrtdown-site-map-designer',
+          },
+          summary: 'Move fixture label below Kennedy Town.',
+          files: {
+            constraint:
+              'schematic-map/system/generator/constraint/2025-06.json',
+            semanticDiff: 'artifacts/schematic-map/2025-04..2025-06.json',
+            generatorDiff:
+              'artifacts/schematic-map/2025-04..2025-06.generator.json',
+            preview: 'artifacts/schematic-map/2025-06.svg',
+          },
+          notes: ['Fixture review note.'],
+        },
+        null,
+        2,
+      ),
+    );
+
+    const validate = createIo();
+    await expect(
+      runCli(
+        [
+          '--data-dir',
+          dataDir,
+          'schematic-map',
+          'validate-submission',
+          '--file',
+          bundlePath,
+        ],
+        validate.io,
+      ),
+    ).resolves.toBe(0);
+    expect(JSON.parse(validate.stdout[0] as string)).toMatchObject({
+      type: 'schematic-map-designer-submission',
+      sourceEffectiveDate: '2025-04',
+      targetEffectiveDate: '2025-06',
+      layoutEngineId: 'lta-system-map-2011',
+      constraints: {
+        path: 'schematic-map/system/generator/constraint/2025-06.json',
+        total: 2,
+        byType: {
+          label_hint: 1,
+          map_frame: 1,
+        },
+      },
+      generatorDiff: {
+        from: '2025-04',
+        to: '2025-06',
+        constraints: {
+          added: ['frame_2025_06', 'label_ket'],
+          removed: ['anchor_ket', 'frame_2025_04'],
+        },
+      },
+      semanticDiff: {
+        from: '2025-04',
+        to: '2025-06',
+      },
+      notes: ['Fixture review note.'],
+    });
+
+    const invalidBundlePath = join(dataDir, 'invalid-submission.json');
+    await writeFile(
+      invalidBundlePath,
+      JSON.stringify({
+        schemaVersion: 1,
+        type: 'schematic-map-designer-submission',
+        mapId: 'system',
+        sourceEffectiveDate: '2025-04',
+        targetEffectiveDate: '2025-06',
+        layoutEngineId: 'lta-system-map-2011',
+        source: { tool: 'mrtdown-site-map-designer' },
+        summary: 'Invalid path fixture.',
+        files: {
+          constraint: 'schematic-map/system/generator/constraint/wrong.json',
+        },
+      }),
+    );
+    const invalid = createIo();
+    await expect(
+      runCli(
+        [
+          '--data-dir',
+          dataDir,
+          'schematic-map',
+          'validate-submission',
+          '--file',
+          invalidBundlePath,
+        ],
+        invalid.io,
+      ),
+    ).resolves.toBe(1);
+    expect(invalid.stderr).toEqual([
+      'submission.files.constraint must be schematic-map/system/generator/constraint/2025-06.json',
+    ]);
+  });
+
   it('generates and writes schematic map snapshots through the CLI', async () => {
     const dataDir = await mkdtemp(join(tmpdir(), 'mrtdown-cli-'));
     await cp(fixtureDataDir, dataDir, { recursive: true });

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -973,6 +973,9 @@ describe('@mrtdown/cli', () => {
           map_frame: 1,
         },
       },
+      validation: {
+        'schematic-map': 5,
+      },
       generatorDiff: {
         from: '2025-04',
         to: '2025-06',
@@ -1021,6 +1024,66 @@ describe('@mrtdown/cli', () => {
     ).resolves.toBe(1);
     expect(invalid.stderr).toEqual([
       'submission.files.constraint must be schematic-map/system/generator/constraint/2025-06.json',
+    ]);
+
+    await writeSchematicMapConstraintSet(dataDir, {
+      schemaVersion: 1,
+      mapId: 'system',
+      effectiveDate: '2025-07',
+      layoutEngineId: 'lta-system-map-2011',
+      constraints: [
+        {
+          id: 'frame_2025_07',
+          type: 'map_frame',
+          frame: { x: 0, y: 0, width: 1200, height: 600 },
+        },
+        {
+          id: 'label_nope',
+          type: 'label_hint',
+          stationId: 'NOPE',
+          side: 'bottom',
+        },
+      ],
+    });
+    const invalidReferenceBundlePath = join(
+      dataDir,
+      'invalid-reference-submission.json',
+    );
+    await writeFile(
+      invalidReferenceBundlePath,
+      JSON.stringify({
+        schemaVersion: 1,
+        type: 'schematic-map-designer-submission',
+        mapId: 'system',
+        sourceEffectiveDate: '2025-04',
+        targetEffectiveDate: '2025-07',
+        layoutEngineId: 'lta-system-map-2011',
+        source: { tool: 'mrtdown-site-map-designer' },
+        summary: 'Invalid reference fixture.',
+        files: {
+          constraint: 'schematic-map/system/generator/constraint/2025-07.json',
+        },
+      }),
+    );
+    const invalidReference = createIo();
+    await expect(
+      runCli(
+        [
+          '--data-dir',
+          dataDir,
+          'schematic-map',
+          'validate-submission',
+          '--file',
+          invalidReferenceBundlePath,
+        ],
+        invalidReference.io,
+      ),
+    ).resolves.toBe(1);
+    expect(invalidReference.stderr).toEqual([
+      [
+        'Schematic map validation failed:',
+        'schematic-map/system/generator/constraint/2025-07.json: constraints.1.stationId NOPE does not exist in station/',
+      ].join('\n'),
     ]);
   });
 

--- a/packages/cli/src/usage.ts
+++ b/packages/cli/src/usage.ts
@@ -10,6 +10,7 @@ export const usage = `Usage:
   mrtdown [--data-dir <path>] schematic-map diff <from YYYY-MM> <to YYYY-MM>
   mrtdown [--data-dir <path>] schematic-map generator-diff <from YYYY-MM> <to YYYY-MM>
   mrtdown [--data-dir <path>] schematic-map copy-constraints <from YYYY-MM> <to YYYY-MM> [--write] [--force]
+  mrtdown [--data-dir <path>] schematic-map validate-submission --file <path>
   mrtdown [--data-dir <path>] schematic-map generate <YYYY-MM> [--generated-at <timestamp>] [--write]
   mrtdown [--data-dir <path>] schematic-map preview <YYYY-MM> [--out <path>]
   mrtdown [--data-dir <path>] create issue --date <YYYY-MM-DD> --title <title> [--slug <slug>] [--type <type>] [--source <source>]


### PR DESCRIPTION
## Summary

- Add `schematic-map validate-submission --file <path>` for trusted schematic map designer bundles.
- Document the designer submission contract and branch contents.
- Update the schematic system map plan progress and CLI usage.

## Validation

- `npm run test:cli`
- `npm run check`
- `npm run build:cli`