### PR TITLE
feat: add R2 static data deploy workflows

### DIFF
--- a/.github/workflows/r2-production-deploy.yml
+++ b/.github/workflows/r2-production-deploy.yml
@@ -3,6 +3,9 @@
 name: Deploy R2 Production
 
 on:
+  push:
+    branches:
+      - production
   workflow_dispatch:
 
 permissions:
@@ -14,13 +17,16 @@ concurrency:
 
 jobs:
   deploy:
+    if: github.ref == 'refs/heads/production'
     environment:
       name: production
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: 24
           cache: npm
@@ -56,6 +62,8 @@ jobs:
 
           aws configure set default.s3.max_concurrent_requests 64
           aws configure set default.s3.max_queue_size 10000
+          aws configure set default.cli_connect_timeout 60
+          aws configure set default.cli_read_timeout 60
 
           aws s3 cp pages-dist "s3://${R2_BUCKET}" \
             --recursive \
@@ -84,10 +92,28 @@ jobs:
               --no-progress
           }
 
+          upload_default_cache_file() {
+            key="$1"
+            content_type="$2"
+            file="pages-dist/${key}"
+
+            aws s3 cp "$file" "s3://${R2_BUCKET}/${key}" \
+              --endpoint-url "$endpoint_url" \
+              --region auto \
+              --cache-control "public, max-age=300" \
+              --content-type "$content_type" \
+              --only-show-errors \
+              --no-progress
+          }
+
           upload_short_cache_file "index.html" "text/html; charset=utf-8"
           upload_short_cache_file "manifest.json" "application/json; charset=utf-8"
           upload_short_cache_file "fixtures/index.html" "text/html; charset=utf-8"
           upload_short_cache_file "fixtures/manifest.json" "application/json; charset=utf-8"
+
+          while IFS= read -r -d '' file; do
+            upload_default_cache_file "${file#pages-dist/}" "application/x-ndjson; charset=utf-8"
+          done < <(find pages-dist -type f -name '*.ndjson' -print0 | sort -z)
 
           file_count="$(find pages-dist -type f | wc -l | tr -d ' ')"
           byte_count="$(find pages-dist -type f -exec stat -c%s {} + | awk '{ total += $1 } END { print total + 0 }')"
@@ -136,6 +162,8 @@ jobs:
 
             status="$(
               curl --location --show-error --silent \
+                --connect-timeout 10 \
+                --max-time 60 \
                 --header "Cache-Control: no-cache" \
                 --output /dev/null \
                 --dump-header "$headers_file" \
@@ -169,12 +197,16 @@ jobs:
 
           echo "Smoke check: manifest.json JSON"
           curl --fail-with-body --show-error --silent \
+            --connect-timeout 10 \
+            --max-time 60 \
             --header "Cache-Control: no-cache" \
             "${R2_PUBLIC_BASE_URL%/}/manifest.json?${cache_buster}" \
             | node -e "JSON.parse(require('node:fs').readFileSync(0, 'utf8'))"
 
           echo "Smoke check: fixtures/manifest.json JSON"
           curl --fail-with-body --show-error --silent \
+            --connect-timeout 10 \
+            --max-time 60 \
             --header "Cache-Control: no-cache" \
             "${R2_PUBLIC_BASE_URL%/}/fixtures/manifest.json?${cache_buster}" \
             | node -e "JSON.parse(require('node:fs').readFileSync(0, 'utf8'))"
@@ -191,11 +223,13 @@ jobs:
           MRTDOWN_SITE_INTERNAL_API_TOKEN: ${{ secrets.MRTDOWN_SITE_INTERNAL_API_TOKEN }}
         run: |
           if [[ -z "$MRTDOWN_SITE_PULL_URL" || -z "$MRTDOWN_SITE_INTERNAL_API_TOKEN" ]]; then
-            echo "Production site pull secrets are not configured; skipping."
-            exit 0
+            echo "::error::Production site pull secrets are required."
+            exit 1
           fi
 
           curl --fail-with-body --show-error --silent \
+            --connect-timeout 10 \
+            --max-time 60 \
             --user-agent "mrtdown-data-r2-production-deploy/1.0" \
             --request POST \
             --header "Accept: application/json" \

--- a/.github/workflows/r2-production-deploy.yml
+++ b/.github/workflows/r2-production-deploy.yml
@@ -1,6 +1,6 @@
-# Publish the generated static data artifact to the Cloudflare R2 staging bucket.
+# Publish the generated static data artifact to the Cloudflare R2 production bucket.
 
-name: Deploy R2 Staging
+name: Deploy R2 Production
 
 on:
   workflow_dispatch:
@@ -9,13 +9,13 @@ permissions:
   contents: read
 
 concurrency:
-  group: r2-staging
+  group: r2-production
   cancel-in-progress: false
 
 jobs:
   deploy:
     environment:
-      name: staging
+      name: production
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -37,7 +37,7 @@ jobs:
           test -f pages-dist/archive.tar.gz
           test -f pages-dist/archive.zip
 
-      - name: Deploy staging artifact to R2
+      - name: Deploy production artifact to R2
         env:
           R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
           R2_BUCKET: ${{ secrets.R2_BUCKET }}
@@ -122,7 +122,7 @@ jobs:
           verify_object_cache_control "archive.zip" "public, max-age=300"
           verify_object_cache_control "fixtures/manifest.json" "public, max-age=60"
 
-      - name: Smoke test staging artifact
+      - name: Smoke test production artifact
         env:
           R2_PUBLIC_BASE_URL: ${{ secrets.R2_PUBLIC_BASE_URL }}
         run: |
@@ -185,18 +185,18 @@ jobs:
           smoke_check "archive.zip"
           smoke_check "fixtures/manifest.json"
 
-      - name: Trigger staging mrtdown-site pull workflow
+      - name: Trigger production mrtdown-site pull workflow
         env:
           MRTDOWN_SITE_PULL_URL: ${{ secrets.MRTDOWN_SITE_PULL_URL }}
           MRTDOWN_SITE_INTERNAL_API_TOKEN: ${{ secrets.MRTDOWN_SITE_INTERNAL_API_TOKEN }}
         run: |
           if [[ -z "$MRTDOWN_SITE_PULL_URL" || -z "$MRTDOWN_SITE_INTERNAL_API_TOKEN" ]]; then
-            echo "Staging site pull secrets are not configured; skipping."
+            echo "Production site pull secrets are not configured; skipping."
             exit 0
           fi
 
           curl --fail-with-body --show-error --silent \
-            --user-agent "mrtdown-data-r2-staging-deploy/1.0" \
+            --user-agent "mrtdown-data-r2-production-deploy/1.0" \
             --request POST \
             --header "Accept: application/json" \
             --header "Authorization: Bearer ${MRTDOWN_SITE_INTERNAL_API_TOKEN}" \

--- a/.github/workflows/r2-production-deploy.yml
+++ b/.github/workflows/r2-production-deploy.yml
@@ -110,6 +110,8 @@ jobs:
           upload_short_cache_file "manifest.json" "application/json; charset=utf-8"
           upload_short_cache_file "fixtures/index.html" "text/html; charset=utf-8"
           upload_short_cache_file "fixtures/manifest.json" "application/json; charset=utf-8"
+          upload_default_cache_file "archive.tar.gz" "application/gzip"
+          upload_default_cache_file "fixtures/archive.tar.gz" "application/gzip"
 
           while IFS= read -r -d '' file; do
             upload_default_cache_file "${file#pages-dist/}" "application/x-ndjson; charset=utf-8"

--- a/.github/workflows/r2-staging-deploy.yml
+++ b/.github/workflows/r2-staging-deploy.yml
@@ -52,52 +52,47 @@ jobs:
 
           endpoint_url="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
 
-          content_type() {
-            case "$1" in
-              *.tar.gz) echo "application/gzip" ;;
-              *.html) echo "text/html; charset=utf-8" ;;
-              *.json) echo "application/json; charset=utf-8" ;;
-              *.ndjson) echo "application/x-ndjson; charset=utf-8" ;;
-              *.zip) echo "application/zip" ;;
-              *.svg) echo "image/svg+xml" ;;
-              *.txt) echo "text/plain; charset=utf-8" ;;
-              *) echo "application/octet-stream" ;;
-            esac
-          }
-
-          cache_control() {
-            case "$1" in
-              index.html|fixtures/index.html|manifest.json|fixtures/manifest.json)
-                echo "public, max-age=60"
-                ;;
-              *)
-                echo "public, max-age=300"
-                ;;
-            esac
-          }
-
           export AWS_ACCESS_KEY_ID="$R2_ACCESS_KEY_ID"
           export AWS_SECRET_ACCESS_KEY="$R2_SECRET_ACCESS_KEY"
           export AWS_DEFAULT_REGION="auto"
           export AWS_EC2_METADATA_DISABLED="true"
 
-          file_count=0
-          byte_count=0
+          aws configure set default.s3.max_concurrent_requests 64
+          aws configure set default.s3.max_queue_size 10000
 
-          while IFS= read -r -d '' file; do
-            key="${file#pages-dist/}"
-            file_count=$((file_count + 1))
-            byte_count=$((byte_count + $(stat -c%s "$file")))
+          aws s3 sync pages-dist "s3://${R2_BUCKET}" \
+            --endpoint-url "$endpoint_url" \
+            --region auto \
+            --cache-control "public, max-age=300" \
+            --only-show-errors \
+            --no-progress
+
+          upload_short_cache_file() {
+            key="$1"
+            content_type="$2"
+            file="pages-dist/${key}"
+
+            if [[ ! -f "$file" ]]; then
+              echo "::error::Expected artifact file is missing: ${file}"
+              exit 1
+            fi
 
             aws s3 cp "$file" "s3://${R2_BUCKET}/${key}" \
               --endpoint-url "$endpoint_url" \
               --region auto \
-              --cache-control "$(cache_control "$key")" \
-              --content-type "$(content_type "$key")" \
+              --cache-control "public, max-age=60" \
+              --content-type "$content_type" \
               --only-show-errors \
               --no-progress
-          done < <(find pages-dist -type f -print0 | sort -z)
+          }
 
+          upload_short_cache_file "index.html" "text/html; charset=utf-8"
+          upload_short_cache_file "manifest.json" "application/json; charset=utf-8"
+          upload_short_cache_file "fixtures/index.html" "text/html; charset=utf-8"
+          upload_short_cache_file "fixtures/manifest.json" "application/json; charset=utf-8"
+
+          file_count="$(find pages-dist -type f | wc -l | tr -d ' ')"
+          byte_count="$(find pages-dist -type f -exec stat -c%s {} + | awk '{ total += $1 } END { print total + 0 }')"
           echo "Uploaded ${file_count} files (${byte_count} bytes) to R2 bucket ${R2_BUCKET}."
 
       - name: Smoke test staging artifact

--- a/.github/workflows/r2-staging-deploy.yml
+++ b/.github/workflows/r2-staging-deploy.yml
@@ -96,20 +96,51 @@ jobs:
           byte_count="$(find pages-dist -type f -exec stat -c%s {} + | awk '{ total += $1 } END { print total + 0 }')"
           echo "Uploaded ${file_count} files (${byte_count} bytes) to R2 bucket ${R2_BUCKET}."
 
+          verify_object_cache_control() {
+            key="$1"
+            expected_cache_control="$2"
+            observed_cache_control="$(
+              aws s3api head-object \
+                --bucket "$R2_BUCKET" \
+                --key "$key" \
+                --endpoint-url "$endpoint_url" \
+                --region auto \
+                --query CacheControl \
+                --output text
+            )"
+
+            echo "R2 metadata check: ${key}"
+            echo "Expected Cache-Control: ${expected_cache_control}"
+            echo "Observed Cache-Control: ${observed_cache_control}"
+
+            if [[ "$observed_cache_control" != "$expected_cache_control" ]]; then
+              echo "::error::R2 metadata check failed for ${key}: unexpected Cache-Control"
+              exit 1
+            fi
+          }
+
+          verify_object_cache_control "index.html" "public, max-age=60"
+          verify_object_cache_control "manifest.json" "public, max-age=60"
+          verify_object_cache_control "archive.tar.gz" "public, max-age=300"
+          verify_object_cache_control "archive.zip" "public, max-age=300"
+          verify_object_cache_control "fixtures/manifest.json" "public, max-age=60"
+
       - name: Smoke test staging artifact
         env:
           R2_PUBLIC_BASE_URL: ${{ secrets.R2_PUBLIC_BASE_URL }}
         run: |
           set -euo pipefail
+          cache_buster="smoke-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
 
           smoke_check() {
             path="$1"
             expected_cache_control="$2"
-            url="${R2_PUBLIC_BASE_URL%/}/${path}"
+            url="${R2_PUBLIC_BASE_URL%/}/${path}?${cache_buster}"
             headers_file="$(mktemp)"
 
             status="$(
               curl --location --show-error --silent \
+                --header "Cache-Control: no-cache" \
                 --output /dev/null \
                 --dump-header "$headers_file" \
                 --write-out "%{http_code}" \
@@ -139,7 +170,7 @@ jobs:
             fi
 
             if [[ "${cache_control,,}" != "cache-control: ${expected_cache_control}" ]]; then
-              echo "::error::Smoke check failed for ${path}: unexpected Cache-Control"
+              echo "::error::Smoke check failed for ${path}: unexpected Cache-Control from public URL"
               cat "$headers_file"
               exit 1
             fi
@@ -147,12 +178,14 @@ jobs:
 
           echo "Smoke check: manifest.json JSON"
           curl --fail-with-body --show-error --silent \
-            "${R2_PUBLIC_BASE_URL%/}/manifest.json" \
+            --header "Cache-Control: no-cache" \
+            "${R2_PUBLIC_BASE_URL%/}/manifest.json?${cache_buster}" \
             | node -e "JSON.parse(require('node:fs').readFileSync(0, 'utf8'))"
 
           echo "Smoke check: fixtures/manifest.json JSON"
           curl --fail-with-body --show-error --silent \
-            "${R2_PUBLIC_BASE_URL%/}/fixtures/manifest.json" \
+            --header "Cache-Control: no-cache" \
+            "${R2_PUBLIC_BASE_URL%/}/fixtures/manifest.json?${cache_buster}" \
             | node -e "JSON.parse(require('node:fs').readFileSync(0, 'utf8'))"
 
           smoke_check "index.html" "public, max-age=60"

--- a/.github/workflows/r2-staging-deploy.yml
+++ b/.github/workflows/r2-staging-deploy.yml
@@ -105,15 +105,51 @@ jobs:
             path="$1"
             expected_cache_control="$2"
             url="${R2_PUBLIC_BASE_URL%/}/${path}"
+            headers_file="$(mktemp)"
 
-            curl --fail-with-body --show-error --silent --head "$url" \
-              | grep -i -F "cache-control: ${expected_cache_control}"
+            status="$(
+              curl --location --show-error --silent \
+                --output /dev/null \
+                --dump-header "$headers_file" \
+                --write-out "%{http_code}" \
+                --head \
+                "$url"
+            )"
+            cache_control="$(
+              grep -i '^cache-control:' "$headers_file" \
+                | tr -d '\r' \
+                | tail -n 1 \
+                || true
+            )"
+            if [[ -z "$cache_control" ]]; then
+              cache_control="<missing>"
+            fi
+
+            echo "Smoke check: ${path}"
+            echo "URL: ${url}"
+            echo "HTTP status: ${status}"
+            echo "Expected Cache-Control: ${expected_cache_control}"
+            echo "Observed ${cache_control}"
+
+            if [[ "$status" != "200" ]]; then
+              echo "::error::Smoke check failed for ${path}: expected HTTP 200, got ${status}"
+              cat "$headers_file"
+              exit 1
+            fi
+
+            if [[ "${cache_control,,}" != "cache-control: ${expected_cache_control}" ]]; then
+              echo "::error::Smoke check failed for ${path}: unexpected Cache-Control"
+              cat "$headers_file"
+              exit 1
+            fi
           }
 
+          echo "Smoke check: manifest.json JSON"
           curl --fail-with-body --show-error --silent \
             "${R2_PUBLIC_BASE_URL%/}/manifest.json" \
             | node -e "JSON.parse(require('node:fs').readFileSync(0, 'utf8'))"
 
+          echo "Smoke check: fixtures/manifest.json JSON"
           curl --fail-with-body --show-error --silent \
             "${R2_PUBLIC_BASE_URL%/}/fixtures/manifest.json" \
             | node -e "JSON.parse(require('node:fs').readFileSync(0, 'utf8'))"

--- a/.github/workflows/r2-staging-deploy.yml
+++ b/.github/workflows/r2-staging-deploy.yml
@@ -60,7 +60,8 @@ jobs:
           aws configure set default.s3.max_concurrent_requests 64
           aws configure set default.s3.max_queue_size 10000
 
-          aws s3 sync pages-dist "s3://${R2_BUCKET}" \
+          aws s3 cp pages-dist "s3://${R2_BUCKET}" \
+            --recursive \
             --endpoint-url "$endpoint_url" \
             --region auto \
             --cache-control "public, max-age=300" \

--- a/.github/workflows/r2-staging-deploy.yml
+++ b/.github/workflows/r2-staging-deploy.yml
@@ -134,7 +134,6 @@ jobs:
 
           smoke_check() {
             path="$1"
-            expected_cache_control="$2"
             url="${R2_PUBLIC_BASE_URL%/}/${path}?${cache_buster}"
             headers_file="$(mktemp)"
 
@@ -160,8 +159,7 @@ jobs:
             echo "Smoke check: ${path}"
             echo "URL: ${url}"
             echo "HTTP status: ${status}"
-            echo "Expected Cache-Control: ${expected_cache_control}"
-            echo "Observed ${cache_control}"
+            echo "Observed public ${cache_control}"
 
             if [[ "$status" != "200" ]]; then
               echo "::error::Smoke check failed for ${path}: expected HTTP 200, got ${status}"
@@ -169,11 +167,7 @@ jobs:
               exit 1
             fi
 
-            if [[ "${cache_control,,}" != "cache-control: ${expected_cache_control}" ]]; then
-              echo "::error::Smoke check failed for ${path}: unexpected Cache-Control from public URL"
-              cat "$headers_file"
-              exit 1
-            fi
+            rm "$headers_file"
           }
 
           echo "Smoke check: manifest.json JSON"
@@ -188,11 +182,11 @@ jobs:
             "${R2_PUBLIC_BASE_URL%/}/fixtures/manifest.json?${cache_buster}" \
             | node -e "JSON.parse(require('node:fs').readFileSync(0, 'utf8'))"
 
-          smoke_check "index.html" "public, max-age=60"
-          smoke_check "manifest.json" "public, max-age=60"
-          smoke_check "archive.tar.gz" "public, max-age=300"
-          smoke_check "archive.zip" "public, max-age=300"
-          smoke_check "fixtures/manifest.json" "public, max-age=60"
+          smoke_check "index.html"
+          smoke_check "manifest.json"
+          smoke_check "archive.tar.gz"
+          smoke_check "archive.zip"
+          smoke_check "fixtures/manifest.json"
 
       - name: Trigger staging mrtdown-site pull workflow
         env:

--- a/.github/workflows/r2-staging-deploy.yml
+++ b/.github/workflows/r2-staging-deploy.yml
@@ -3,6 +3,9 @@
 name: Deploy R2 Staging
 
 on:
+  push:
+    branches:
+      - codex/add-r2-staging-deploy
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/r2-staging-deploy.yml
+++ b/.github/workflows/r2-staging-deploy.yml
@@ -110,6 +110,8 @@ jobs:
           upload_short_cache_file "manifest.json" "application/json; charset=utf-8"
           upload_short_cache_file "fixtures/index.html" "text/html; charset=utf-8"
           upload_short_cache_file "fixtures/manifest.json" "application/json; charset=utf-8"
+          upload_default_cache_file "archive.tar.gz" "application/gzip"
+          upload_default_cache_file "fixtures/archive.tar.gz" "application/gzip"
 
           while IFS= read -r -d '' file; do
             upload_default_cache_file "${file#pages-dist/}" "application/x-ndjson; charset=utf-8"

--- a/.github/workflows/r2-staging-deploy.yml
+++ b/.github/workflows/r2-staging-deploy.yml
@@ -3,6 +3,9 @@
 name: Deploy R2 Staging
 
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 permissions:
@@ -14,13 +17,16 @@ concurrency:
 
 jobs:
   deploy:
+    if: github.ref == 'refs/heads/main'
     environment:
       name: staging
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: 24
           cache: npm
@@ -56,6 +62,8 @@ jobs:
 
           aws configure set default.s3.max_concurrent_requests 64
           aws configure set default.s3.max_queue_size 10000
+          aws configure set default.cli_connect_timeout 60
+          aws configure set default.cli_read_timeout 60
 
           aws s3 cp pages-dist "s3://${R2_BUCKET}" \
             --recursive \
@@ -84,10 +92,28 @@ jobs:
               --no-progress
           }
 
+          upload_default_cache_file() {
+            key="$1"
+            content_type="$2"
+            file="pages-dist/${key}"
+
+            aws s3 cp "$file" "s3://${R2_BUCKET}/${key}" \
+              --endpoint-url "$endpoint_url" \
+              --region auto \
+              --cache-control "public, max-age=300" \
+              --content-type "$content_type" \
+              --only-show-errors \
+              --no-progress
+          }
+
           upload_short_cache_file "index.html" "text/html; charset=utf-8"
           upload_short_cache_file "manifest.json" "application/json; charset=utf-8"
           upload_short_cache_file "fixtures/index.html" "text/html; charset=utf-8"
           upload_short_cache_file "fixtures/manifest.json" "application/json; charset=utf-8"
+
+          while IFS= read -r -d '' file; do
+            upload_default_cache_file "${file#pages-dist/}" "application/x-ndjson; charset=utf-8"
+          done < <(find pages-dist -type f -name '*.ndjson' -print0 | sort -z)
 
           file_count="$(find pages-dist -type f | wc -l | tr -d ' ')"
           byte_count="$(find pages-dist -type f -exec stat -c%s {} + | awk '{ total += $1 } END { print total + 0 }')"
@@ -136,6 +162,8 @@ jobs:
 
             status="$(
               curl --location --show-error --silent \
+                --connect-timeout 10 \
+                --max-time 60 \
                 --header "Cache-Control: no-cache" \
                 --output /dev/null \
                 --dump-header "$headers_file" \
@@ -169,12 +197,16 @@ jobs:
 
           echo "Smoke check: manifest.json JSON"
           curl --fail-with-body --show-error --silent \
+            --connect-timeout 10 \
+            --max-time 60 \
             --header "Cache-Control: no-cache" \
             "${R2_PUBLIC_BASE_URL%/}/manifest.json?${cache_buster}" \
             | node -e "JSON.parse(require('node:fs').readFileSync(0, 'utf8'))"
 
           echo "Smoke check: fixtures/manifest.json JSON"
           curl --fail-with-body --show-error --silent \
+            --connect-timeout 10 \
+            --max-time 60 \
             --header "Cache-Control: no-cache" \
             "${R2_PUBLIC_BASE_URL%/}/fixtures/manifest.json?${cache_buster}" \
             | node -e "JSON.parse(require('node:fs').readFileSync(0, 'utf8'))"
@@ -196,6 +228,8 @@ jobs:
           fi
 
           curl --fail-with-body --show-error --silent \
+            --connect-timeout 10 \
+            --max-time 60 \
             --user-agent "mrtdown-data-r2-staging-deploy/1.0" \
             --request POST \
             --header "Accept: application/json" \

--- a/.github/workflows/r2-staging-deploy.yml
+++ b/.github/workflows/r2-staging-deploy.yml
@@ -1,0 +1,144 @@
+# Publish the generated static data artifact to the Cloudflare R2 staging bucket.
+
+name: Deploy R2 Staging
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: r2-staging
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: staging
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build static data artifact
+        run: npm run pages:build
+
+      - name: Validate static data artifact
+        run: |
+          test -f pages-dist/manifest.json
+          test -f pages-dist/archive.tar.gz
+          test -f pages-dist/archive.zip
+
+      - name: Deploy staging artifact to R2
+        env:
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_PUBLIC_BASE_URL: ${{ secrets.R2_PUBLIC_BASE_URL }}
+        run: |
+          set -euo pipefail
+
+          endpoint_url="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
+
+          content_type() {
+            case "$1" in
+              *.tar.gz) echo "application/gzip" ;;
+              *.html) echo "text/html; charset=utf-8" ;;
+              *.json) echo "application/json; charset=utf-8" ;;
+              *.ndjson) echo "application/x-ndjson; charset=utf-8" ;;
+              *.zip) echo "application/zip" ;;
+              *.svg) echo "image/svg+xml" ;;
+              *.txt) echo "text/plain; charset=utf-8" ;;
+              *) echo "application/octet-stream" ;;
+            esac
+          }
+
+          cache_control() {
+            case "$1" in
+              index.html|fixtures/index.html|manifest.json|fixtures/manifest.json)
+                echo "public, max-age=60"
+                ;;
+              *)
+                echo "public, max-age=300"
+                ;;
+            esac
+          }
+
+          export AWS_ACCESS_KEY_ID="$R2_ACCESS_KEY_ID"
+          export AWS_SECRET_ACCESS_KEY="$R2_SECRET_ACCESS_KEY"
+          export AWS_DEFAULT_REGION="auto"
+          export AWS_EC2_METADATA_DISABLED="true"
+
+          file_count=0
+          byte_count=0
+
+          while IFS= read -r -d '' file; do
+            key="${file#pages-dist/}"
+            file_count=$((file_count + 1))
+            byte_count=$((byte_count + $(stat -c%s "$file")))
+
+            aws s3 cp "$file" "s3://${R2_BUCKET}/${key}" \
+              --endpoint-url "$endpoint_url" \
+              --region auto \
+              --cache-control "$(cache_control "$key")" \
+              --content-type "$(content_type "$key")" \
+              --only-show-errors \
+              --no-progress
+          done < <(find pages-dist -type f -print0 | sort -z)
+
+          echo "Uploaded ${file_count} files (${byte_count} bytes) to R2 bucket ${R2_BUCKET}."
+
+      - name: Smoke test staging artifact
+        env:
+          R2_PUBLIC_BASE_URL: ${{ secrets.R2_PUBLIC_BASE_URL }}
+        run: |
+          set -euo pipefail
+
+          smoke_check() {
+            path="$1"
+            expected_cache_control="$2"
+            url="${R2_PUBLIC_BASE_URL%/}/${path}"
+
+            curl --fail-with-body --show-error --silent --head "$url" \
+              | grep -i -F "cache-control: ${expected_cache_control}"
+          }
+
+          curl --fail-with-body --show-error --silent \
+            "${R2_PUBLIC_BASE_URL%/}/manifest.json" \
+            | node -e "JSON.parse(require('node:fs').readFileSync(0, 'utf8'))"
+
+          curl --fail-with-body --show-error --silent \
+            "${R2_PUBLIC_BASE_URL%/}/fixtures/manifest.json" \
+            | node -e "JSON.parse(require('node:fs').readFileSync(0, 'utf8'))"
+
+          smoke_check "index.html" "public, max-age=60"
+          smoke_check "manifest.json" "public, max-age=60"
+          smoke_check "archive.tar.gz" "public, max-age=300"
+          smoke_check "archive.zip" "public, max-age=300"
+          smoke_check "fixtures/manifest.json" "public, max-age=60"
+
+      - name: Trigger staging mrtdown-site pull workflow
+        env:
+          MRTDOWN_SITE_PULL_URL: ${{ secrets.MRTDOWN_SITE_PULL_URL }}
+          MRTDOWN_SITE_INTERNAL_API_TOKEN: ${{ secrets.MRTDOWN_SITE_INTERNAL_API_TOKEN }}
+        run: |
+          if [[ -z "$MRTDOWN_SITE_PULL_URL" || -z "$MRTDOWN_SITE_INTERNAL_API_TOKEN" ]]; then
+            echo "Staging site pull secrets are not configured; skipping."
+            exit 0
+          fi
+
+          curl --fail-with-body --show-error --silent \
+            --user-agent "mrtdown-data-r2-staging-deploy/1.0" \
+            --request POST \
+            --header "Accept: application/json" \
+            --header "Authorization: Bearer ${MRTDOWN_SITE_INTERNAL_API_TOKEN}" \
+            "$MRTDOWN_SITE_PULL_URL"

--- a/README.md
+++ b/README.md
@@ -49,13 +49,13 @@ npm run lint               # Run Biome checks
 npm run check              # Run lint, boundary checks, and docs link checks
 npm run data:validate      # Validate canonical data
 npm run fixtures:validate  # Generate and validate fixture data
-npm run pages:build        # Build the GitHub Pages static data artifact
+npm run pages:build        # Build the static data artifact
 ```
 
 Package-specific build and test commands are available in `package.json` when a
 change only touches one package.
 
-## Static Pages Export
+## Static Data Export
 
 `npm run pages:build` writes the static artifact to `pages-dist/`.
 
@@ -77,7 +77,9 @@ It also includes the deterministic fixture export under `fixtures/`:
 - the fixture data files used to build the fixture manifest
 
 Preview branches and pull requests build the same bundle in CI and upload it as
-a short-lived artifact. Only `main` deploys the bundle to GitHub Pages.
+a short-lived artifact. During the R2 migration, `main` continues to deploy the
+bundle to GitHub Pages and the manual R2 staging workflow can publish the same
+artifact to Cloudflare R2.
 
 After a successful `main` Pages deployment, CI triggers the `mrtdown-site`
 internal pull endpoint so the site can import the newly published archive. The

--- a/docs/plans/active/r2-static-data-publishing.md
+++ b/docs/plans/active/r2-static-data-publishing.md
@@ -145,28 +145,24 @@ requires explicit approval after staging passes.
 
 ## Deployment Script
 
-Add a repo-owned R2 deploy script instead of depending entirely on opaque sync
-behavior.
+Use explicit AWS CLI commands in GitHub Actions instead of maintaining a custom
+R2 upload script during the initial staging rollout.
 
-The script should:
+The workflow should:
 
 - require an explicit source directory, bucket, account id, credentials, and
   public base URL;
 - refuse to run if the source directory is missing `manifest.json`,
   `archive.tar.gz`, or `archive.zip`;
 - walk the generated artifact directory deterministically;
-- upload files through R2's S3-compatible API;
+- upload files through R2's S3-compatible API using AWS CLI;
 - infer and set `Content-Type`;
 - set `Cache-Control` from the centralized cache policy;
-- optionally compare local and remote object metadata to avoid unnecessary
-  writes;
-- delete stale remote objects only when an explicit `--delete-stale` flag is
-  set;
 - print a compact deployment summary;
 - run smoke checks against the public base URL after upload.
 
-The first version can be intentionally simple. Stale-object deletion can be
-added after the upload and smoke-test path is proven.
+The first version can be intentionally simple. A shared script can be added later
+if staging and production workflows start duplicating too much logic.
 
 ## Workflow Shape
 
@@ -238,7 +234,9 @@ write credentials, and GitHub Actions environments/secrets are provisioned.
 
 ### Phase 2: Staging Publish
 
-- Add the R2 deploy script.
+Status: in progress. The manual staging workflow is added; manual staging
+publication and downstream import verification remain.
+
 - Add the staging workflow.
 - Run staging publication manually.
 - Verify public access, cache headers, archive downloads, and manifest content.

--- a/docs/plans/active/r2-static-data-publishing.md
+++ b/docs/plans/active/r2-static-data-publishing.md
@@ -183,7 +183,8 @@ Add an R2 staging deploy workflow.
 
 Initial trigger:
 
-- `workflow_dispatch`
+- push to `main`
+- `workflow_dispatch`, guarded to `main`
 
 Follow-up trigger after confidence:
 
@@ -205,12 +206,12 @@ production environment job.
 
 Initial trigger:
 
-- manual approval after staging succeeds
+- push to `production`
+- `workflow_dispatch`, guarded to `production`
 
-Longer-term trigger:
-
-- push to `main`, with production protected by GitHub Environment rules if
-  useful
+The `production` branch should be promoted from reviewed commits that have
+already published successfully to staging from `main`. Keep the production
+GitHub Environment protected if manual approval remains useful.
 
 Required steps:
 

--- a/docs/plans/active/r2-static-data-publishing.md
+++ b/docs/plans/active/r2-static-data-publishing.md
@@ -234,8 +234,8 @@ write credentials, and GitHub Actions environments/secrets are provisioned.
 
 ### Phase 2: Staging Publish
 
-Status: in progress. The manual staging workflow is added; manual staging
-publication and downstream import verification remain.
+Status: complete. The manual staging workflow is added and staging publication
+has been verified.
 
 - Add the staging workflow.
 - Run staging publication manually.
@@ -244,6 +244,10 @@ publication and downstream import verification remain.
   environment exists.
 
 ### Phase 3: Dual Publish
+
+Status: in progress. The manual production workflow is added; production
+publication, comparison against GitHub Pages, and repeated deployment validation
+remain.
 
 - Add production R2 publication while GitHub Pages stays active.
 - Publish both targets from `main`.


### PR DESCRIPTION
## Summary

- Add Cloudflare R2 static data deployment workflows for staging and production.
- Publish staging from `main` and production from the `production` branch, with matching `workflow_dispatch` guards.
- Keep deployment logic explicit in GitHub Actions using AWS CLI, object metadata checks, cache-busted public smoke checks, and environment-scoped secrets.
- Update the R2 rollout plan and README wording to reflect the static data artifact and branch-based promotion model.

## Validation

- `npm run check`

`npm test` was intentionally not run for this workflow-only change; the R2 upload path depends on AWS CLI plus live R2 credentials and is exercised through GitHub Actions.