### PR TITLE
docs: complete crowdsourced reports plan

### DIFF
--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -6,8 +6,6 @@ plan.
 
 ## Active
 
-- [Crowdsourced reports canonical ingest](active/crowdsourced-reports.md):
-  public report payload contract and canonical evidence ingestion plan.
 - [GTFS static and realtime support](active/gtfs-static-realtime.md):
   deterministic GTFS Static export, Pages publication, and GTFS Realtime
   evidence ingest boundaries.
@@ -20,6 +18,8 @@ plan.
 
 ## Completed
 
+- [Crowdsourced reports canonical ingest](completed/crowdsourced-reports.md):
+  public report payload contract and canonical evidence ingestion path.
 - [Data overhaul split](completed/data-overhaul-split.md): historical split
   sequence for the package/data repository migration.
 - [Ingest contracts package](completed/ingest-contracts-package.md): shared

--- a/docs/plans/completed/crowdsourced-reports.md
+++ b/docs/plans/completed/crowdsourced-reports.md
@@ -1,5 +1,9 @@
 # Crowdsourced Reports Canonical Ingest Plan
 
+Status: completed. The shared ingest contract, triage formatting, canonical
+`report.public` evidence mapping, checked-in manual fixture, workflow path, and
+deterministic validation coverage are in place.
+
 ## Context
 
 `mrtdown-data` is the canonical reviewed data repository. It owns target-layout
@@ -218,6 +222,10 @@ Exit criteria:
 - 2026-06-16: Hardened the crowd-report contract to require offset-bearing ISO
   datetimes, reject reports observed after producer acceptance, and require
   HTTP(S) source URLs.
+- 2026-06-17: Verified the completed canonical ingest path with
+  `npm run build:ingest-contracts`, `npm run test:ingest-contracts`,
+  `npm run build:triage`, `npm run test:triage`, `npm run data:validate`, and
+  `npm run check`.
 
 ## Decision Log
 


### PR DESCRIPTION
## Summary

- Move the crowdsourced reports canonical ingest plan from active to completed.
- Add completion status and the June 17 validation note to the completed plan.
- Update the plans index so active/completed links reflect the current state.

## Impact

This records that the `mrtdown-data` side of the crowdsourced report ingest plan is complete. The paired `mrtdown-site` runtime collection and moderation work remains outside this repository's plan scope.

## Validation

- `npm run build:ingest-contracts`
- `npm run test:ingest-contracts`
- `npm run build:triage`
- `npm run test:triage`
- `npm run data:validate`
- `npm run check`
- `npm run check:docs`