### PR TITLE
test: cover crowd report ingest persistence

### DIFF
--- a/docs/plans/active/crowdsourced-reports.md
+++ b/docs/plans/active/crowdsourced-reports.md
@@ -202,6 +202,9 @@ Exit criteria:
   tests, triage text formatting, and public-report evidence type mapping.
 - 2026-06-13: Added a checked-in crowd-report ingest fixture for manual
   workflow dispatch and deterministic contract validation.
+- 2026-06-13: Added deterministic `ingestContent` coverage proving the checked-in
+  crowd-report fixture can create canonical `report.public` evidence and impact
+  events without a special persistence path.
 
 ## Decision Log
 

--- a/packages/triage/src/util/ingestContent/index.test.ts
+++ b/packages/triage/src/util/ingestContent/index.test.ts
@@ -1,7 +1,8 @@
 import { constants } from 'node:fs';
-import { access, cp, mkdtemp, rm } from 'node:fs/promises';
+import { access, cp, mkdtemp, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
+import { readIssueBundle } from '@mrtdown/fs';
 import type { IngestContent } from '@mrtdown/ingest-contracts';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { ingestContent } from './index.js';
@@ -32,6 +33,10 @@ vi.mock('../../llm/functions/triageNewEvidence/index.js', () => ({
 const FIXTURE_DATA_DIR = resolve(
   process.env.MRTDOWN_FIXTURE_DATA_DIR ??
     resolve(import.meta.dirname, '../../../../../fixtures/generated/data'),
+);
+const CROWD_REPORT_FIXTURE = resolve(
+  import.meta.dirname,
+  '../../../../../fixtures/ingest/crowd-report.json',
 );
 
 describe('ingestContent', () => {
@@ -71,6 +76,99 @@ describe('ingestContent', () => {
         dataDir,
         'issue/2026/05/2026-05-26-bus-service-26-vehicle-breakdown-sims-avenue-east-chai-chee-drive-bs-83081',
       ),
+    );
+  });
+
+  test('creates canonical public-report evidence from an accepted crowd report', async () => {
+    mocks.triageNewEvidence.mockResolvedValue({
+      result: { kind: 'part-of-new-issue', issueType: 'disruption' },
+    });
+    mocks.extractClaimsFromNewEvidence.mockResolvedValue({
+      claims: [
+        {
+          entity: { type: 'service', serviceId: 'DTL_MAIN_E' },
+          effect: {
+            service: { kind: 'delay', duration: 'PT15M' },
+            facility: null,
+          },
+          scopes: {
+            service: [{ type: 'service.point', stationId: 'BCL' }],
+          },
+          statusSignal: 'open',
+          timeHints: {
+            kind: 'start-only',
+            startAt: '2026-05-23T09:03:00+08:00',
+          },
+          causes: ['delay'],
+        },
+      ],
+    });
+    mocks.generateIssueTitleAndSlug.mockResolvedValue({
+      title: 'Downtown Line delay near Beauty World',
+      slug: 'downtown-line-delay-near-beauty-world',
+    });
+    mocks.translate.mockImplementation(async (text: string) => ({
+      'en-SG': text,
+      'zh-Hans': null,
+      ms: null,
+      ta: null,
+    }));
+
+    const fixture = JSON.parse(
+      await readFile(CROWD_REPORT_FIXTURE, 'utf8'),
+    ) as {
+      content: [IngestContent];
+    };
+    const [content] = fixture.content;
+
+    await ingestContent(content, { dataDir });
+
+    const issueId = '2026-05-23-downtown-line-delay-near-beauty-world';
+    const bundle = await readIssueBundle(dataDir, issueId);
+
+    expect(bundle.issue).toMatchObject({
+      id: issueId,
+      type: 'disruption',
+      title: {
+        'en-SG': 'Downtown Line delay near Beauty World',
+      },
+    });
+    expect(bundle.evidence).toHaveLength(1);
+    expect(bundle.evidence[0]).toMatchObject({
+      type: 'report.public',
+      sourceUrl:
+        'https://example.com/crowd-reports/accepted-20260523-0903-dtl-001',
+      text: [
+        'Report: Several commuters report 15 minute delays on the DTL.',
+        'Observed at: 2026-05-23T09:03:00+08:00',
+        'Accepted at: 2026-05-23T09:04:00.000+08:00',
+        'Lines: DTL',
+        'Stations: BCL',
+        'Direction: towards Expo',
+        'Effect: delay',
+        'Delay minutes: 15',
+        'Report count: 4',
+      ].join('\n\n'),
+    });
+    expect(bundle.impactEvents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'service_effects.set',
+          entity: { type: 'service', serviceId: 'DTL_MAIN_E' },
+          effect: { kind: 'delay', duration: 'PT15M' },
+        }),
+        expect.objectContaining({
+          type: 'periods.set',
+          entity: { type: 'service', serviceId: 'DTL_MAIN_E' },
+          periods: [
+            {
+              kind: 'fixed',
+              startAt: '2026-05-23T09:03:00+08:00',
+              endAt: null,
+            },
+          ],
+        }),
+      ]),
     );
   });
 });


### PR DESCRIPTION
## Summary

- Add deterministic `ingestContent` coverage for the checked-in crowd-report fixture.
- Verify accepted crowd reports create canonical `report.public` evidence, preserve the report URL as `sourceUrl`, and emit impact events without a special persistence path.
- Update the active crowdsourced reports plan progress log.

## Validation

- `npm run test:triage`
- `npm run check`

## Notes

This is not a model eval. The test mocks triage, extraction, slug generation, and translation so it only verifies ingest persistence plumbing.