### PR TITLE
feat: require crowd report counts

### DIFF
--- a/.changeset/required-reports-count.md
+++ b/.changeset/required-reports-count.md
@@ -1,0 +1,6 @@
+---
+"@mrtdown/ingest-contracts": major
+---
+
+Require crowd-report payloads to include `reportCount` so single accepted
+reports and accepted report clusters share a consistent contract shape.

--- a/docs/plans/active/crowdsourced-reports.md
+++ b/docs/plans/active/crowdsourced-reports.md
@@ -113,7 +113,7 @@ Candidate content shape:
   directionText?: string,
   effect?: 'delay' | 'no-service' | 'crowding' | 'skipped-stop' | 'unknown',
   delayMinutes?: number,
-  reportCount?: number,
+  reportCount: number,
   url: string
 }
 ```
@@ -127,6 +127,8 @@ Contract rules:
 - `text` is the natural-language evidence passed to triage.
 - `lineIds` and `stationIds` may contain one or more affected entities. At
   least one line or station should be present.
+- `reportCount` is required; use `1` for a single accepted report and a larger
+  count for an accepted cluster.
 - `url` is required because canonical evidence stores a `sourceUrl`. Use a
   stable, non-PII public report URL or moderation URL that is safe to publish in
   canonical evidence.
@@ -184,10 +186,13 @@ Exit criteria:
 
 ### Phase 4: Confidence And Replay Support
 
-- Decide whether `reportCount` or cluster metadata should be stored only in
-  evidence text or represented as contract fields.
-- Add eval fixtures only if the current prompt cannot reliably distinguish
-  irrelevant reports, existing issues, and new issues.
+- Keep `reportCount` as a required contract field and render it into canonical
+  evidence text. Use `1` for a single accepted report, and do not add a separate
+  canonical confidence field for crowd reports unless review discovers a
+  consumer that needs structured confidence.
+- Add eval fixtures only if deterministic tests or manual replay show that the
+  current prompt cannot reliably distinguish irrelevant reports, existing
+  issues, and new issues.
 - Update `packages/triage/README.md` cost expectations when expanding evals.
 
 Exit criteria:
@@ -205,6 +210,9 @@ Exit criteria:
 - 2026-06-13: Added deterministic `ingestContent` coverage proving the checked-in
   crowd-report fixture can create canonical `report.public` evidence and impact
   events without a special persistence path.
+- 2026-06-15: Documented single-report and cluster handling in
+  `packages/triage/README.md`; `reportCount` is a required contract field
+  rendered into evidence text, not a separate canonical confidence field.
 
 ## Decision Log
 
@@ -212,6 +220,10 @@ Exit criteria:
   only accepted reports enter this repo as canonical public evidence.
 - 2026-05-24: Use the existing ingest contract and triage package instead of
   adding a separate crowd-report writer to canonical data.
+- 2026-06-15: Store crowd-report confidence and clustering context in evidence
+  text using the accepted payload fields (`reportCount`, `effect`,
+  `delayMinutes`, and `text`) rather than adding new canonical issue or evidence
+  state.
 
 ## Validation
 

--- a/packages/ingest-contracts/README.md
+++ b/packages/ingest-contracts/README.md
@@ -78,6 +78,8 @@ Contract rules:
 - `observedAt` is when the condition was observed.
 - `text` is the natural-language evidence passed to triage.
 - At least one `lineIds` or `stationIds` entry is required.
+- `reportCount` is required; use `1` for a single accepted report and a larger
+  count for an accepted cluster.
 - `url` is required because canonical evidence stores a public `sourceUrl`.
 - Site-local metadata is rejected. Keep submitter identities, IP addresses,
   user-agent strings, contact fields, moderation notes, abuse scores, and

--- a/packages/ingest-contracts/src/index.test.ts
+++ b/packages/ingest-contracts/src/index.test.ts
@@ -104,7 +104,7 @@ describe('IngestPayloadSchema', () => {
     ).toThrow();
   });
 
-  test('accepts crowd reports with optional cluster fields', () => {
+  test('accepts crowd reports with cluster fields', () => {
     expect(() =>
       IngestPayloadSchema.parse({
         content: [
@@ -141,6 +141,25 @@ describe('IngestPayloadSchema', () => {
             text: 'Several commuters report delays.',
             createdAt: '2026-05-23T09:04:00+08:00',
             observedAt: '2026-05-23T09:03:00+08:00',
+            reportCount: 1,
+            url: 'https://example.com/crowd-reports/accepted-20260523-0903-dtl-001',
+          },
+        ],
+      }),
+    ).toThrow();
+  });
+
+  test('rejects crowd reports without a report count', () => {
+    expect(() =>
+      IngestPayloadSchema.parse({
+        content: [
+          {
+            source: 'crowd-report',
+            reportId: 'accepted-20260523-0903-dtl-001',
+            text: 'Several commuters report delays.',
+            createdAt: '2026-05-23T09:04:00+08:00',
+            observedAt: '2026-05-23T09:03:00+08:00',
+            lineIds: ['DTL'],
             url: 'https://example.com/crowd-reports/accepted-20260523-0903-dtl-001',
           },
         ],
@@ -159,6 +178,7 @@ describe('IngestPayloadSchema', () => {
             createdAt: '2026-05-23T09:04:00+08:00',
             observedAt: '2026-05-23T09:03:00+08:00',
             lineIds: ['DTL'],
+            reportCount: 1,
             url: 'https://example.com/crowd-reports/accepted-20260523-0903-dtl-001',
             submitterEmail: 'commuter@example.com',
           },

--- a/packages/ingest-contracts/src/index.ts
+++ b/packages/ingest-contracts/src/index.ts
@@ -82,7 +82,7 @@ export const IngestContentCrowdReportSchema = z
     directionText: z.string().optional(),
     effect: IngestContentCrowdReportEffectSchema.optional(),
     delayMinutes: z.number().int().nonnegative().optional(),
-    reportCount: z.number().int().positive().optional(),
+    reportCount: z.number().int().positive(),
     url: z.string().min(1),
   })
   .strict()

--- a/packages/triage/README.md
+++ b/packages/triage/README.md
@@ -12,6 +12,25 @@ npm run build:triage
 npm run test:triage
 ```
 
+## Crowd Reports
+
+Crowd reports enter triage through the shared
+`@mrtdown/ingest-contracts` `crowd-report` content type. The site or another
+producer must moderate reports before dispatching them here; this package does
+not store submitter identity, abuse signals, queue state, or moderation notes.
+
+Triage formats accepted reports into structured evidence text, maps them to
+canonical `report.public` evidence, and stores the payload `url` as
+`sourceUrl`. Single reports and accepted clusters use the same path. Producers
+must set `reportCount` to `1` for a single accepted report, or to the accepted
+cluster size for clustered reports. Confidence stays in the evidence text
+through `reportCount`, `effect`, `delayMinutes`, and the producer-supplied
+natural-language `text`; there is no separate canonical confidence field for
+crowd reports.
+
+Use `fixtures/ingest/crowd-report.json` as the lightweight manual fixture for
+`workflow_dispatch` or local `MESSAGE` testing.
+
 ## Paid Eval
 
 `test:eval` is reserved for model-dependent triage evaluation. It must not run

--- a/packages/triage/src/util/ingestContent/helpers/formatContentTextForIngest.test.ts
+++ b/packages/triage/src/util/ingestContent/helpers/formatContentTextForIngest.test.ts
@@ -97,4 +97,31 @@ describe('formatContentTextForIngest', () => {
       ].join('\n\n'),
     );
   });
+
+  test('formats single crowd reports with report count one', () => {
+    expect(
+      formatContentTextForIngest({
+        source: 'crowd-report',
+        reportId: 'accepted-20260523-0910-ewl-001',
+        text: 'Train held at Outram Park for several minutes.',
+        createdAt: '2026-05-23T09:11:00+08:00',
+        observedAt: '2026-05-23T09:10:00+08:00',
+        lineIds: ['EWL'],
+        stationIds: ['OTP'],
+        effect: 'unknown',
+        reportCount: 1,
+        url: 'https://example.com/crowd-reports/accepted-20260523-0910-ewl-001',
+      }),
+    ).toBe(
+      [
+        'Report: Train held at Outram Park for several minutes.',
+        'Observed at: 2026-05-23T09:10:00+08:00',
+        'Accepted at: 2026-05-23T09:11:00+08:00',
+        'Lines: EWL',
+        'Stations: OTP',
+        'Effect: unknown',
+        'Report count: 1',
+      ].join('\n\n'),
+    );
+  });
 });

--- a/packages/triage/src/util/ingestContent/helpers/formatContentTextForIngest.ts
+++ b/packages/triage/src/util/ingestContent/helpers/formatContentTextForIngest.ts
@@ -31,10 +31,7 @@ export function formatContentTextForIngest(content: IngestContent): string {
             ? undefined
             : String(content.delayMinutes),
         ],
-        [
-          'Report count',
-          content.reportCount == null ? undefined : String(content.reportCount),
-        ],
+        ['Report count', String(content.reportCount)],
       ]);
     }
     case 'twitter':

--- a/packages/triage/src/util/ingestContent/helpers/getEvidenceProvenanceForIngestContent.test.ts
+++ b/packages/triage/src/util/ingestContent/helpers/getEvidenceProvenanceForIngestContent.test.ts
@@ -11,6 +11,7 @@ describe('getEvidenceProvenanceForIngestContent', () => {
         createdAt: '2026-05-23T09:04:00+08:00',
         observedAt: '2026-05-23T09:03:00+08:00',
         lineIds: ['DTL'],
+        reportCount: 1,
         url: 'https://example.com/crowd-reports/accepted-20260523-0903-dtl-001',
       }),
     ).toEqual({


### PR DESCRIPTION
## Summary

- Require `reportCount` on `crowd-report` ingest payloads so single reports and clusters use a consistent shape.
- Always render `Report count` into canonical crowd-report evidence text.
- Update contract docs, triage docs, and the active crowdsourced reports plan with the `reportCount: 1` single-report convention.

## Validation

- `npm run test:ingest-contracts`
- `npm run test:triage`
- `npm run check`