### PR TITLE
fix: harden crowd report ingest contract

### DIFF
--- a/.changeset/tough-reports-check.md
+++ b/.changeset/tough-reports-check.md
@@ -1,0 +1,6 @@
+---
+"@mrtdown/ingest-contracts": major
+---
+
+Require crowd-report timestamps to include timezone offsets, reject reports
+observed after producer acceptance, and require HTTP(S) source URLs.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,7 +90,8 @@ the repository shape.
 - If documentation and code disagree, fix the documentation or narrow the PR
   before adding more implementation.
 - Use Conventional Commits style for commit messages and PR titles, for example
-  `feat: add Pages artifact publishing foundation`.
+  `feat: add Pages artifact publishing foundation`. Do not add tool or agent
+  prefixes such as `[codex]` to PR titles.
 - Do not merge temporary branch names, one-off deploy triggers, or local
   generated artifacts.
 

--- a/docs/plans/active/crowdsourced-reports.md
+++ b/docs/plans/active/crowdsourced-reports.md
@@ -122,16 +122,18 @@ Contract rules:
 
 - `reportId` must be stable and non-PII. Site-local database IDs are acceptable
   if they cannot reveal user identity.
-- `createdAt` is when the site accepted the report or cluster for dispatch.
-- `observedAt` is when the reporter observed the condition.
+- `createdAt` is an ISO 8601 datetime with timezone offset for when the site
+  accepted the report or cluster for dispatch.
+- `observedAt` is an ISO 8601 datetime with timezone offset for when the
+  reporter observed the condition. It must not be later than `createdAt`.
 - `text` is the natural-language evidence passed to triage.
 - `lineIds` and `stationIds` may contain one or more affected entities. At
   least one line or station should be present.
 - `reportCount` is required; use `1` for a single accepted report and a larger
   count for an accepted cluster.
 - `url` is required because canonical evidence stores a `sourceUrl`. Use a
-  stable, non-PII public report URL or moderation URL that is safe to publish in
-  canonical evidence.
+  stable, non-PII HTTP(S) public report URL or moderation URL that is safe to
+  publish in canonical evidence.
 - Personal details, IP addresses, user-agent strings, contact fields,
   moderation notes, abuse scores, and Turnstile tokens must remain site-local.
 
@@ -213,6 +215,9 @@ Exit criteria:
 - 2026-06-15: Documented single-report and cluster handling in
   `packages/triage/README.md`; `reportCount` is a required contract field
   rendered into evidence text, not a separate canonical confidence field.
+- 2026-06-16: Hardened the crowd-report contract to require offset-bearing ISO
+  datetimes, reject reports observed after producer acceptance, and require
+  HTTP(S) source URLs.
 
 ## Decision Log
 

--- a/packages/ingest-contracts/README.md
+++ b/packages/ingest-contracts/README.md
@@ -73,14 +73,16 @@ the crowd-report source and effect values.
 Contract rules:
 
 - `reportId` must be stable and non-PII.
-- `createdAt` is when the producer accepted the report or cluster for
-  dispatch.
-- `observedAt` is when the condition was observed.
+- `createdAt` is an ISO 8601 datetime with timezone offset for when the
+  producer accepted the report or cluster for dispatch.
+- `observedAt` is an ISO 8601 datetime with timezone offset for when the
+  condition was observed. It must not be later than `createdAt`.
 - `text` is the natural-language evidence passed to triage.
 - At least one `lineIds` or `stationIds` entry is required.
 - `reportCount` is required; use `1` for a single accepted report and a larger
   count for an accepted cluster.
 - `url` is required because canonical evidence stores a public `sourceUrl`.
+  It must be an HTTP(S) URL.
 - Site-local metadata is rejected. Keep submitter identities, IP addresses,
   user-agent strings, contact fields, moderation notes, abuse scores, and
   challenge tokens out of this payload.

--- a/packages/ingest-contracts/src/index.test.ts
+++ b/packages/ingest-contracts/src/index.test.ts
@@ -167,6 +167,63 @@ describe('IngestPayloadSchema', () => {
     ).toThrow();
   });
 
+  test('rejects crowd reports with timestamps that omit timezone offsets', () => {
+    expect(() =>
+      IngestPayloadSchema.parse({
+        content: [
+          {
+            source: 'crowd-report',
+            reportId: 'accepted-20260523-0903-dtl-001',
+            text: 'Several commuters report delays.',
+            createdAt: '2026-05-23T09:04:00',
+            observedAt: '2026-05-23T09:03:00',
+            lineIds: ['DTL'],
+            reportCount: 1,
+            url: 'https://example.com/crowd-reports/accepted-20260523-0903-dtl-001',
+          },
+        ],
+      }),
+    ).toThrow();
+  });
+
+  test('rejects crowd reports observed after producer acceptance', () => {
+    expect(() =>
+      IngestPayloadSchema.parse({
+        content: [
+          {
+            source: 'crowd-report',
+            reportId: 'accepted-20260523-0903-dtl-001',
+            text: 'Several commuters report delays.',
+            createdAt: '2026-05-23T09:04:00+08:00',
+            observedAt: '2026-05-23T09:05:00+08:00',
+            lineIds: ['DTL'],
+            reportCount: 1,
+            url: 'https://example.com/crowd-reports/accepted-20260523-0903-dtl-001',
+          },
+        ],
+      }),
+    ).toThrow();
+  });
+
+  test('rejects crowd reports without an HTTP(S) source URL', () => {
+    expect(() =>
+      IngestPayloadSchema.parse({
+        content: [
+          {
+            source: 'crowd-report',
+            reportId: 'accepted-20260523-0903-dtl-001',
+            text: 'Several commuters report delays.',
+            createdAt: '2026-05-23T09:04:00+08:00',
+            observedAt: '2026-05-23T09:03:00+08:00',
+            lineIds: ['DTL'],
+            reportCount: 1,
+            url: 'mailto:moderator@example.com',
+          },
+        ],
+      }),
+    ).toThrow();
+  });
+
   test('rejects site-local crowd report metadata', () => {
     expect(() =>
       IngestPayloadSchema.parse({

--- a/packages/ingest-contracts/src/index.test.ts
+++ b/packages/ingest-contracts/src/index.test.ts
@@ -224,6 +224,41 @@ describe('IngestPayloadSchema', () => {
     ).toThrow();
   });
 
+  test('returns validation failure for malformed crowd report URLs', () => {
+    expect(() =>
+      IngestPayloadSchema.safeParse({
+        content: [
+          {
+            source: 'crowd-report',
+            reportId: 'accepted-20260523-0903-dtl-001',
+            text: 'Several commuters report delays.',
+            createdAt: '2026-05-23T09:04:00+08:00',
+            observedAt: '2026-05-23T09:03:00+08:00',
+            lineIds: ['DTL'],
+            reportCount: 1,
+            url: 'not a url',
+          },
+        ],
+      }),
+    ).not.toThrow();
+    expect(
+      IngestPayloadSchema.safeParse({
+        content: [
+          {
+            source: 'crowd-report',
+            reportId: 'accepted-20260523-0903-dtl-001',
+            text: 'Several commuters report delays.',
+            createdAt: '2026-05-23T09:04:00+08:00',
+            observedAt: '2026-05-23T09:03:00+08:00',
+            lineIds: ['DTL'],
+            reportCount: 1,
+            url: 'not a url',
+          },
+        ],
+      }).success,
+    ).toBe(false);
+  });
+
   test('rejects site-local crowd report metadata', () => {
     expect(() =>
       IngestPayloadSchema.parse({

--- a/packages/ingest-contracts/src/index.ts
+++ b/packages/ingest-contracts/src/index.ts
@@ -76,8 +76,12 @@ const IngestContentCrowdReportTimestampSchema = z.iso.datetime({
 
 const IngestContentCrowdReportUrlSchema = z.url().refine(
   (value) => {
-    const { protocol } = new URL(value);
-    return protocol === 'http:' || protocol === 'https:';
+    try {
+      const { protocol } = new URL(value);
+      return protocol === 'http:' || protocol === 'https:';
+    } catch {
+      return false;
+    }
   },
   { message: 'Expected an HTTP(S) URL' },
 );

--- a/packages/ingest-contracts/src/index.ts
+++ b/packages/ingest-contracts/src/index.ts
@@ -70,20 +70,32 @@ export type IngestContentCrowdReportEffect = z.infer<
   typeof IngestContentCrowdReportEffectSchema
 >;
 
+const IngestContentCrowdReportTimestampSchema = z.iso.datetime({
+  offset: true,
+});
+
+const IngestContentCrowdReportUrlSchema = z.url().refine(
+  (value) => {
+    const { protocol } = new URL(value);
+    return protocol === 'http:' || protocol === 'https:';
+  },
+  { message: 'Expected an HTTP(S) URL' },
+);
+
 export const IngestContentCrowdReportSchema = z
   .object({
     source: z.literal(IngestContentCrowdReportSource),
     reportId: z.string().min(1),
     text: z.string().min(1),
-    createdAt: z.string(),
-    observedAt: z.string(),
+    createdAt: IngestContentCrowdReportTimestampSchema,
+    observedAt: IngestContentCrowdReportTimestampSchema,
     lineIds: z.array(z.string().min(1)).optional(),
     stationIds: z.array(z.string().min(1)).optional(),
     directionText: z.string().optional(),
     effect: IngestContentCrowdReportEffectSchema.optional(),
     delayMinutes: z.number().int().nonnegative().optional(),
     reportCount: z.number().int().positive(),
-    url: z.string().min(1),
+    url: IngestContentCrowdReportUrlSchema,
   })
   .strict()
   .refine(
@@ -93,6 +105,14 @@ export const IngestContentCrowdReportSchema = z
     {
       message: 'Expected at least one lineIds or stationIds entry',
       path: ['lineIds'],
+    },
+  )
+  .refine(
+    (content) =>
+      Date.parse(content.observedAt) <= Date.parse(content.createdAt),
+    {
+      message: 'Expected observedAt to be before or equal to createdAt',
+      path: ['observedAt'],
     },
   );
 


### PR DESCRIPTION
## Summary

- Require crowd-report `createdAt` and `observedAt` values to be ISO datetimes with timezone offsets.
- Reject crowd reports where `observedAt` is later than producer acceptance time.
- Require crowd-report source URLs to be HTTP(S), and document the tightened handoff contract.

## Why

The crowdsourced-report plan treats this payload as the public handoff from `mrtdown-site` or another producer into canonical data. Tightening these fields makes malformed dispatches fail at contract validation before they can become canonical `report.public` evidence.

## Validation

- `npm run test:ingest-contracts`
- `npm run build:ingest-contracts`
- `npm run check`

Note: Turbo printed a non-fatal sandbox cache IO warning during the focused build/test runs; each command exited successfully.