### PR TITLE
test: upgrade vitest evals

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1585,6 +1585,26 @@
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "license": "ISC"
     },
+    "node_modules/@vitest-evals/core": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@vitest-evals/core/-/core-0.12.0.tgz",
+      "integrity": "sha512-JOatlrVw4jcP9VCBAFcM07pGxUA2iLt4Ks5jaRYqyATjkNwPYnyNDL+YHgvelANfPA0BBX8MzRfs6vEkzJgC+A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "zod": ">=3 <5"
+      }
+    },
+    "node_modules/@vitest-evals/report-ui": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@vitest-evals/report-ui/-/report-ui-0.12.0.tgz",
+      "integrity": "sha512-rjWKnB+WL1ekiIvHdcnEX0tfaCwfeG3BNU6jvGKuJsHqkf8JRtuTyy/xgUKKsb56CokcZ3K3hmeo6RKik/KBrQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vitest-evals/core": "0.12.0"
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "4.1.8",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
@@ -4708,14 +4728,31 @@
       }
     },
     "node_modules/vitest-evals": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/vitest-evals/-/vitest-evals-0.5.0.tgz",
-      "integrity": "sha512-kg8r6NKNBD6jkmyjdO64qduATW6IUG+62atCJj3dLzaRZEG4TIdfFVy64iEh0dSSo1CCpAJi+dJqSN2Y2qv2Sw==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/vitest-evals/-/vitest-evals-0.12.0.tgz",
+      "integrity": "sha512-pyVA4N8gM+T2JB+SGFNSuXcgf/CHbBygAXkXR1fEPEfleKyMacJXPF9gLWIyyC1x5BCrt0r4zkwzkdjZrdpwZQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@vitest-evals/core": "0.12.0",
+        "@vitest-evals/report-ui": "0.12.0"
+      },
+      "bin": {
+        "vitest-evals": "bin/vitest-evals.js"
+      },
       "peerDependencies": {
-        "tinyrainbow": "*",
-        "vitest": "*"
+        "ai": ">=4 <7",
+        "tinyrainbow": ">=2 <4",
+        "vitest": ">=4 <5",
+        "zod": ">=3 <5"
+      },
+      "peerDependenciesMeta": {
+        "ai": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/web-namespaces": {
@@ -4875,7 +4912,7 @@
         "@types/node": "24.13.2",
         "typescript": "^5.8.3",
         "vitest": "^4.1.8",
-        "vitest-evals": "^0.5.0"
+        "vitest-evals": "^0.12.0"
       }
     },
     "packages/triage/node_modules/openai": {

--- a/packages/triage/package.json
+++ b/packages/triage/package.json
@@ -51,6 +51,6 @@
     "@types/node": "24.13.2",
     "typescript": "^5.8.3",
     "vitest": "^4.1.8",
-    "vitest-evals": "^0.5.0"
+    "vitest-evals": "^0.12.0"
   }
 }

--- a/packages/triage/src/llm/functions/extractClaimsFromNewEvidence/eval.test.ts
+++ b/packages/triage/src/llm/functions/extractClaimsFromNewEvidence/eval.test.ts
@@ -3,7 +3,11 @@ import { resolve } from 'node:path';
 import { FileStore, MRTDownRepository } from '@mrtdown/fs';
 import { config as loadDotEnv } from 'dotenv';
 import { describe } from 'vitest';
-import { describeEval, StructuredOutputScorer } from 'vitest-evals';
+import {
+  createHarness,
+  describeEval,
+  StructuredOutputJudge,
+} from 'vitest-evals';
 import { assert } from '../../../util/assert.js';
 import {
   type ExtractClaimsFromNewEvidenceParams,
@@ -42,16 +46,37 @@ const hkFixtureTimeZone = ((actual: unknown) =>
   actual === 'Asia/Hong_Kong' ||
   actual === 'Asia/Singapore') as unknown as 'Asia/Hong_Kong';
 
+const extractClaimsHarness = createHarness<
+  ExtractClaimsFromNewEvidenceParams,
+  string,
+  { expected: ExtractClaimsFromNewEvidenceResult }
+>({
+  name: 'extractClaimsFromNewEvidence',
+  async run({ input }) {
+    const result = await extractClaimsFromNewEvidence(input);
+    return { output: JSON.stringify(result) };
+  },
+});
+
+const fuzzyStructuredOutputJudge = StructuredOutputJudge({
+  match: 'fuzzy',
+  fuzzyOptions: { ignoreArrayOrder: true },
+});
+
 describe('extractClaimsFromNewEvidence', () => {
-  describeEval('should extract claims from new disruption evidence', {
-    // @ts-expect-error input is a string in the vitest-evals library
-    async data() {
+  describeEval(
+    'should extract claims from new disruption evidence',
+    {
+      harness: extractClaimsHarness,
+      judges: [fuzzyStructuredOutputJudge],
+    },
+    (it) => {
       const store = new FileStore(FIXTURE_DATA_DIR);
       const repo = new MRTDownRepository({ store });
       const issueBundle = repo.issues.get(FIXTURE_META.issues.trainFault.id);
       assert(issueBundle != null, 'Issue bundle not found');
 
-      return [
+      const cases = [
         {
           input: {
             newEvidence: {
@@ -200,27 +225,29 @@ describe('extractClaimsFromNewEvidence', () => {
         input: ExtractClaimsFromNewEvidenceParams & { toString(): string };
         expected: ExtractClaimsFromNewEvidenceResult;
       }[];
+
+      it.for(
+        cases.map(({ input, expected }) => ({
+          name: input.toString(),
+          input,
+          expected,
+        })),
+      )('$name', async ({ input, expected }, { run }) => {
+        await run(input, { metadata: { expected } });
+      });
     },
-    async task(input) {
-      const result = await extractClaimsFromNewEvidence(
-        input as unknown as ExtractClaimsFromNewEvidenceParams,
-      );
-      return JSON.stringify(result);
+  );
+  describeEval(
+    'should compute the impact of new maintenance evidence',
+    {
+      harness: extractClaimsHarness,
+      judges: [fuzzyStructuredOutputJudge],
     },
-    scorers: [
-      StructuredOutputScorer({
-        match: 'fuzzy',
-        fuzzyOptions: { ignoreArrayOrder: true },
-      }),
-    ],
-  });
-  describeEval('should compute the impact of new maintenance evidence', {
-    // @ts-expect-error input is a string in the vitest-evals library
-    async data() {
+    (it) => {
       const store = new FileStore(FIXTURE_DATA_DIR);
       const repo = new MRTDownRepository({ store });
 
-      return [
+      const cases = [
         {
           input: {
             newEvidence: {
@@ -560,18 +587,16 @@ describe('extractClaimsFromNewEvidence', () => {
         input: ExtractClaimsFromNewEvidenceParams & { toString(): string };
         expected: ExtractClaimsFromNewEvidenceResult;
       }[];
+
+      it.for(
+        cases.map(({ input, expected }) => ({
+          name: input.toString(),
+          input,
+          expected,
+        })),
+      )('$name', async ({ input, expected }, { run }) => {
+        await run(input, { metadata: { expected } });
+      });
     },
-    async task(input) {
-      const result = await extractClaimsFromNewEvidence(
-        input as unknown as ExtractClaimsFromNewEvidenceParams,
-      );
-      return JSON.stringify(result);
-    },
-    scorers: [
-      StructuredOutputScorer({
-        match: 'fuzzy',
-        fuzzyOptions: { ignoreArrayOrder: true },
-      }),
-    ],
-  });
+  );
 });

--- a/packages/triage/src/llm/functions/extractClaimsFromNewEvidence/eval.test.ts
+++ b/packages/triage/src/llm/functions/extractClaimsFromNewEvidence/eval.test.ts
@@ -48,13 +48,13 @@ const hkFixtureTimeZone = ((actual: unknown) =>
 
 const extractClaimsHarness = createHarness<
   ExtractClaimsFromNewEvidenceParams,
-  string,
+  ExtractClaimsFromNewEvidenceResult,
   { expected: ExtractClaimsFromNewEvidenceResult }
 >({
   name: 'extractClaimsFromNewEvidence',
   async run({ input }) {
     const result = await extractClaimsFromNewEvidence(input);
-    return { output: JSON.stringify(result) };
+    return { output: result };
   },
 });
 

--- a/packages/triage/src/llm/functions/translate/eval.test.ts
+++ b/packages/triage/src/llm/functions/translate/eval.test.ts
@@ -2,7 +2,7 @@ import { resolve } from 'node:path';
 import { type Translations, TranslationsSchema } from '@mrtdown/core';
 import { config as loadDotEnv } from 'dotenv';
 import { describe } from 'vitest';
-import { type BaseScorerOptions, describeEval } from 'vitest-evals';
+import { createHarness, createJudge, describeEval } from 'vitest-evals';
 import { translate } from './index.js';
 
 loadDotEnv({
@@ -13,7 +13,7 @@ type TranslateEvalExpected = {
   englishIncludes: string[];
 };
 
-type TranslateEvalScorerOptions = BaseScorerOptions & {
+type TranslateEvalMetadata = {
   expected: TranslateEvalExpected;
 };
 
@@ -36,7 +36,10 @@ function includesAll(haystack: string, needles: string[]) {
 const TranslateQualityScorer = ({
   expected,
   output,
-}: TranslateEvalScorerOptions) => {
+}: {
+  expected: TranslateEvalExpected;
+  output: string;
+}) => {
   const parsed = parseTranslations(output);
   if (typeof parsed === 'string') {
     return {
@@ -101,17 +104,38 @@ const TranslateQualityScorer = ({
   };
 };
 
+const translateHarness = createHarness<string, string, TranslateEvalMetadata>({
+  name: 'translate',
+  async run({ input }) {
+    const result = await translate(input);
+    return { output: JSON.stringify(result) };
+  },
+});
+
+const TranslateQualityJudge = createJudge(
+  'TranslateQualityJudge',
+  ({ metadata, output }) =>
+    TranslateQualityScorer({ expected: metadata.expected, output }),
+);
+
 describe('translate', () => {
-  describeEval('should translate transit issue text into render locales', {
-    async data() {
-      return [
+  describeEval(
+    'should translate transit issue text into render locales',
+    {
+      harness: translateHarness,
+      judges: [TranslateQualityJudge],
+    },
+    (it) => {
+      it.for([
         {
+          name: 'Island Line delay near Admiralty',
           input: 'Island Line delay near Admiralty',
           expected: {
             englishIncludes: ['Island Line', 'delay', 'Admiralty'],
           },
         },
         {
+          name: 'Island Line track fault',
           input:
             '[ISL] Due to a track fault at HKU, train services on the Island Line are delayed between Kennedy Town and Admiralty.',
           expected: {
@@ -119,6 +143,7 @@ describe('translate', () => {
           },
         },
         {
+          name: 'Platform screen door renewal works',
           input:
             'Platform screen doors at Tsuen Wan Line stations will undergo renewal works from 1 March to 31 March 2026.',
           expected: {
@@ -130,14 +155,12 @@ describe('translate', () => {
           },
         },
       ] satisfies {
+        name: string;
         input: string;
         expected: TranslateEvalExpected;
-      }[];
+      }[])('$name', async ({ input, expected }, { run }) => {
+        await run(input, { metadata: { expected } });
+      });
     },
-    async task(input) {
-      const result = await translate(input);
-      return JSON.stringify(result);
-    },
-    scorers: [TranslateQualityScorer],
-  });
+  );
 });

--- a/packages/triage/src/llm/functions/triageNewEvidence/eval.test.ts
+++ b/packages/triage/src/llm/functions/triageNewEvidence/eval.test.ts
@@ -55,13 +55,13 @@ const TRAIN_FAULT_FOLLOW_UP_TS = addSecondsToIsoTimestamp(
 
 const triageNewEvidenceHarness = createHarness<
   TriageNewEvidenceParams,
-  string,
+  TriageNewEvidenceResult,
   { expected: TriageNewEvidenceResult }
 >({
   name: 'triageNewEvidence',
   async run({ input }) {
     const result = await triageNewEvidence(input);
-    return { output: JSON.stringify(result) };
+    return { output: result };
   },
 });
 

--- a/packages/triage/src/llm/functions/triageNewEvidence/eval.test.ts
+++ b/packages/triage/src/llm/functions/triageNewEvidence/eval.test.ts
@@ -4,7 +4,11 @@ import { FileStore, MRTDownRepository } from '@mrtdown/fs';
 import { config as loadDotEnv } from 'dotenv';
 import { DateTime } from 'luxon';
 import { describe } from 'vitest';
-import { describeEval, StructuredOutputScorer } from 'vitest-evals';
+import {
+  createHarness,
+  describeEval,
+  StructuredOutputJudge,
+} from 'vitest-evals';
 import {
   type TriageNewEvidenceParams,
   type TriageNewEvidenceResult,
@@ -49,161 +53,170 @@ const TRAIN_FAULT_FOLLOW_UP_TS = addSecondsToIsoTimestamp(
   10,
 );
 
+const triageNewEvidenceHarness = createHarness<
+  TriageNewEvidenceParams,
+  string,
+  { expected: TriageNewEvidenceResult }
+>({
+  name: 'triageNewEvidence',
+  async run({ input }) {
+    const result = await triageNewEvidence(input);
+    return { output: JSON.stringify(result) };
+  },
+});
+
 describe('triageNewEvidence', () => {
   describeEval(
     'should triage the new evidence into an existing issue or a new issue',
     {
-      // @ts-expect-error input is a string in the vitest-evals library
-      async data() {
-        const store = new FileStore(FIXTURE_DATA_DIR);
-        const repo = new MRTDownRepository({ store });
+      harness: triageNewEvidenceHarness,
+      judges: [StructuredOutputJudge()],
+    },
+    (it) => {
+      const store = new FileStore(FIXTURE_DATA_DIR);
+      const repo = new MRTDownRepository({ store });
 
-        return [
-          {
-            input: {
-              newEvidence: {
-                ts: TRAIN_FAULT_FOLLOW_UP_TS,
-                text: '[ISL] Due to a track fault at HKU, train services on the Island Line are delayed between Kennedy Town and Admiralty',
-              },
-              repo,
-              // This is used by vitest-evals as the test name, as the library expects `input` to be a string.
-              toString() {
-                return '[DISRUPTION] Related to an existing issue';
-              },
+      const cases = [
+        {
+          input: {
+            newEvidence: {
+              ts: TRAIN_FAULT_FOLLOW_UP_TS,
+              text: '[ISL] Due to a track fault at HKU, train services on the Island Line are delayed between Kennedy Town and Admiralty',
             },
-            expected: {
-              result: {
-                kind: 'part-of-existing-issue',
-                issueId: FIXTURE_META.issues.trainFault.id,
-              },
+            repo,
+            toString() {
+              return '[DISRUPTION] Related to an existing issue';
             },
           },
-          {
-            input: {
-              newEvidence: {
-                ts: TRAIN_FAULT_FOLLOW_UP_TS,
-                text: '[ISL] Due to a track fault at HKU, train services on the Island Line are delayed between Admiralty and Causeway Bay',
-              },
-              repo,
-              // This is used by vitest-evals as the test name, as the library expects `input` to be a string.
-              toString() {
-                return '[DISRUPTION] Related to a new issue on a different part of the same line';
-              },
-            },
-            expected: {
-              result: {
-                kind: 'part-of-new-issue',
-                issueType: 'disruption',
-              },
+          expected: {
+            result: {
+              kind: 'part-of-existing-issue',
+              issueId: FIXTURE_META.issues.trainFault.id,
             },
           },
-          {
-            input: {
-              newEvidence: {
-                ts: TRAIN_FAULT_FOLLOW_UP_TS,
-                text: '[ISL] Due to maintenance works, services on the Island Line will end earlier at 11pm tonight.',
-              },
-              repo,
-              // This is used by vitest-evals as the test name, as the library expects `input` to be a string.
-              toString() {
-                return '[MAINTENANCE] Related to a new issue';
-              },
+        },
+        {
+          input: {
+            newEvidence: {
+              ts: TRAIN_FAULT_FOLLOW_UP_TS,
+              text: '[ISL] Due to a track fault at HKU, train services on the Island Line are delayed between Admiralty and Causeway Bay',
             },
-            expected: {
-              result: {
-                kind: 'part-of-new-issue',
-                issueType: 'maintenance',
-              },
+            repo,
+            toString() {
+              return '[DISRUPTION] Related to a new issue on a different part of the same line';
             },
           },
-          {
-            input: {
-              newEvidence: {
-                ts: '2026-03-01T07:10:00+08:00',
-                text: '[TWL] Due to a track fault at Mong Kok, train services on the Tsuen Wan Line are delayed between Tsuen Wan and Mong Kok',
-              },
-              repo: new MRTDownRepository({
-                store: new FileStore(FIXTURE_DATA_DIR),
-              }),
-              // This is used by vitest-evals as the test name, as the library expects `input` to be a string.
-              toString() {
-                return '[DISRUPTION] Related to a new issue';
-              },
-            },
-            expected: {
-              result: {
-                kind: 'part-of-new-issue',
-                issueType: 'disruption',
-              },
+          expected: {
+            result: {
+              kind: 'part-of-new-issue',
+              issueType: 'disruption',
             },
           },
-          {
-            input: {
-              newEvidence: {
-                ts: '2026-03-01T07:10:00+08:00',
-                text: '[TWL] Platform screen doors at Tsuen Wan Line stations will undergo renewal works from 1st March to 31st March 2026.',
-              },
-              repo,
-              // This is used by vitest-evals as the test name, as the library expects `input` to be a string.
-              toString() {
-                return '[INFRA] Related to a new issue';
-              },
+        },
+        {
+          input: {
+            newEvidence: {
+              ts: TRAIN_FAULT_FOLLOW_UP_TS,
+              text: '[ISL] Due to maintenance works, services on the Island Line will end earlier at 11pm tonight.',
             },
-            expected: {
-              result: {
-                kind: 'part-of-new-issue',
-                issueType: 'infra',
-              },
+            repo,
+            toString() {
+              return '[MAINTENANCE] Related to a new issue';
             },
           },
-          {
-            input: {
-              newEvidence: {
-                ts: '2026-03-01T07:10:00+08:00',
-                text: "Hong Kong's rail system is the best in the world.",
-              },
-              repo,
-              // This is used by vitest-evals as the test name, as the library expects `input` to be a string.
-              toString() {
-                return 'Irrelevant content';
-              },
-            },
-            expected: {
-              result: {
-                kind: 'irrelevant-content',
-              },
+          expected: {
+            result: {
+              kind: 'part-of-new-issue',
+              issueType: 'maintenance',
             },
           },
-          {
-            input: {
-              newEvidence: {
-                ts: '2026-05-26T14:48:44+08:00',
-                text: '14:23-Due to vehicle breakdown along Sims Avenue East, at the junction with Chai Chee Drive after bus stop BS 83081, bus service 26 is diverted.',
-              },
-              repo,
-              // This is used by vitest-evals as the test name, as the library expects `input` to be a string.
-              toString() {
-                return 'Irrelevant bus-only service diversion';
-              },
+        },
+        {
+          input: {
+            newEvidence: {
+              ts: '2026-03-01T07:10:00+08:00',
+              text: '[TWL] Due to a track fault at Mong Kok, train services on the Tsuen Wan Line are delayed between Tsuen Wan and Mong Kok',
             },
-            expected: {
-              result: {
-                kind: 'irrelevant-content',
-              },
+            repo: new MRTDownRepository({
+              store: new FileStore(FIXTURE_DATA_DIR),
+            }),
+            toString() {
+              return '[DISRUPTION] Related to a new issue';
             },
           },
-        ] satisfies {
-          input: TriageNewEvidenceParams & { toString(): string };
-          expected: TriageNewEvidenceResult;
-        }[];
-      },
-      async task(input) {
-        const result = await triageNewEvidence(
-          input as unknown as TriageNewEvidenceParams,
-        );
-        return JSON.stringify(result);
-      },
-      scorers: [StructuredOutputScorer()],
+          expected: {
+            result: {
+              kind: 'part-of-new-issue',
+              issueType: 'disruption',
+            },
+          },
+        },
+        {
+          input: {
+            newEvidence: {
+              ts: '2026-03-01T07:10:00+08:00',
+              text: '[TWL] Platform screen doors at Tsuen Wan Line stations will undergo renewal works from 1st March to 31st March 2026.',
+            },
+            repo,
+            toString() {
+              return '[INFRA] Related to a new issue';
+            },
+          },
+          expected: {
+            result: {
+              kind: 'part-of-new-issue',
+              issueType: 'infra',
+            },
+          },
+        },
+        {
+          input: {
+            newEvidence: {
+              ts: '2026-03-01T07:10:00+08:00',
+              text: "Hong Kong's rail system is the best in the world.",
+            },
+            repo,
+            toString() {
+              return 'Irrelevant content';
+            },
+          },
+          expected: {
+            result: {
+              kind: 'irrelevant-content',
+            },
+          },
+        },
+        {
+          input: {
+            newEvidence: {
+              ts: '2026-05-26T14:48:44+08:00',
+              text: '14:23-Due to vehicle breakdown along Sims Avenue East, at the junction with Chai Chee Drive after bus stop BS 83081, bus service 26 is diverted.',
+            },
+            repo,
+            toString() {
+              return 'Irrelevant bus-only service diversion';
+            },
+          },
+          expected: {
+            result: {
+              kind: 'irrelevant-content',
+            },
+          },
+        },
+      ] satisfies {
+        input: TriageNewEvidenceParams & { toString(): string };
+        expected: TriageNewEvidenceResult;
+      }[];
+
+      it.for(
+        cases.map(({ input, expected }) => ({
+          name: input.toString(),
+          input,
+          expected,
+        })),
+      )('$name', async ({ input, expected }, { run }) => {
+        await run(input, { metadata: { expected } });
+      });
     },
   );
 });

--- a/packages/triage/src/llm/functions/triageNewEvidence/prompt.ts
+++ b/packages/triage/src/llm/functions/triageNewEvidence/prompt.ts
@@ -27,11 +27,11 @@ TOOL USE GUIDANCE:
 CLASSIFICATION RULES:
 
 Domain Gate:
-- This repository tracks Singapore MRT/LRT rail operations and station
-  facilities only.
+- This repository tracks the configured MRT/LRT/rail operations and station
+  facilities in its data set only.
 - Bus-only incidents, bus route diversions, bus stop incidents, road traffic,
   and private vehicle breakdowns are irrelevant unless the evidence explicitly
-  states an impact on MRT/LRT train service, LRT service, or an MRT/LRT station
+  states an impact on a tracked rail train service, rail line, or rail station
   facility.
 - Do not create issues for bus service numbers, bus stops, or road locations
   by themselves.

--- a/packages/triage/vitest.eval.config.ts
+++ b/packages/triage/vitest.eval.config.ts
@@ -3,5 +3,6 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     include: ['src/**/eval.test.ts'],
+    testTimeout: 60_000,
   },
 });


### PR DESCRIPTION
## Summary

- Upgrade `vitest-evals` from `0.5.0` to `0.12.0`.
- Migrate triage evals from the legacy scorer-first API to the root harness/judge API.
- Keep existing deterministic scoring behavior with `StructuredOutputJudge` and a custom translate judge.
- Avoid adding the optional `ai` peer dependency by removing `vitest-evals/legacy` usage.

## Validation

- `npm run build:triage`
- `npm run test:triage`
- `node scripts/run-fixture-command.mjs -- npm --workspace @mrtdown/triage exec -- vitest --run --config vitest.eval.config.ts --testNamePattern '__codex_no_eval_execution__' --passWithNoTests`
- `npm run check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored evaluation test suite to use updated testing patterns.

* **Chores**
  * Updated development dependency to latest version.
  * Added explicit test timeout configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->