### PR TITLE
feat: add station first-last train schema

### DIFF
--- a/data/station/CDT.json
+++ b/data/station/CDT.json
@@ -34,6 +34,23 @@
   "firstLastTrain": {
     "services": [
       {
+        "serviceId": "CCL_MAIN_CCW",
+        "times": {
+          "weekday": {
+            "firstTrain": "05:28",
+            "lastTrain": "23:23"
+          },
+          "saturday": {
+            "firstTrain": "05:28",
+            "lastTrain": "23:23"
+          },
+          "sunday_public_holiday": {
+            "firstTrain": "05:52",
+            "lastTrain": "23:23"
+          }
+        }
+      },
+      {
         "serviceId": "CCL_MAIN_CW",
         "times": {
           "weekday": {
@@ -72,15 +89,15 @@
         "times": {
           "weekday": {
             "firstTrain": "05:48",
-            "lastTrain": "23:58"
+            "lastTrain": "23:52"
           },
           "saturday": {
             "firstTrain": "05:48",
-            "lastTrain": "23:58"
+            "lastTrain": "23:52"
           },
           "sunday_public_holiday": {
             "firstTrain": "06:08",
-            "lastTrain": "23:58"
+            "lastTrain": "23:52"
           }
         }
       }
@@ -95,8 +112,7 @@
         "label": "A",
         "lineId": "CCL",
         "serviceIds": [
-          "CCL_MAIN_CCW",
-          "CCL_EXT_CCW"
+          "CCL_MAIN_CCW"
         ],
         "accessPoints": []
       },
@@ -105,14 +121,13 @@
         "label": "B",
         "lineId": "CCL",
         "serviceIds": [
-          "CCL_MAIN_CW",
-          "CCL_EXT_CW"
+          "CCL_MAIN_CW"
         ],
         "accessPoints": []
       },
       {
-        "id": "TCDT_B",
-        "label": "B",
+        "id": "TCDT_D",
+        "label": "D",
         "lineId": "TEL",
         "serviceIds": [
           "TEL_MAIN_N"
@@ -120,8 +135,8 @@
         "accessPoints": []
       },
       {
-        "id": "TCDT_A",
-        "label": "A",
+        "id": "TCDT_C",
+        "label": "C",
         "lineId": "TEL",
         "serviceIds": [
           "TEL_MAIN_S"

--- a/data/station/CDT.json
+++ b/data/station/CDT.json
@@ -30,5 +30,105 @@
     "singapore-institute-of-technology",
     "bishan-park"
   ],
-  "townId": "toa-payoh"
+  "townId": "toa-payoh",
+  "firstLastTrain": {
+    "services": [
+      {
+        "serviceId": "CCL_MAIN_CW",
+        "times": {
+          "weekday": {
+            "firstTrain": "05:34",
+            "lastTrain": "23:30"
+          },
+          "saturday": {
+            "firstTrain": "05:34",
+            "lastTrain": "23:30"
+          },
+          "sunday_public_holiday": {
+            "firstTrain": "06:02",
+            "lastTrain": "23:30"
+          }
+        }
+      },
+      {
+        "serviceId": "TEL_MAIN_N",
+        "times": {
+          "weekday": {
+            "firstTrain": "05:52",
+            "lastTrain": "00:23"
+          },
+          "saturday": {
+            "firstTrain": "05:52",
+            "lastTrain": "00:23"
+          },
+          "sunday_public_holiday": {
+            "firstTrain": "06:12",
+            "lastTrain": "00:23"
+          }
+        }
+      },
+      {
+        "serviceId": "TEL_MAIN_S",
+        "times": {
+          "weekday": {
+            "firstTrain": "05:48",
+            "lastTrain": "23:58"
+          },
+          "saturday": {
+            "firstTrain": "05:48",
+            "lastTrain": "23:58"
+          },
+          "sunday_public_holiday": {
+            "firstTrain": "06:08",
+            "lastTrain": "23:58"
+          }
+        }
+      }
+    ]
+  },
+  "layout": {
+    "levels": [],
+    "exits": [],
+    "platforms": [
+      {
+        "id": "CCDT_A",
+        "label": "A",
+        "lineId": "CCL",
+        "serviceIds": [
+          "CCL_MAIN_CCW",
+          "CCL_EXT_CCW"
+        ],
+        "accessPoints": []
+      },
+      {
+        "id": "CCDT_B",
+        "label": "B",
+        "lineId": "CCL",
+        "serviceIds": [
+          "CCL_MAIN_CW",
+          "CCL_EXT_CW"
+        ],
+        "accessPoints": []
+      },
+      {
+        "id": "TCDT_B",
+        "label": "B",
+        "lineId": "TEL",
+        "serviceIds": [
+          "TEL_MAIN_N"
+        ],
+        "accessPoints": []
+      },
+      {
+        "id": "TCDT_A",
+        "label": "A",
+        "lineId": "TEL",
+        "serviceIds": [
+          "TEL_MAIN_S"
+        ],
+        "accessPoints": []
+      }
+    ],
+    "transferPaths": []
+  }
 }

--- a/data/station/LTI.json
+++ b/data/station/LTI.json
@@ -31,5 +31,77 @@
     "little-india-arcade",
     "tekka-centre"
   ],
-  "townId": "rochor"
+  "townId": "rochor",
+  "firstLastTrain": {
+    "services": [
+      {
+        "serviceId": "NEL_MAIN_N",
+        "times": {
+          "weekday": {
+            "firstTrain": "05:56",
+            "lastTrain": "00:07"
+          },
+          "saturday": {
+            "firstTrain": "05:56",
+            "lastTrain": "00:07"
+          },
+          "sunday_public_holiday": {
+            "firstTrain": "06:16",
+            "lastTrain": "00:07"
+          }
+        }
+      },
+      {
+        "serviceId": "NEL_MAIN_S",
+        "times": {
+          "weekday": {
+            "firstTrain": "06:04",
+            "lastTrain": "23:50"
+          },
+          "saturday": {
+            "firstTrain": "06:04",
+            "lastTrain": "23:50"
+          },
+          "sunday_public_holiday": {
+            "firstTrain": "06:24",
+            "lastTrain": "23:50"
+          }
+        }
+      },
+      {
+        "serviceId": "DTL_MAIN_E",
+        "times": {
+          "weekday": {
+            "firstTrain": "05:53",
+            "lastTrain": "23:58"
+          },
+          "saturday": {
+            "firstTrain": "05:53",
+            "lastTrain": "23:58"
+          },
+          "sunday_public_holiday": {
+            "firstTrain": "06:13",
+            "lastTrain": "23:58"
+          }
+        }
+      },
+      {
+        "serviceId": "DTL_MAIN_W",
+        "times": {
+          "weekday": {
+            "firstTrain": "06:06",
+            "lastTrain": "00:26"
+          },
+          "saturday": {
+            "firstTrain": "06:06",
+            "lastTrain": "00:26"
+          },
+          "sunday_public_holiday": {
+            "firstTrain": "06:30",
+            "lastTrain": "00:26"
+          }
+        }
+      }
+    ]
+  }
 }

--- a/docs/plans/active/station-first-last-train-data.md
+++ b/docs/plans/active/station-first-last-train-data.md
@@ -157,6 +157,19 @@ Start with these recurring special categories:
 Calendar categories should be data categories first. Any mapping to GTFS
 `calendar.txt` or `calendar_dates.txt` can happen in generator metadata later.
 
+## Source Policy
+
+Seed first/last train timings from official operator or agency sources, such as
+SMRT, SBS Transit, LTA, or published operator station pages. Transport
+enthusiast sites, wiki pages, blogs, and route guides can be useful for manual
+sanity checks, but they should not be the authoritative source for canonical
+timing values.
+
+When official sources disagree or expose different levels of detail, prefer the
+source that directly represents the operator-published passenger timing table.
+Do not add reusable ingestion scripts for undocumented operator APIs unless a
+later plan explicitly accepts that maintenance risk.
+
 ## Seeded Data Notes
 
 The first narrow seeds are intentionally hand-reviewed station records rather

--- a/docs/plans/active/station-first-last-train-data.md
+++ b/docs/plans/active/station-first-last-train-data.md
@@ -74,18 +74,46 @@ Add an optional `firstLastTrain` object to `StationSchema`:
 ```json
 {
   "firstLastTrain": {
-    "entries": [
+    "services": [
       {
         "serviceId": "TEL_MAIN_N",
-        "calendar": "weekday",
-        "firstTrain": "06:07",
-        "lastTrain": "00:07"
+        "times": {
+          "weekday": {
+            "firstTrain": "06:07",
+            "lastTrain": "00:07"
+          },
+          "saturday": {
+            "firstTrain": "06:07",
+            "lastTrain": "00:07"
+          },
+          "sunday_public_holiday": {
+            "firstTrain": "06:27",
+            "lastTrain": "00:07"
+          }
+        },
+        "specialTimes": {
+          "eve_public_holiday": {
+            "firstTrain": null,
+            "lastTrain": "00:35"
+          }
+        }
       },
       {
         "serviceId": "TEL_MAIN_N_TO_ORC",
-        "calendar": "weekday",
-        "firstTrain": null,
-        "lastTrain": "00:25"
+        "times": {
+          "weekday": {
+            "firstTrain": null,
+            "lastTrain": "00:25"
+          },
+          "saturday": {
+            "firstTrain": null,
+            "lastTrain": "00:25"
+          },
+          "sunday_public_holiday": {
+            "firstTrain": null,
+            "lastTrain": "00:25"
+          }
+        }
       }
     ]
   }
@@ -95,8 +123,13 @@ Add an optional `firstLastTrain` object to `StationSchema`:
 Rules:
 
 - `serviceId` is required.
-- `calendar` is required.
-- `firstTrain` and `lastTrain` are nullable, but at least one must be present.
+- `times` is keyed by normal calendar category.
+- `specialTimes` is keyed by recurring special calendar category.
+- Timing values always use the same shape:
+  `{ "firstTrain": "HH:mm" | null, "lastTrain": "HH:mm" | null }`.
+- At least one of `times` or `specialTimes` must be present for each service.
+- In every timing value, `firstTrain` and `lastTrain` are nullable, but at
+  least one must be non-null.
 - Times are local operating-day times in Singapore time. Values after midnight
   should use the displayed clock time, such as `00:25`, unless GTFS generation
   later needs a derived service-day offset.
@@ -111,15 +144,28 @@ Start with the categories used by published operator tables:
 - `weekday_saturday`
 - `daily`
 
-Add more categories only when a published table requires them. Candidate future
-categories:
+Add more normal categories only when a published table requires them. Candidate
+future categories:
 
-- `friday_saturday_eve_public_holiday`
 - `school_holiday`
 - `special`
 
+Start with these recurring special categories:
+
+- `eve_public_holiday`
+
 Calendar categories should be data categories first. Any mapping to GTFS
 `calendar.txt` or `calendar_dates.txt` can happen in generator metadata later.
+
+## Seeded Data Notes
+
+The first narrow seeds are intentionally hand-reviewed station records rather
+than outputs from a reusable operator ingest script:
+
+- `CDT` seeds one SMRT-operated interchange slice, including CCL/TEL platform
+  relationship validation.
+- `LTI` seeds one SBS Transit-operated interchange slice from the public SBS
+  Transit first/last train page, covering both NEL and DTL timing table shapes.
 
 ## Platform Relationship
 
@@ -132,9 +178,12 @@ This keeps timing rows simple:
 ```json
 {
   "serviceId": "TEL_MAIN_N",
-  "calendar": "weekday",
-  "firstTrain": "06:07",
-  "lastTrain": "00:07"
+  "times": {
+    "weekday": {
+      "firstTrain": "06:07",
+      "lastTrain": "00:07"
+    }
+  }
 }
 ```
 
@@ -159,7 +208,7 @@ Add validation that catches:
 - timing rows where the station is not in the referenced service path;
 - rows with both `firstTrain` and `lastTrain` set to `null`;
 - invalid local time values;
-- duplicate rows for the same `serviceId` and `calendar`;
+- duplicate rows for the same `serviceId`;
 - timing rows whose `serviceId` is not present on any station layout platform
   when layout data exists;
 - stations with no `firstLastTrain` continuing to validate.

--- a/docs/plans/active/station-first-last-train-data.md
+++ b/docs/plans/active/station-first-last-train-data.md
@@ -162,8 +162,8 @@ Calendar categories should be data categories first. Any mapping to GTFS
 The first narrow seeds are intentionally hand-reviewed station records rather
 than outputs from a reusable operator ingest script:
 
-- `CDT` seeds one SMRT-operated interchange slice, including CCL/TEL platform
-  relationship validation.
+- `CDT` seeds one SMRT-operated CCL/TEL platform relationship slice at an
+  interchange station, including current pre-CCL6 CCL main-service timings.
 - `LTI` seeds one SBS Transit-operated interchange slice from the public SBS
   Transit first/last train page, covering both NEL and DTL timing table shapes.
 

--- a/docs/plans/active/station-layout-data.md
+++ b/docs/plans/active/station-layout-data.md
@@ -378,7 +378,10 @@ Exit criteria:
 
 ### Phase 4: Seed Real Data
 
-- Seed one reviewed station first, preferably `OTP`, because it covers three
+- Seed `CDT` first as a narrow platform-to-service mapping slice because its
+  reviewed platform direction data maps cleanly to current CCL and TEL service
+  patterns.
+- Keep `OTP` as a later complete-layout candidate because it covers three
   lines, multiple platform levels, door-anchored access points, and multiple
   transfer path classifications.
 - Include reviewed station-root discovery metadata in the first station PR
@@ -386,6 +389,8 @@ Exit criteria:
 - Include public exits for the first station if reviewed exit labels and
   coordinates are available.
 - Keep the first data PR small enough for manual review.
+- The initial seed can start with platform-to-service mappings before levels,
+  exits, or access points when only platform direction data is reviewed.
 
 Exit criteria:
 

--- a/docs/plans/active/station-layout-data.md
+++ b/docs/plans/active/station-layout-data.md
@@ -378,9 +378,10 @@ Exit criteria:
 
 ### Phase 4: Seed Real Data
 
-- Seed `CDT` first as a narrow platform-to-service mapping slice because its
-  reviewed platform direction data maps cleanly to current CCL and TEL service
-  patterns.
+- Seed `CDT` first as a narrow CCL/TEL platform-to-service mapping slice
+  because its reviewed platform direction data maps cleanly to current service
+  patterns. The CCL rows use the current pre-CCL6 service catalog until the CCL6
+  service revisions are added.
 - Keep `OTP` as a later complete-layout candidate because it covers three
   lines, multiple platform levels, door-anchored access points, and multiple
   transfer path classifications.

--- a/docs/plans/active/station-layout-data.md
+++ b/docs/plans/active/station-layout-data.md
@@ -100,6 +100,20 @@ Rules:
 - Preserve `geo` as the authoritative station point; exit-specific coordinates
   belong in `layout.exits`.
 
+## Source Policy
+
+Seed station layout data from official operator or agency sources wherever
+available, such as LTA, SMRT, SBS Transit, operator station pages, official
+wayfinding maps, OneMap, or station signage reviewed directly. Transport
+enthusiast sites, wiki pages, blogs, and route guides can be used as
+non-authoritative cross-checks, but they should not be the source of record for
+canonical layout facts.
+
+When an official source does not expose a needed layout detail, leave that
+field absent until it can be reviewed from an official source or direct
+observation. Do not fill canonical layout fields solely from enthusiast
+secondary sources.
+
 ## Station Record Shape
 
 Add an optional `layout` object to `StationSchema`:

--- a/packages/core/src/schema/Station.test.ts
+++ b/packages/core/src/schema/Station.test.ts
@@ -194,4 +194,29 @@ describe('StationSchema', () => {
       }),
     ).not.toThrow();
   });
+
+  it('rejects layout platforms without service ids', () => {
+    const result = StationSchema.safeParse({
+      ...minimalStation(),
+      layout: {
+        levels: [],
+        exits: [],
+        platforms: [
+          {
+            id: 'KET_ISL_A',
+            label: 'A',
+            lineId: 'ISL',
+            serviceIds: [],
+            accessPoints: [],
+          },
+        ],
+        transferPaths: [],
+      },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0]?.path.join('.')).toBe(
+      'layout.platforms.0.serviceIds',
+    );
+  });
 });

--- a/packages/core/src/schema/Station.test.ts
+++ b/packages/core/src/schema/Station.test.ts
@@ -29,29 +29,39 @@ function minimalStation() {
 }
 
 describe('StationSchema', () => {
-  it('accepts first and last train entries with nullable halves', () => {
+  it('accepts first and last train services with nullable halves', () => {
     expect(() =>
       StationSchema.parse({
         ...minimalStation(),
         firstLastTrain: {
-          entries: [
+          services: [
             {
               serviceId: 'ISL_MAIN_E',
-              calendar: 'weekday',
-              firstTrain: '06:00',
-              lastTrain: '00:50',
-            },
-            {
-              serviceId: 'ISL_MAIN_E',
-              calendar: 'saturday',
-              firstTrain: '06:05',
-              lastTrain: null,
+              times: {
+                weekday: {
+                  firstTrain: '06:00',
+                  lastTrain: '00:50',
+                },
+                saturday: {
+                  firstTrain: '06:05',
+                  lastTrain: null,
+                },
+              },
+              specialTimes: {
+                eve_public_holiday: {
+                  firstTrain: null,
+                  lastTrain: '01:05',
+                },
+              },
             },
             {
               serviceId: 'ISL_MAIN_W',
-              calendar: 'weekday',
-              firstTrain: null,
-              lastTrain: '00:35',
+              times: {
+                weekday: {
+                  firstTrain: null,
+                  lastTrain: '00:35',
+                },
+              },
             },
           ],
         },
@@ -63,12 +73,15 @@ describe('StationSchema', () => {
     const result = StationSchema.safeParse({
       ...minimalStation(),
       firstLastTrain: {
-        entries: [
+        services: [
           {
             serviceId: 'ISL_MAIN_E',
-            calendar: 'weekday',
-            firstTrain: null,
-            lastTrain: null,
+            times: {
+              weekday: {
+                firstTrain: null,
+                lastTrain: null,
+              },
+            },
           },
         ],
       },
@@ -84,12 +97,21 @@ describe('StationSchema', () => {
     const result = StationSchema.safeParse({
       ...minimalStation(),
       firstLastTrain: {
-        entries: [
+        services: [
           {
             serviceId: 'ISL_MAIN_E',
-            calendar: 'holiday',
-            firstTrain: '25:00',
-            lastTrain: '00:50',
+            times: {
+              holiday: {
+                firstTrain: '25:00',
+                lastTrain: '00:50',
+              },
+            },
+            specialTimes: {
+              school_holiday: {
+                firstTrain: null,
+                lastTrain: '00:55',
+              },
+            },
           },
         ],
       },
@@ -98,9 +120,78 @@ describe('StationSchema', () => {
     expect(result.success).toBe(false);
     expect(result.error?.issues.map((issue) => issue.path.join('.'))).toEqual(
       expect.arrayContaining([
-        'firstLastTrain.entries.0.calendar',
-        'firstLastTrain.entries.0.firstTrain',
+        'firstLastTrain.services.0.times.holiday',
+        'firstLastTrain.services.0.specialTimes.school_holiday',
       ]),
     );
+  });
+
+  it('accepts station layout data', () => {
+    expect(() =>
+      StationSchema.parse({
+        ...minimalStation(),
+        layout: {
+          levels: [
+            {
+              id: 'B2',
+              index: -2,
+              name: {
+                'en-SG': 'Platforms',
+                'zh-Hans': null,
+                ms: null,
+                ta: null,
+              },
+            },
+          ],
+          exits: [
+            {
+              id: 'KET_EXIT_A',
+              label: 'A',
+              levelId: 'B2',
+              paidArea: false,
+            },
+          ],
+          platforms: [
+            {
+              id: 'KET_ISL_A',
+              label: 'A',
+              lineId: 'ISL',
+              levelId: 'B2',
+              serviceIds: ['ISL_MAIN_E'],
+              doorCount: 24,
+              accessPoints: [
+                {
+                  id: 'KET_ISL_A_ESC_01',
+                  kind: 'escalator',
+                  nearestDoor: '12',
+                  position: 'middle',
+                  connectsToLevelId: 'B2',
+                  direction: 'up',
+                },
+              ],
+            },
+          ],
+          transferPaths: [
+            {
+              id: 'KET_TRANSFER',
+              from: {
+                kind: 'platform',
+                id: 'KET_ISL_A',
+              },
+              to: {
+                kind: 'level',
+                id: 'B2',
+              },
+              paidArea: true,
+              modes: ['walk', 'escalator'],
+              levelChange: 0,
+              classification: 'short',
+              estimatedTraversalSeconds: null,
+              distanceMeters: null,
+            },
+          ],
+        },
+      }),
+    ).not.toThrow();
   });
 });

--- a/packages/core/src/schema/Station.ts
+++ b/packages/core/src/schema/Station.ts
@@ -178,7 +178,7 @@ export const StationLayoutPlatformSchema = z.object({
   label: z.string(),
   lineId: z.string(),
   levelId: z.string().optional(),
-  serviceIds: z.array(z.string()),
+  serviceIds: z.array(z.string()).nonempty(),
   doorCount: z.number().int().positive().optional(),
   accessPoints: z.array(StationLayoutAccessPointSchema),
 });

--- a/packages/core/src/schema/Station.ts
+++ b/packages/core/src/schema/Station.ts
@@ -12,25 +12,208 @@ export type StationFirstLastTrainCalendar = z.infer<
   typeof StationFirstLastTrainCalendarSchema
 >;
 
-export const StationFirstLastTrainEntrySchema = z
+export const StationFirstLastTrainSpecialCalendarSchema = z.enum([
+  'eve_public_holiday',
+]);
+export type StationFirstLastTrainSpecialCalendar = z.infer<
+  typeof StationFirstLastTrainSpecialCalendarSchema
+>;
+
+export const StationFirstLastTrainTimeSchema = z
   .object({
-    serviceId: z.string(),
-    calendar: StationFirstLastTrainCalendarSchema,
     firstTrain: z.iso.time().nullable(),
     lastTrain: z.iso.time().nullable(),
   })
   .refine(
-    (entry) => entry.firstTrain !== null || entry.lastTrain !== null,
+    (entry) => entry.firstTrain != null || entry.lastTrain != null,
     'At least one of firstTrain or lastTrain must be set',
   );
-export type StationFirstLastTrainEntry = z.infer<
-  typeof StationFirstLastTrainEntrySchema
+export type StationFirstLastTrainTime = z.infer<
+  typeof StationFirstLastTrainTimeSchema
+>;
+
+export const StationFirstLastTrainServiceSchema = z
+  .object({
+    serviceId: z.string(),
+    times: z
+      .partialRecord(
+        StationFirstLastTrainCalendarSchema,
+        StationFirstLastTrainTimeSchema,
+      )
+      .optional(),
+    specialTimes: z
+      .partialRecord(
+        StationFirstLastTrainSpecialCalendarSchema,
+        StationFirstLastTrainTimeSchema,
+      )
+      .optional(),
+  })
+  .refine(
+    (service) =>
+      Object.keys(service.times ?? {}).length > 0 ||
+      Object.keys(service.specialTimes ?? {}).length > 0,
+    'At least one of times or specialTimes must be set',
+  );
+export type StationFirstLastTrainService = z.infer<
+  typeof StationFirstLastTrainServiceSchema
 >;
 
 export const StationFirstLastTrainSchema = z.object({
-  entries: z.array(StationFirstLastTrainEntrySchema),
+  services: z.array(StationFirstLastTrainServiceSchema),
 });
 export type StationFirstLastTrain = z.infer<typeof StationFirstLastTrainSchema>;
+
+export const StationLayoutAccessPointKindSchema = z.enum([
+  'stairs',
+  'escalator',
+  'lift',
+  'travellator',
+  'ramp',
+  'gate',
+  'concourse_link',
+  'other',
+]);
+export type StationLayoutAccessPointKind = z.infer<
+  typeof StationLayoutAccessPointKindSchema
+>;
+
+export const StationLayoutAccessPointPositionSchema = z.enum([
+  'front',
+  'middle',
+  'rear',
+  'unknown',
+]);
+export type StationLayoutAccessPointPosition = z.infer<
+  typeof StationLayoutAccessPointPositionSchema
+>;
+
+export const StationLayoutAccessPointDirectionSchema = z.enum([
+  'up',
+  'down',
+  'bidirectional',
+  'unknown',
+]);
+export type StationLayoutAccessPointDirection = z.infer<
+  typeof StationLayoutAccessPointDirectionSchema
+>;
+
+export const StationLayoutTransferEndpointKindSchema = z.enum([
+  'platform',
+  'access_point',
+  'level',
+]);
+export type StationLayoutTransferEndpointKind = z.infer<
+  typeof StationLayoutTransferEndpointKindSchema
+>;
+
+export const StationLayoutTransferModeSchema = z.enum([
+  'walk',
+  'stairs',
+  'escalator',
+  'lift',
+  'travellator',
+  'ramp',
+]);
+export type StationLayoutTransferMode = z.infer<
+  typeof StationLayoutTransferModeSchema
+>;
+
+export const StationLayoutTransferClassificationSchema = z.enum([
+  'same_platform',
+  'short',
+  'medium',
+  'long',
+  'out_of_station',
+  'not_recommended',
+  'restricted',
+  'unknown',
+]);
+export type StationLayoutTransferClassification = z.infer<
+  typeof StationLayoutTransferClassificationSchema
+>;
+
+export const StationLayoutLevelSchema = z.object({
+  id: z.string(),
+  index: z.number().int(),
+  name: TranslationsSchema,
+});
+export type StationLayoutLevel = z.infer<typeof StationLayoutLevelSchema>;
+
+export const StationLayoutExitSchema = z.object({
+  id: z.string(),
+  label: z.string(),
+  levelId: z.string().optional(),
+  geo: z
+    .object({
+      latitude: z.number().gte(-90).lte(90),
+      longitude: z.number().gte(-180).lte(180),
+    })
+    .optional(),
+  nearbyLandmarkIds: z.array(z.string()).optional(),
+  roadNames: z.array(z.string()).optional(),
+  paidArea: z.boolean(),
+  accessibility: z
+    .object({
+      stepFree: z.boolean().optional(),
+      lift: z.boolean().optional(),
+    })
+    .optional(),
+});
+export type StationLayoutExit = z.infer<typeof StationLayoutExitSchema>;
+
+export const StationLayoutAccessPointSchema = z.object({
+  id: z.string(),
+  kind: StationLayoutAccessPointKindSchema,
+  nearestDoor: z.string().optional(),
+  position: StationLayoutAccessPointPositionSchema,
+  connectsToLevelId: z.string().optional(),
+  direction: StationLayoutAccessPointDirectionSchema.optional(),
+});
+export type StationLayoutAccessPoint = z.infer<
+  typeof StationLayoutAccessPointSchema
+>;
+
+export const StationLayoutPlatformSchema = z.object({
+  id: z.string(),
+  label: z.string(),
+  lineId: z.string(),
+  levelId: z.string().optional(),
+  serviceIds: z.array(z.string()),
+  doorCount: z.number().int().positive().optional(),
+  accessPoints: z.array(StationLayoutAccessPointSchema),
+});
+export type StationLayoutPlatform = z.infer<typeof StationLayoutPlatformSchema>;
+
+export const StationLayoutTransferEndpointSchema = z.object({
+  kind: StationLayoutTransferEndpointKindSchema,
+  id: z.string(),
+});
+export type StationLayoutTransferEndpoint = z.infer<
+  typeof StationLayoutTransferEndpointSchema
+>;
+
+export const StationLayoutTransferPathSchema = z.object({
+  id: z.string(),
+  from: StationLayoutTransferEndpointSchema,
+  to: StationLayoutTransferEndpointSchema,
+  paidArea: z.boolean(),
+  modes: z.array(StationLayoutTransferModeSchema),
+  levelChange: z.number().int().nullable(),
+  classification: StationLayoutTransferClassificationSchema,
+  estimatedTraversalSeconds: z.number().int().positive().nullable(),
+  distanceMeters: z.number().positive().nullable(),
+});
+export type StationLayoutTransferPath = z.infer<
+  typeof StationLayoutTransferPathSchema
+>;
+
+export const StationLayoutSchema = z.object({
+  levels: z.array(StationLayoutLevelSchema),
+  exits: z.array(StationLayoutExitSchema),
+  platforms: z.array(StationLayoutPlatformSchema),
+  transferPaths: z.array(StationLayoutTransferPathSchema),
+});
+export type StationLayout = z.infer<typeof StationLayoutSchema>;
 
 export const StationStructureTypeSchema = z.enum([
   'elevated',
@@ -59,5 +242,6 @@ export const StationSchema = z.object({
   landmarkIds: z.array(z.string()),
   townId: z.string(),
   firstLastTrain: StationFirstLastTrainSchema.optional(),
+  layout: StationLayoutSchema.optional(),
 });
 export type Station = z.infer<typeof StationSchema>;

--- a/packages/fs/src/index.test.ts
+++ b/packages/fs/src/index.test.ts
@@ -2750,7 +2750,7 @@ describe('@mrtdown/fs', () => {
                 id: 'KET_TWL_A',
                 label: 'A',
                 lineId: 'ISL',
-                serviceIds: ['TWL_MAIN_N'],
+                serviceIds: ['TWL_MAIN_N', 'ISL_SKIP_KET'],
                 accessPoints: [
                   {
                     id: 'KET_AP_DUP',
@@ -2785,6 +2785,48 @@ describe('@mrtdown/fs', () => {
         2,
       )}\n`,
     );
+    await writeFile(
+      join(dataDir, 'service/ISL_SKIP_KET.json'),
+      `${JSON.stringify(
+        {
+          id: 'ISL_SKIP_KET',
+          name: {
+            'en-SG': 'Island Line Skip Kennedy Town',
+            'zh-Hans': null,
+            ms: null,
+            ta: null,
+          },
+          lineId: 'ISL',
+          revisions: [
+            {
+              id: 'r_current',
+              startAt: '1979-10-01',
+              endAt: null,
+              path: {
+                stations: [
+                  {
+                    stationId: 'HKU',
+                    displayCode: 'ISL2',
+                  },
+                ],
+              },
+              operatingHours: {
+                weekdays: {
+                  start: '05:30',
+                  end: '00:30',
+                },
+                weekends: {
+                  start: '05:30',
+                  end: '00:30',
+                },
+              },
+            },
+          ],
+        },
+        null,
+        2,
+      )}\n`,
+    );
 
     const result = await validateDataRoot(dataDir, ['station']);
 
@@ -2799,6 +2841,7 @@ describe('@mrtdown/fs', () => {
         'station/KET.json: layout.platforms.0.levelId MISSING does not exist in layout.levels',
         'station/KET.json: layout.platforms.0.serviceIds.0 MISSING_SERVICE does not exist in service/',
         'station/KET.json: layout.platforms.1.serviceIds.0 TWL_MAIN_N belongs to line TWL, not ISL',
+        'station/KET.json: layout.platforms.1.serviceIds.1 ISL_SKIP_KET revision r_current does not include station KET in its current service path',
         'station/KET.json: layout.platforms.0.accessPoints.0.connectsToLevelId MISSING does not exist in layout.levels',
         'station/KET.json: layout.platforms.0.accessPoints.0.nearestDoor 25 is outside doorCount 24',
         'station/KET.json: layout.transferPaths.0.from platform MISSING_PLATFORM does not exist in layout',

--- a/packages/fs/src/index.test.ts
+++ b/packages/fs/src/index.test.ts
@@ -2409,48 +2409,69 @@ describe('@mrtdown/fs', () => {
           landmarkIds: [],
           townId: 'central-western',
           firstLastTrain: {
-            entries: [
+            services: [
               {
                 serviceId: 'ISL_MAIN_E',
-                calendar: 'weekday',
-                firstTrain: '06:00',
-                lastTrain: '00:50',
+                times: {
+                  weekday: {
+                    firstTrain: '06:00',
+                    lastTrain: '00:50',
+                  },
+                },
               },
               {
                 serviceId: 'ISL_MAIN_E',
-                calendar: 'weekday',
-                firstTrain: '06:05',
-                lastTrain: null,
+                times: {
+                  saturday: {
+                    firstTrain: '06:05',
+                    lastTrain: null,
+                  },
+                },
               },
               {
                 serviceId: 'MISSING',
-                calendar: 'weekday',
-                firstTrain: null,
-                lastTrain: '00:30',
+                times: {
+                  weekday: {
+                    firstTrain: null,
+                    lastTrain: '00:30',
+                  },
+                },
               },
               {
                 serviceId: 'TWL_MAIN_N',
-                calendar: 'weekday',
-                firstTrain: null,
-                lastTrain: '00:35',
+                times: {
+                  weekday: {
+                    firstTrain: null,
+                    lastTrain: '00:35',
+                  },
+                },
               },
               {
                 serviceId: 'ISL_ENDED',
-                calendar: 'weekday',
-                firstTrain: '06:10',
-                lastTrain: null,
+                times: {
+                  weekday: {
+                    firstTrain: '06:10',
+                    lastTrain: null,
+                  },
+                },
               },
               {
                 serviceId: 'ISL_FUTURE_ENDED',
-                calendar: 'daily',
-                firstTrain: '06:15',
-                lastTrain: null,
+                times: {
+                  daily: {
+                    firstTrain: '06:15',
+                    lastTrain: null,
+                  },
+                },
               },
               {
                 serviceId: 'ISL_MULTI_CURRENT',
-                calendar: 'sunday_public_holiday',
-                firstTrain: null,
-                lastTrain: '00:45',
+                times: {
+                  sunday_public_holiday: {
+                    firstTrain: null,
+                    lastTrain: '00:45',
+                  },
+                },
               },
             ],
           },
@@ -2614,16 +2635,175 @@ describe('@mrtdown/fs', () => {
     expect(result.ok).toBe(false);
     expect(result.errors).toEqual(
       expect.arrayContaining([
-        'station/KET.json: firstLastTrain.entries.1 duplicates serviceId/calendar ISL_MAIN_E:weekday (first seen at firstLastTrain.entries.0)',
-        'station/KET.json: firstLastTrain.entries.2.serviceId MISSING does not exist in service/',
-        'station/KET.json: firstLastTrain.entries.3.serviceId TWL_MAIN_N revision r_initial does not include station KET in its current service path',
-        'station/KET.json: firstLastTrain.entries.4.serviceId ISL_ENDED does not have a current service revision',
-        'station/KET.json: firstLastTrain.entries.6.serviceId ISL_MULTI_CURRENT revision r_hku does not include station KET in its current service path',
+        'station/KET.json: firstLastTrain.services.1.serviceId ISL_MAIN_E duplicates firstLastTrain.services.0.serviceId',
+        'station/KET.json: firstLastTrain.services.2.serviceId MISSING does not exist in service/',
+        'station/KET.json: firstLastTrain.services.3.serviceId TWL_MAIN_N revision r_initial does not include station KET in its current service path',
+        'station/KET.json: firstLastTrain.services.4.serviceId ISL_ENDED does not have a current service revision',
+        'station/KET.json: firstLastTrain.services.6.serviceId ISL_MULTI_CURRENT revision r_hku does not include station KET in its current service path',
       ]),
     );
     expect(result.errors).not.toEqual(
       expect.arrayContaining([
-        'station/KET.json: firstLastTrain.entries.5.serviceId ISL_FUTURE_ENDED does not have a current service revision',
+        'station/KET.json: firstLastTrain.services.5.serviceId ISL_FUTURE_ENDED does not have a current service revision',
+      ]),
+    );
+  });
+
+  it('rejects invalid station layout relationships', async () => {
+    const dataDir = await mkdtemp(join(tmpdir(), 'mrtdown-fs-'));
+    await cp(fixtureDataDir, dataDir, { recursive: true });
+    await writeFile(
+      join(dataDir, 'station/KET.json'),
+      `${JSON.stringify(
+        {
+          id: 'KET',
+          name: {
+            'en-SG': 'Kennedy Town',
+            'zh-Hans': null,
+            ms: null,
+            ta: null,
+          },
+          geo: {
+            latitude: 22.2813,
+            longitude: 114.1286,
+          },
+          stationCodes: [
+            {
+              lineId: 'ISL',
+              code: 'ISL1',
+              startedAt: '1979-10-01T00:00:00Z',
+              endedAt: null,
+              structureType: 'underground',
+            },
+          ],
+          landmarkIds: [],
+          townId: 'central-western',
+          firstLastTrain: {
+            services: [
+              {
+                serviceId: 'ISL_MAIN_E',
+                times: {
+                  weekday: {
+                    firstTrain: '06:00',
+                    lastTrain: '00:50',
+                  },
+                },
+              },
+            ],
+          },
+          layout: {
+            levels: [
+              {
+                id: 'B2',
+                index: -2,
+                name: {
+                  'en-SG': 'Platforms',
+                  'zh-Hans': null,
+                  ms: null,
+                  ta: null,
+                },
+              },
+              {
+                id: 'B2',
+                index: -2,
+                name: {
+                  'en-SG': 'Duplicate platforms',
+                  'zh-Hans': null,
+                  ms: null,
+                  ta: null,
+                },
+              },
+            ],
+            exits: [
+              {
+                id: 'KET_EXIT_A',
+                label: 'A',
+                levelId: 'MISSING',
+                nearbyLandmarkIds: ['missing-landmark'],
+                paidArea: false,
+              },
+              {
+                id: 'KET_EXIT_B',
+                label: 'a',
+                paidArea: false,
+              },
+            ],
+            platforms: [
+              {
+                id: 'KET_ISL_A',
+                label: 'A',
+                lineId: 'ISL',
+                levelId: 'MISSING',
+                serviceIds: ['MISSING_SERVICE'],
+                doorCount: 24,
+                accessPoints: [
+                  {
+                    id: 'KET_AP_DUP',
+                    kind: 'escalator',
+                    nearestDoor: '25',
+                    position: 'middle',
+                    connectsToLevelId: 'MISSING',
+                  },
+                ],
+              },
+              {
+                id: 'KET_TWL_A',
+                label: 'A',
+                lineId: 'ISL',
+                serviceIds: ['TWL_MAIN_N'],
+                accessPoints: [
+                  {
+                    id: 'KET_AP_DUP',
+                    kind: 'stairs',
+                    position: 'front',
+                  },
+                ],
+              },
+            ],
+            transferPaths: [
+              {
+                id: 'KET_TRANSFER',
+                from: {
+                  kind: 'platform',
+                  id: 'MISSING_PLATFORM',
+                },
+                to: {
+                  kind: 'access_point',
+                  id: 'MISSING_ACCESS_POINT',
+                },
+                paidArea: true,
+                modes: ['walk'],
+                levelChange: null,
+                classification: 'unknown',
+                estimatedTraversalSeconds: null,
+                distanceMeters: null,
+              },
+            ],
+          },
+        },
+        null,
+        2,
+      )}\n`,
+    );
+
+    const result = await validateDataRoot(dataDir, ['station']);
+
+    expect(result.ok).toBe(false);
+    expect(result.errors).toEqual(
+      expect.arrayContaining([
+        'station/KET.json: layout.levels.1 duplicates B2 (first seen at layout.levels.0)',
+        'station/KET.json: layout.exits.label.1 duplicates a (first seen at layout.exits.label.0)',
+        'station/KET.json: layout.platforms.1.accessPoints.0.id KET_AP_DUP duplicates another access point id in layout',
+        'station/KET.json: layout.exits.0.levelId MISSING does not exist in layout.levels',
+        'station/KET.json: layout.exits.0.nearbyLandmarkIds.0 missing-landmark does not exist in landmark/',
+        'station/KET.json: layout.platforms.0.levelId MISSING does not exist in layout.levels',
+        'station/KET.json: layout.platforms.0.serviceIds.0 MISSING_SERVICE does not exist in service/',
+        'station/KET.json: layout.platforms.1.serviceIds.0 TWL_MAIN_N belongs to line TWL, not ISL',
+        'station/KET.json: layout.platforms.0.accessPoints.0.connectsToLevelId MISSING does not exist in layout.levels',
+        'station/KET.json: layout.platforms.0.accessPoints.0.nearestDoor 25 is outside doorCount 24',
+        'station/KET.json: layout.transferPaths.0.from platform MISSING_PLATFORM does not exist in layout',
+        'station/KET.json: layout.transferPaths.0.to access_point MISSING_ACCESS_POINT does not exist in layout',
+        'station/KET.json: firstLastTrain.services.0.serviceId ISL_MAIN_E is not served by any layout platform',
       ]),
     );
   });

--- a/packages/fs/src/validate.ts
+++ b/packages/fs/src/validate.ts
@@ -352,6 +352,31 @@ async function validateStationReferences(
             errors.push(
               `${station.path}: layout.platforms.${platformIndex}.serviceIds.${serviceIndex} ${serviceId} belongs to line ${service.value.lineId}, not ${platform.lineId}`,
             );
+            continue;
+          }
+
+          const currentRevisions = service.value.revisions.filter((revision) =>
+            revisionContainsTimestamp(revision, validationTimestamp),
+          );
+          if (currentRevisions.length === 0) {
+            errors.push(
+              `${station.path}: layout.platforms.${platformIndex}.serviceIds.${serviceIndex} ${serviceId} does not have a current service revision`,
+            );
+            continue;
+          }
+
+          for (const revision of currentRevisions) {
+            const stationIds = new Set(
+              revision.path.stations.map(
+                (serviceStation) => serviceStation.stationId,
+              ),
+            );
+
+            if (!stationIds.has(station.value.id)) {
+              errors.push(
+                `${station.path}: layout.platforms.${platformIndex}.serviceIds.${serviceIndex} ${serviceId} revision ${revision.id} does not include station ${station.value.id} in its current service path`,
+              );
+            }
           }
         }
       }

--- a/packages/fs/src/validate.ts
+++ b/packages/fs/src/validate.ts
@@ -96,6 +96,26 @@ function impactEventSetterKey(event: ImpactEvent): string {
   );
 }
 
+function validateDuplicateValue(
+  errors: string[],
+  path: string,
+  label: string,
+  values: Iterable<[number, string]>,
+): void {
+  const seen = new Map<string, number>();
+
+  for (const [index, value] of values) {
+    const previousIndex = seen.get(value);
+    if (previousIndex != null) {
+      errors.push(
+        `${path}: ${label}.${index} duplicates ${value} (first seen at ${label}.${previousIndex})`,
+      );
+    } else {
+      seen.set(value, index);
+    }
+  }
+}
+
 async function loadEntityRecords<K extends EntityCollection>(
   dataDir: string,
   records: ValidationRecords,
@@ -204,24 +224,187 @@ async function validateStationReferences(
       }
     }
 
-    const seenFirstLastTrainEntries = new Map<string, number>();
-    for (const [index, entry] of (
-      station.value.firstLastTrain?.entries ?? []
-    ).entries()) {
-      const key = `${entry.serviceId}:${entry.calendar}`;
-      const previousIndex = seenFirstLastTrainEntries.get(key);
-      if (previousIndex != null) {
-        errors.push(
-          `${station.path}: firstLastTrain.entries.${index} duplicates serviceId/calendar ${key} (first seen at firstLastTrain.entries.${previousIndex})`,
-        );
-      } else {
-        seenFirstLastTrainEntries.set(key, index);
+    const layoutPlatformServiceIds = new Set<string>();
+    const layout = station.value.layout;
+    if (layout) {
+      validateDuplicateValue(
+        errors,
+        station.path,
+        'layout.levels',
+        layout.levels.map((level, index) => [index, level.id]),
+      );
+      validateDuplicateValue(
+        errors,
+        station.path,
+        'layout.exits',
+        layout.exits.map((exit, index) => [index, exit.id]),
+      );
+      validateDuplicateValue(
+        errors,
+        station.path,
+        'layout.exits.label',
+        layout.exits.map((exit, index) => [
+          index,
+          exit.label.trim().toLowerCase(),
+        ]),
+      );
+      validateDuplicateValue(
+        errors,
+        station.path,
+        'layout.platforms',
+        layout.platforms.map((platform, index) => [index, platform.id]),
+      );
+      validateDuplicateValue(
+        errors,
+        station.path,
+        'layout.transferPaths',
+        layout.transferPaths.map((transferPath, index) => [
+          index,
+          transferPath.id,
+        ]),
+      );
+
+      const layoutLevelIds = new Set(layout.levels.map((level) => level.id));
+      const layoutPlatformIds = new Set(
+        layout.platforms.map((platform) => platform.id),
+      );
+      const layoutAccessPointIds = new Set<string>();
+
+      for (const [platformIndex, platform] of layout.platforms.entries()) {
+        for (const [
+          accessPointIndex,
+          accessPoint,
+        ] of platform.accessPoints.entries()) {
+          const previousSize = layoutAccessPointIds.size;
+          layoutAccessPointIds.add(accessPoint.id);
+          if (layoutAccessPointIds.size === previousSize) {
+            errors.push(
+              `${station.path}: layout.platforms.${platformIndex}.accessPoints.${accessPointIndex}.id ${accessPoint.id} duplicates another access point id in layout`,
+            );
+          }
+
+          if (
+            accessPoint.connectsToLevelId &&
+            !layoutLevelIds.has(accessPoint.connectsToLevelId)
+          ) {
+            errors.push(
+              `${station.path}: layout.platforms.${platformIndex}.accessPoints.${accessPointIndex}.connectsToLevelId ${accessPoint.connectsToLevelId} does not exist in layout.levels`,
+            );
+          }
+
+          const numericDoor = accessPoint.nearestDoor
+            ? Number(accessPoint.nearestDoor)
+            : Number.NaN;
+          if (
+            platform.doorCount != null &&
+            Number.isInteger(numericDoor) &&
+            (numericDoor < 1 || numericDoor > platform.doorCount)
+          ) {
+            errors.push(
+              `${station.path}: layout.platforms.${platformIndex}.accessPoints.${accessPointIndex}.nearestDoor ${accessPoint.nearestDoor} is outside doorCount ${platform.doorCount}`,
+            );
+          }
+        }
       }
 
-      const service = serviceById.get(entry.serviceId);
+      for (const [exitIndex, exit] of layout.exits.entries()) {
+        if (exit.levelId && !layoutLevelIds.has(exit.levelId)) {
+          errors.push(
+            `${station.path}: layout.exits.${exitIndex}.levelId ${exit.levelId} does not exist in layout.levels`,
+          );
+        }
+
+        for (const [landmarkIndex, landmarkId] of (
+          exit.nearbyLandmarkIds ?? []
+        ).entries()) {
+          if (!landmarkIds.has(landmarkId)) {
+            errors.push(
+              `${station.path}: layout.exits.${exitIndex}.nearbyLandmarkIds.${landmarkIndex} ${landmarkId} does not exist in landmark/`,
+            );
+          }
+        }
+      }
+
+      for (const [platformIndex, platform] of layout.platforms.entries()) {
+        if (!lineIds.has(platform.lineId)) {
+          errors.push(
+            `${station.path}: layout.platforms.${platformIndex}.lineId ${platform.lineId} does not exist in line/`,
+          );
+        }
+
+        if (platform.levelId && !layoutLevelIds.has(platform.levelId)) {
+          errors.push(
+            `${station.path}: layout.platforms.${platformIndex}.levelId ${platform.levelId} does not exist in layout.levels`,
+          );
+        }
+
+        for (const [serviceIndex, serviceId] of platform.serviceIds.entries()) {
+          layoutPlatformServiceIds.add(serviceId);
+          const service = serviceById.get(serviceId);
+          if (!service) {
+            errors.push(
+              `${station.path}: layout.platforms.${platformIndex}.serviceIds.${serviceIndex} ${serviceId} does not exist in service/`,
+            );
+            continue;
+          }
+
+          if (service.value.lineId !== platform.lineId) {
+            errors.push(
+              `${station.path}: layout.platforms.${platformIndex}.serviceIds.${serviceIndex} ${serviceId} belongs to line ${service.value.lineId}, not ${platform.lineId}`,
+            );
+          }
+        }
+      }
+
+      for (const [
+        transferPathIndex,
+        transferPath,
+      ] of layout.transferPaths.entries()) {
+        for (const [endpointName, endpoint] of [
+          ['from', transferPath.from],
+          ['to', transferPath.to],
+        ] as const) {
+          const endpointExists =
+            (endpoint.kind === 'level' && layoutLevelIds.has(endpoint.id)) ||
+            (endpoint.kind === 'platform' &&
+              layoutPlatformIds.has(endpoint.id)) ||
+            (endpoint.kind === 'access_point' &&
+              layoutAccessPointIds.has(endpoint.id));
+
+          if (!endpointExists) {
+            errors.push(
+              `${station.path}: layout.transferPaths.${transferPathIndex}.${endpointName} ${endpoint.kind} ${endpoint.id} does not exist in layout`,
+            );
+          }
+        }
+      }
+    }
+
+    const seenFirstLastTrainServices = new Map<string, number>();
+    for (const [index, serviceTiming] of (
+      station.value.firstLastTrain?.services ?? []
+    ).entries()) {
+      const previousIndex = seenFirstLastTrainServices.get(
+        serviceTiming.serviceId,
+      );
+      if (previousIndex != null) {
+        errors.push(
+          `${station.path}: firstLastTrain.services.${index}.serviceId ${serviceTiming.serviceId} duplicates firstLastTrain.services.${previousIndex}.serviceId`,
+        );
+      } else {
+        seenFirstLastTrainServices.set(serviceTiming.serviceId, index);
+      }
+
+      if (layout && !layoutPlatformServiceIds.has(serviceTiming.serviceId)) {
+        errors.push(
+          `${station.path}: firstLastTrain.services.${index}.serviceId ${serviceTiming.serviceId} is not served by any layout platform`,
+        );
+      }
+
+      const service = serviceById.get(serviceTiming.serviceId);
       if (!service) {
         errors.push(
-          `${station.path}: firstLastTrain.entries.${index}.serviceId ${entry.serviceId} does not exist in service/`,
+          `${station.path}: firstLastTrain.services.${index}.serviceId ${serviceTiming.serviceId} does not exist in service/`,
         );
         continue;
       }
@@ -231,7 +414,7 @@ async function validateStationReferences(
       );
       if (currentRevisions.length === 0) {
         errors.push(
-          `${station.path}: firstLastTrain.entries.${index}.serviceId ${entry.serviceId} does not have a current service revision`,
+          `${station.path}: firstLastTrain.services.${index}.serviceId ${serviceTiming.serviceId} does not have a current service revision`,
         );
         continue;
       }
@@ -245,7 +428,7 @@ async function validateStationReferences(
 
         if (!stationIds.has(station.value.id)) {
           errors.push(
-            `${station.path}: firstLastTrain.entries.${index}.serviceId ${entry.serviceId} revision ${revision.id} does not include station ${station.value.id} in its current service path`,
+            `${station.path}: firstLastTrain.services.${index}.serviceId ${serviceTiming.serviceId} revision ${revision.id} does not include station ${station.value.id} in its current service path`,
           );
         }
       }

--- a/scripts/generate-fixtures.mjs
+++ b/scripts/generate-fixtures.mjs
@@ -296,24 +296,28 @@ function buildStaticEntities() {
       'central-western',
       [],
       {
-        entries: [
+        services: [
           {
             serviceId: 'ISL_MAIN_E',
-            calendar: 'weekday',
-            firstTrain: '06:00',
-            lastTrain: '00:50',
-          },
-          {
-            serviceId: 'ISL_MAIN_E',
-            calendar: 'saturday',
-            firstTrain: '06:05',
-            lastTrain: null,
+            times: {
+              weekday: {
+                firstTrain: '06:00',
+                lastTrain: '00:50',
+              },
+              saturday: {
+                firstTrain: '06:05',
+                lastTrain: null,
+              },
+            },
           },
           {
             serviceId: 'ISL_MAIN_W',
-            calendar: 'weekday',
-            firstTrain: null,
-            lastTrain: '00:35',
+            times: {
+              weekday: {
+                firstTrain: null,
+                lastTrain: '00:35',
+              },
+            },
           },
         ],
       },


### PR DESCRIPTION
## Summary

- Add grouped station `firstLastTrain` schemas with normal and recurring special calendar timing maps.
- Add station layout schema support and repository validation for layout references, platform service coverage, and first/last train service references.
- Seed reviewed `CDT` and `LTI` station timing data, including one SBS Transit sanity-check slice, and update the active plans to match the implemented shape.

## Validation

- `npm run test:core`
- `npm run test:fs`
- `npm run data:validate`
- `npm run check`

Note: Turbo printed its local `IO error: Operation not permitted` warning during some runs, but all validation commands exited successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Station records now include per-service first/last train times (weekday/saturday/sunday & public holidays) and an optional station layout with platforms and platform→service mappings.

* **Documentation**
  * Updated data plan and seeding guidance to the new services/times shape and revised seeding order for layouts.

* **Tests**
  * Tests added/updated to validate the new timing schema, special calendars, layout structure, and duplicate/coverage checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->