### PR TITLE
fix: inspect generated schematic map sources

### DIFF
--- a/packages/cli/src/commands/schematicMap.ts
+++ b/packages/cli/src/commands/schematicMap.ts
@@ -1341,6 +1341,32 @@ async function readOptionalSchematicMapManifest(
   }
 }
 
+function isMissingFileError(error: unknown): boolean {
+  return error instanceof Error && 'code' in error && error.code === 'ENOENT';
+}
+
+async function readOrGenerateSchematicMapVersionSnapshot(
+  dataDir: string,
+  effectiveDate: string,
+): Promise<SchematicMapVersionSnapshot> {
+  const parsedEffectiveDate =
+    SchematicMapEffectiveDateSchema.parse(effectiveDate);
+
+  try {
+    return (await readSchematicMapVersionSnapshot(dataDir, parsedEffectiveDate))
+      .value;
+  } catch (error) {
+    if (!isMissingFileError(error)) {
+      throw error;
+    }
+  }
+
+  return generateSchematicMapVersionSnapshot(dataDir, {
+    effectiveDate: parsedEffectiveDate,
+    generatedAt: '1970-01-01T00:00:00.000Z',
+  });
+}
+
 async function updateSchematicMapManifest(
   dataDir: string,
   snapshot: SchematicMapVersionSnapshot,
@@ -1555,17 +1581,15 @@ export async function runSchematicMap(
       throw new Error('schematic-map stats requires YYYY-MM');
     }
 
-    const effectiveDate = SchematicMapEffectiveDateSchema.parse(id);
     const [snapshot, constraintEffectiveDates] = await Promise.all([
-      readSchematicMapVersionSnapshot(globals.dataDir, effectiveDate),
+      readOrGenerateSchematicMapVersionSnapshot(globals.dataDir, id),
       listSchematicMapConstraintSetEffectiveDates(globals.dataDir),
     ]);
+    const effectiveDate = SchematicMapEffectiveDateSchema.parse(id);
     const constraintSet = constraintEffectiveDates.includes(effectiveDate)
       ? await readSchematicMapConstraintSet(globals.dataDir, effectiveDate)
       : undefined;
-    const coordinateClasses = countSchematicMapSnapshotCoordinates(
-      snapshot.value,
-    );
+    const coordinateClasses = countSchematicMapSnapshotCoordinates(snapshot);
     const constraintTypes = countConstraintTypes(
       constraintSet?.value.constraints ?? [],
     );
@@ -1603,19 +1627,13 @@ export async function runSchematicMap(
     }
 
     const [fromSnapshot, toSnapshot] = await Promise.all([
-      readSchematicMapVersionSnapshot(
-        globals.dataDir,
-        SchematicMapEffectiveDateSchema.parse(fromId),
-      ),
-      readSchematicMapVersionSnapshot(
-        globals.dataDir,
-        SchematicMapEffectiveDateSchema.parse(toId),
-      ),
+      readOrGenerateSchematicMapVersionSnapshot(globals.dataDir, fromId),
+      readOrGenerateSchematicMapVersionSnapshot(globals.dataDir, toId),
     ]);
 
     io.stdout(
       JSON.stringify(
-        diffSchematicMapSnapshots(fromSnapshot.value, toSnapshot.value),
+        diffSchematicMapSnapshots(fromSnapshot, toSnapshot),
         null,
         2,
       ),
@@ -1792,14 +1810,11 @@ export async function runSchematicMap(
     }
 
     const out = readOption(args, '--out');
-    const snapshot = await readSchematicMapVersionSnapshot(
+    const snapshot = await readOrGenerateSchematicMapVersionSnapshot(
       globals.dataDir,
-      SchematicMapEffectiveDateSchema.parse(id),
+      id,
     );
-    const svg = await renderSchematicMapPreviewSvg(
-      globals.dataDir,
-      snapshot.value,
-    );
+    const svg = await renderSchematicMapPreviewSvg(globals.dataDir, snapshot);
 
     if (out) {
       const outPath = resolve(globals.cwd, out);

--- a/packages/cli/src/commands/schematicMap.ts
+++ b/packages/cli/src/commands/schematicMap.ts
@@ -1361,6 +1361,17 @@ async function readOrGenerateSchematicMapVersionSnapshot(
     }
   }
 
+  try {
+    await readSchematicMapConstraintSet(dataDir, parsedEffectiveDate);
+  } catch (error) {
+    if (!isMissingFileError(error)) {
+      throw error;
+    }
+    throw new Error(
+      `No schematic map version snapshot or constraint set exists for ${parsedEffectiveDate}`,
+    );
+  }
+
   return generateSchematicMapVersionSnapshot(dataDir, {
     effectiveDate: parsedEffectiveDate,
     generatedAt: '1970-01-01T00:00:00.000Z',

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -567,6 +567,17 @@ describe('@mrtdown/cli', () => {
       },
     });
 
+    const missingSourceStats = createIo();
+    await expect(
+      runCli(
+        ['--data-dir', dataDir, 'schematic-map', 'stats', '2025-06'],
+        missingSourceStats.io,
+      ),
+    ).resolves.toBe(1);
+    expect(missingSourceStats.stderr).toEqual([
+      'No schematic map version snapshot or constraint set exists for 2025-06',
+    ]);
+
     const previewPath = join(dataDir, 'preview.svg');
     const preview = createIo();
     await expect(

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -51,9 +51,10 @@ function createIo() {
 
 async function seedSchematicMap(
   dataDir: string,
-  options: { writeConstraintSet?: boolean } = {},
+  options: { writeConstraintSet?: boolean; writeSnapshot?: boolean } = {},
 ): Promise<void> {
   const writeConstraintSet = options.writeConstraintSet ?? true;
+  const writeSnapshot = options.writeSnapshot ?? true;
   await writeSchematicMapRuleSet(dataDir, {
     schemaVersion: 1,
     mapId: 'system',
@@ -81,6 +82,10 @@ async function seedSchematicMap(
         },
       ],
     });
+  }
+
+  if (!writeSnapshot) {
+    return;
   }
 
   await writeSchematicMapVersionSnapshot(dataDir, {
@@ -530,6 +535,91 @@ describe('@mrtdown/cli', () => {
     expect(JSON.parse(stats.stdout[0] as string)).toMatchObject({
       constraints: {
         total: 0,
+      },
+    });
+  });
+
+  it('inspects schematic map generator inputs without committed snapshots', async () => {
+    const dataDir = await mkdtemp(join(tmpdir(), 'mrtdown-cli-'));
+    await cp(fixtureDataDir, dataDir, { recursive: true });
+    await seedSchematicMap(dataDir, { writeSnapshot: false });
+
+    const validate = createIo();
+    await expect(
+      runCli(
+        ['--data-dir', dataDir, 'validate', '--scope', 'schematic-map'],
+        validate.io,
+      ),
+    ).resolves.toBe(0);
+    expect(JSON.parse(validate.stdout[0] as string)['schematic-map']).toBe(2);
+
+    const stats = createIo();
+    await expect(
+      runCli(
+        ['--data-dir', dataDir, 'schematic-map', 'stats', '2025-04'],
+        stats.io,
+      ),
+    ).resolves.toBe(0);
+    expect(JSON.parse(stats.stdout[0] as string)).toMatchObject({
+      effectiveDate: '2025-04',
+      constraints: {
+        total: 2,
+      },
+    });
+
+    const previewPath = join(dataDir, 'preview.svg');
+    const preview = createIo();
+    await expect(
+      runCli(
+        [
+          '--data-dir',
+          dataDir,
+          'schematic-map',
+          'preview',
+          '2025-04',
+          '--out',
+          previewPath,
+        ],
+        preview.io,
+      ),
+    ).resolves.toBe(0);
+    expect(preview.stdout).toEqual([previewPath]);
+    await expect(readFile(previewPath, 'utf8')).resolves.toContain(
+      'Kennedy Town',
+    );
+
+    await writeSchematicMapConstraintSet(dataDir, {
+      schemaVersion: 1,
+      mapId: 'system',
+      effectiveDate: '2025-05',
+      layoutEngineId: 'lta-system-map-2011',
+      constraints: [
+        {
+          id: 'frame_2025_05',
+          type: 'map_frame',
+          frame: { x: 0, y: 0, width: 3140, height: 2400 },
+        },
+        {
+          id: 'anchor_ket_2025_05',
+          type: 'station_anchor',
+          stationId: 'KET',
+          point: { x: 120, y: 120 },
+        },
+      ],
+    });
+
+    const diff = createIo();
+    await expect(
+      runCli(
+        ['--data-dir', dataDir, 'schematic-map', 'diff', '2025-04', '2025-05'],
+        diff.io,
+      ),
+    ).resolves.toBe(0);
+    expect(JSON.parse(diff.stdout[0] as string)).toMatchObject({
+      from: '2025-04',
+      to: '2025-05',
+      stations: {
+        moved: ['KET'],
       },
     });
   });


### PR DESCRIPTION
## Summary

- Allow schematic map `stats`, `diff`, and `preview` to inspect source-only generator inputs by generating a deterministic snapshot when no version artifact is committed.
- Keep existing behavior of preferring committed/generated snapshot files when they are present.
- Add CLI regression coverage for stats, preview, and diff without committed schematic map snapshots.

## Why

Generated schematic map versions are publication artifacts, but reviewer tooling still expected version files to exist locally. This lets the CLI operate against the tracked rule and constraint inputs, matching the current schematic map plan.

## Validation

- `npm run test:cli`
- `npm run check`
- `npm run data:validate`
- `npm run pages:build`
- `node packages/cli/dist/index.js --data-dir data schematic-map stats 2025-04`
- `node packages/cli/dist/index.js --data-dir data schematic-map preview 2025-04 --out /tmp/mrtdown-schematic-preview.svg`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced schematic-map command to gracefully handle missing snapshot files. When a snapshot file is unavailable for a requested date, the command now generates a default snapshot instead of failing, improving reliability for stats, diff, and preview operations.

* **Tests**
  * Added comprehensive test coverage for missing snapshot scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->