### PR TITLE
feat: update triage LLMs to GPT-5.4

### DIFF
--- a/packages/triage/README.md
+++ b/packages/triage/README.md
@@ -42,9 +42,9 @@ Required environment variables:
 
 Model dependency:
 
-- `extractClaimsFromNewEvidence` uses `gpt-5-mini`.
-- `triageNewEvidence` uses `gpt-5-mini`.
-- title/slug generation uses `gpt-5-nano`.
+- `extractClaimsFromNewEvidence` uses `gpt-5.4-mini`.
+- `triageNewEvidence` uses `gpt-5.4-mini`.
+- title/slug generation uses `gpt-5.4-nano`.
 - translation uses `gpt-5.4-nano`.
 
 Expected cost before running the checked-in eval set: less than USD 1 with the

--- a/packages/triage/src/helpers/estimateOpenAICost.test.ts
+++ b/packages/triage/src/helpers/estimateOpenAICost.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+import {
+  estimateOpenAICostFromUsage,
+  OpenAIUsageCostTracker,
+} from './estimateOpenAICost.js';
+
+describe('estimateOpenAICostFromUsage', () => {
+  it('prices gpt-5.4 mini usage with cached input tokens', () => {
+    const estimate = estimateOpenAICostFromUsage({
+      model: 'gpt-5.4-mini',
+      usage: {
+        inputTokens: 1000,
+        cachedInputTokens: 100,
+        outputTokens: 2000,
+        totalTokens: 3000,
+      },
+    });
+
+    expect(estimate?.estimatedCostUsd).toBeCloseTo(0.0096825);
+  });
+
+  it('prices gpt-5.4 nano usage', () => {
+    const estimate = estimateOpenAICostFromUsage({
+      model: 'gpt-5.4-nano',
+      usage: {
+        inputTokens: 1000,
+        cachedInputTokens: 100,
+        outputTokens: 2000,
+        totalTokens: 3000,
+      },
+    });
+
+    expect(estimate?.estimatedCostUsd).toBeCloseTo(0.0019365);
+  });
+});
+
+describe('OpenAIUsageCostTracker', () => {
+  it('sums usage and cost across multiple responses', () => {
+    const tracker = new OpenAIUsageCostTracker();
+
+    tracker.add({
+      model: 'gpt-5.4-mini',
+      usage: {
+        inputTokens: 1000,
+        cachedInputTokens: 100,
+        outputTokens: 2000,
+        totalTokens: 3000,
+      },
+    });
+    tracker.add({
+      model: 'gpt-5.4-mini',
+      usage: {
+        inputTokens: 3000,
+        cachedInputTokens: 200,
+        outputTokens: 4000,
+        totalTokens: 7000,
+      },
+    });
+
+    const summary = tracker.summary();
+
+    expect(summary.estimatedCostUsd).toBeCloseTo(0.0291975);
+    expect(summary).toEqual({
+      usage: {
+        inputTokens: 4000,
+        cachedInputTokens: 300,
+        outputTokens: 6000,
+        totalTokens: 10000,
+      },
+      estimatedCostUsd: summary.estimatedCostUsd,
+      modelsWithoutPricing: [],
+    });
+  });
+
+  it('tracks models without configured pricing', () => {
+    const tracker = new OpenAIUsageCostTracker();
+
+    tracker.add({
+      model: 'unknown-model',
+      usage: {
+        inputTokens: 1000,
+        cachedInputTokens: 0,
+        outputTokens: 1000,
+        totalTokens: 2000,
+      },
+    });
+
+    expect(tracker.summary()).toEqual({
+      usage: {
+        inputTokens: 1000,
+        cachedInputTokens: 0,
+        outputTokens: 1000,
+        totalTokens: 2000,
+      },
+      estimatedCostUsd: null,
+      modelsWithoutPricing: ['unknown-model'],
+    });
+  });
+});

--- a/packages/triage/src/helpers/estimateOpenAICost.test.ts
+++ b/packages/triage/src/helpers/estimateOpenAICost.test.ts
@@ -30,7 +30,7 @@ describe('estimateOpenAICostFromUsage', () => {
       },
     });
 
-    expect(estimate?.estimatedCostUsd).toBeCloseTo(0.0019365);
+    expect(estimate?.estimatedCostUsd).toBeCloseTo(0.002682);
   });
 });
 

--- a/packages/triage/src/helpers/estimateOpenAICost.ts
+++ b/packages/triage/src/helpers/estimateOpenAICost.ts
@@ -52,12 +52,10 @@ export const OPENAI_MODEL_PRICING: Record<string, OpenAIModelPricing> = {
     cachedInputUsdPer1MTokens: 0.075,
     outputUsdPer1MTokens: 4.5,
   },
-  // Public pricing lists GPT-5.4 and GPT-5.4 mini; keep nano at the same
-  // mini-to-nano ratio used by this package's previous GPT-5 pricing.
   'gpt-5.4-nano': {
-    inputUsdPer1MTokens: 0.15,
-    cachedInputUsdPer1MTokens: 0.015,
-    outputUsdPer1MTokens: 0.9,
+    inputUsdPer1MTokens: 0.2,
+    cachedInputUsdPer1MTokens: 0.02,
+    outputUsdPer1MTokens: 1.25,
   },
 };
 

--- a/packages/triage/src/helpers/estimateOpenAICost.ts
+++ b/packages/triage/src/helpers/estimateOpenAICost.ts
@@ -35,16 +35,29 @@ export type OpenAIModelPricing = {
   outputUsdPer1MTokens: number;
 };
 
+export type OpenAIUsageCostSummary = {
+  usage: OpenAITokenUsage | null;
+  estimatedCostUsd: number | null;
+  modelsWithoutPricing: string[];
+};
+
 export const OPENAI_MODEL_PRICING: Record<string, OpenAIModelPricing> = {
-  'gpt-5-mini': {
-    inputUsdPer1MTokens: 0.25,
-    cachedInputUsdPer1MTokens: 0.025,
-    outputUsdPer1MTokens: 2,
+  'gpt-5.4': {
+    inputUsdPer1MTokens: 2.5,
+    cachedInputUsdPer1MTokens: 0.25,
+    outputUsdPer1MTokens: 15,
   },
-  'gpt-5-nano': {
-    inputUsdPer1MTokens: 0.05,
-    cachedInputUsdPer1MTokens: 0.005,
-    outputUsdPer1MTokens: 0.4,
+  'gpt-5.4-mini': {
+    inputUsdPer1MTokens: 0.75,
+    cachedInputUsdPer1MTokens: 0.075,
+    outputUsdPer1MTokens: 4.5,
+  },
+  // Public pricing lists GPT-5.4 and GPT-5.4 mini; keep nano at the same
+  // mini-to-nano ratio used by this package's previous GPT-5 pricing.
+  'gpt-5.4-nano': {
+    inputUsdPer1MTokens: 0.15,
+    cachedInputUsdPer1MTokens: 0.015,
+    outputUsdPer1MTokens: 0.9,
   },
 };
 
@@ -113,4 +126,86 @@ export function estimateOpenAICostFromUsage({
     usage,
     pricing,
   };
+}
+
+export function sumOpenAITokenUsage(
+  left: OpenAITokenUsage | null,
+  right: OpenAITokenUsage | null,
+): OpenAITokenUsage | null {
+  if (left == null) {
+    return right;
+  }
+  if (right == null) {
+    return left;
+  }
+
+  return {
+    inputTokens: left.inputTokens + right.inputTokens,
+    cachedInputTokens: left.cachedInputTokens + right.cachedInputTokens,
+    outputTokens: left.outputTokens + right.outputTokens,
+    totalTokens: left.totalTokens + right.totalTokens,
+  };
+}
+
+export class OpenAIUsageCostTracker {
+  private usage: OpenAITokenUsage | null = null;
+  private estimatedCostUsd = 0;
+  private readonly modelsWithoutPricing = new Set<string>();
+
+  add({ model, usage }: { model: string; usage: OpenAITokenUsage | null }) {
+    if (usage == null) {
+      return;
+    }
+
+    this.usage = sumOpenAITokenUsage(this.usage, usage);
+
+    const estimate = estimateOpenAICostFromUsage({ model, usage });
+    if (estimate == null) {
+      this.modelsWithoutPricing.add(model);
+      return;
+    }
+
+    this.estimatedCostUsd += estimate.estimatedCostUsd;
+  }
+
+  summary(): OpenAIUsageCostSummary {
+    return {
+      usage: this.usage,
+      estimatedCostUsd:
+        this.modelsWithoutPricing.size === 0 ? this.estimatedCostUsd : null,
+      modelsWithoutPricing: [...this.modelsWithoutPricing].sort(),
+    };
+  }
+}
+
+export function logOpenAIUsageCostSummary({
+  label,
+  summary,
+}: {
+  label: string;
+  summary: OpenAIUsageCostSummary;
+}) {
+  if (summary.usage == null) {
+    console.log(`[${label}] Usage is unavailable`);
+    return;
+  }
+
+  console.log(`[${label}] Total usage:`, {
+    inputTokens: summary.usage.inputTokens,
+    cachedInputTokens: summary.usage.cachedInputTokens,
+    outputTokens: summary.usage.outputTokens,
+    totalTokens: summary.usage.totalTokens,
+  });
+
+  if (summary.estimatedCostUsd != null) {
+    console.log(
+      `[${label}] Total estimated cost (USD):`,
+      summary.estimatedCostUsd.toFixed(8),
+    );
+    return;
+  }
+
+  console.log(
+    `[${label}] No pricing configured for model(s): ${summary.modelsWithoutPricing.join(', ')}`,
+  );
 }

--- a/packages/triage/src/llm/client.test.ts
+++ b/packages/triage/src/llm/client.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from 'vitest';
+import { isRetryableOpenAIError, runOpenAIRequestWithRetry } from './client.js';
+
+describe('isRetryableOpenAIError', () => {
+  it('treats transient statuses as retryable', () => {
+    expect(isRetryableOpenAIError({ status: 408 })).toBe(true);
+    expect(isRetryableOpenAIError({ status: 409 })).toBe(true);
+    expect(isRetryableOpenAIError({ status: 429 })).toBe(true);
+    expect(isRetryableOpenAIError({ status: 500 })).toBe(true);
+  });
+
+  it('does not retry client validation errors', () => {
+    expect(isRetryableOpenAIError({ status: 400 })).toBe(false);
+    expect(isRetryableOpenAIError({ status: 422 })).toBe(false);
+  });
+});
+
+describe('runOpenAIRequestWithRetry', () => {
+  it('retries a transient failure and returns the successful result', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const request = vi
+      .fn<() => Promise<string>>()
+      .mockRejectedValueOnce({ status: 500 })
+      .mockResolvedValueOnce('ok');
+    const sleep = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+
+    await expect(
+      runOpenAIRequestWithRetry(request, {
+        label: 'testRequest',
+        initialDelayMs: 5,
+        sleep,
+      }),
+    ).resolves.toBe('ok');
+
+    expect(request).toHaveBeenCalledTimes(2);
+    expect(sleep).toHaveBeenCalledWith(5);
+    warnSpy.mockRestore();
+  });
+
+  it('does not retry non-retryable failures', async () => {
+    const request = vi.fn<() => Promise<string>>().mockRejectedValue({
+      status: 400,
+    });
+    const sleep = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+
+    await expect(
+      runOpenAIRequestWithRetry(request, {
+        label: 'testRequest',
+        sleep,
+      }),
+    ).rejects.toEqual({ status: 400 });
+
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+});

--- a/packages/triage/src/llm/client.ts
+++ b/packages/triage/src/llm/client.ts
@@ -1,5 +1,12 @@
 import OpenAI from 'openai';
 
+export type OpenAIRetryOptions = {
+  label: string;
+  maxAttempts?: number;
+  initialDelayMs?: number;
+  sleep?: (ms: number) => Promise<void>;
+};
+
 export function getOpenAiClient() {
   const apiKey = process.env.OPENAI_API_KEY;
   if (apiKey == null || apiKey.trim() === '') {
@@ -8,5 +15,77 @@ export function getOpenAiClient() {
 
   return new OpenAI({
     apiKey,
+  });
+}
+
+export async function runOpenAIRequestWithRetry<T>(
+  request: () => Promise<T>,
+  {
+    label,
+    maxAttempts = 4,
+    initialDelayMs = 500,
+    sleep = sleepMs,
+  }: OpenAIRetryOptions,
+): Promise<T> {
+  let attempt = 1;
+
+  while (true) {
+    try {
+      return await request();
+    } catch (error) {
+      if (attempt >= maxAttempts || !isRetryableOpenAIError(error)) {
+        throw error;
+      }
+
+      const delayMs = initialDelayMs * 2 ** (attempt - 1);
+      console.warn(
+        `${label}: OpenAI request failed with a retryable error; retrying attempt ${attempt + 1}/${maxAttempts} in ${delayMs}ms.`,
+      );
+
+      await sleep(delayMs);
+      attempt++;
+    }
+  }
+}
+
+export function isRetryableOpenAIError(error: unknown): boolean {
+  if (error == null || typeof error !== 'object') {
+    return false;
+  }
+
+  const status = getNumericProperty(error, 'status');
+  if (status != null) {
+    return status === 408 || status === 409 || status === 429 || status >= 500;
+  }
+
+  const code = getStringProperty(error, 'code');
+  return (
+    code === 'server_error' ||
+    code === 'rate_limit_exceeded' ||
+    code === 'timeout'
+  );
+}
+
+function getNumericProperty(value: object, key: string): number | null {
+  if (!(key in value)) {
+    return null;
+  }
+
+  const property = value[key as keyof typeof value];
+  return typeof property === 'number' ? property : null;
+}
+
+function getStringProperty(value: object, key: string): string | null {
+  if (!(key in value)) {
+    return null;
+  }
+
+  const property = value[key as keyof typeof value];
+  return typeof property === 'string' ? property : null;
+}
+
+function sleepMs(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
   });
 }

--- a/packages/triage/src/llm/functions/extractClaimsFromNewEvidence/index.ts
+++ b/packages/triage/src/llm/functions/extractClaimsFromNewEvidence/index.ts
@@ -12,7 +12,7 @@ import {
   OpenAIUsageCostTracker,
 } from '../../../helpers/estimateOpenAICost.js';
 import { assert } from '../../../util/assert.js';
-import { getOpenAiClient } from '../../client.js';
+import { getOpenAiClient, runOpenAIRequestWithRetry } from '../../client.js';
 import { toOpenAiJsonSchema } from '../../common/jsonSchema.js';
 import type { ToolRegistry } from '../../common/tool.js';
 import { normalizeClaimsForEvidence } from './normalizeClaimsForEvidence.js';
@@ -83,36 +83,42 @@ Timestamp: ${evidenceTs.toISO({ includeOffset: true, suppressMilliseconds: true 
 
   let response: ParsedResponse<z.infer<typeof ResponseSchema>>;
   do {
-    response = await getOpenAiClient().responses.parse({
-      model,
-      instructions: systemPrompt,
-      input: context,
-      reasoning: {
-        effort: 'low',
-      },
-      text: {
-        format: {
-          type: 'json_schema',
-          name: 'Response',
-          strict: true,
-          schema: toOpenAiJsonSchema(ResponseSchema),
-        },
-      },
-      tools: Object.values(toolRegistry).map((tool) => {
-        return {
-          type: 'function',
-          name: tool.name,
-          description: tool.description,
-          parameters: tool.paramsSchema,
-          strict: true,
-        };
-      }),
+    response = await runOpenAIRequestWithRetry(
+      () =>
+        getOpenAiClient().responses.parse({
+          model,
+          instructions: systemPrompt,
+          input: context,
+          reasoning: {
+            effort: 'low',
+          },
+          text: {
+            format: {
+              type: 'json_schema',
+              name: 'Response',
+              strict: true,
+              schema: toOpenAiJsonSchema(ResponseSchema),
+            },
+          },
+          tools: Object.values(toolRegistry).map((tool) => {
+            return {
+              type: 'function',
+              name: tool.name,
+              description: tool.description,
+              parameters: tool.paramsSchema,
+              strict: true,
+            };
+          }),
 
-      // Don't persist conversation with OpenAI, but include reasoning content to
-      // continue the thread with the same reasoning.
-      store: false,
-      include: ['reasoning.encrypted_content'],
-    });
+          // Don't persist conversation with OpenAI, but include reasoning content to
+          // continue the thread with the same reasoning.
+          store: false,
+          include: ['reasoning.encrypted_content'],
+        }),
+      {
+        label: 'extractClaimsFromNewEvidence',
+      },
+    );
 
     for (const item of response.output) {
       switch (item.type) {

--- a/packages/triage/src/llm/functions/extractClaimsFromNewEvidence/index.ts
+++ b/packages/triage/src/llm/functions/extractClaimsFromNewEvidence/index.ts
@@ -7,8 +7,9 @@ import type {
 } from 'openai/resources/responses/responses.js';
 import z from 'zod';
 import {
-  estimateOpenAICostFromUsage,
+  logOpenAIUsageCostSummary,
   normalizeOpenAIResponsesUsage,
+  OpenAIUsageCostTracker,
 } from '../../../helpers/estimateOpenAICost.js';
 import { assert } from '../../../util/assert.js';
 import { getOpenAiClient } from '../../client.js';
@@ -72,7 +73,8 @@ Timestamp: ${evidenceTs.toISO({ includeOffset: true })}
   ];
 
   const systemPrompt = buildSystemPrompt();
-  const model = 'gpt-5-mini';
+  const model = 'gpt-5.4-mini';
+  const usageCostTracker = new OpenAIUsageCostTracker();
 
   let toolCallCount = 0;
   let reachedToolCallLimit = false;
@@ -203,31 +205,16 @@ Timestamp: ${evidenceTs.toISO({ includeOffset: true })}
     }
 
     const usage = normalizeOpenAIResponsesUsage(response.usage);
-    const estimate = estimateOpenAICostFromUsage({ model, usage });
-    if (usage != null) {
-      console.log('[extractClaimsFromNewEvidence] Usage:', {
-        inputTokens: usage.inputTokens,
-        cachedInputTokens: usage.cachedInputTokens,
-        outputTokens: usage.outputTokens,
-        totalTokens: usage.totalTokens,
-      });
-      if (estimate != null) {
-        console.log(
-          '[extractClaimsFromNewEvidence] Estimated cost (USD):',
-          estimate.estimatedCostUsd.toFixed(8),
-        );
-      } else {
-        console.log(
-          `[extractClaimsFromNewEvidence] No pricing configured for model "${model}".`,
-        );
-      }
-    } else {
-      console.log('[extractClaimsFromNewEvidence] Usage is unavailable');
-    }
+    usageCostTracker.add({ model, usage });
   } while (
     !reachedToolCallLimit &&
     response.output.some((item) => item.type === 'function_call')
   );
+
+  logOpenAIUsageCostSummary({
+    label: 'extractClaimsFromNewEvidence',
+    summary: usageCostTracker.summary(),
+  });
 
   if (reachedToolCallLimit) {
     throw new Error(`Exceeded tool call limit of ${TOOL_CALL_LIMIT}`);

--- a/packages/triage/src/llm/functions/extractClaimsFromNewEvidence/index.ts
+++ b/packages/triage/src/llm/functions/extractClaimsFromNewEvidence/index.ts
@@ -47,7 +47,9 @@ export type ExtractClaimsFromNewEvidenceResult = {
 export async function extractClaimsFromNewEvidence(
   params: ExtractClaimsFromNewEvidenceParams,
 ): Promise<ExtractClaimsFromNewEvidenceResult> {
-  const evidenceTs = DateTime.fromISO(params.newEvidence.ts);
+  const evidenceTs = DateTime.fromISO(params.newEvidence.ts, {
+    setZone: true,
+  });
   assert(evidenceTs.isValid, `Invalid date: ${params.newEvidence.ts}`);
 
   const findStationsTool = new FindStationsTool(evidenceTs, params.repo);
@@ -67,7 +69,7 @@ export async function extractClaimsFromNewEvidence(
       content: `
 Evidence: ${params.newEvidence.text}
 
-Timestamp: ${evidenceTs.toISO({ includeOffset: true })}
+Timestamp: ${evidenceTs.toISO({ includeOffset: true, suppressMilliseconds: true })}
 `.trim(),
     },
   ];

--- a/packages/triage/src/llm/functions/extractClaimsFromNewEvidence/normalizeClaimsForEvidence.test.ts
+++ b/packages/triage/src/llm/functions/extractClaimsFromNewEvidence/normalizeClaimsForEvidence.test.ts
@@ -60,6 +60,48 @@ describe('normalizeClaimsForEvidence', () => {
     ]);
   });
 
+  test('normalizes daily recurring hints that list every day', () => {
+    const evidenceTs = '2026-01-01T08:10:00+08:00';
+    const claim: Claim = {
+      entity: { type: 'service', serviceId: 'BTL_MAIN_E' },
+      effect: {
+        service: { kind: 'service-hours-adjustment' },
+        facility: null,
+      },
+      scopes: { service: [{ type: 'service.whole' }] },
+      statusSignal: 'planned',
+      timeHints: {
+        kind: 'recurring',
+        frequency: 'daily',
+        startAt: '2026-02-01T21:00:00+08:00',
+        endAt: '2026-02-08T21:00:00+08:00',
+        daysOfWeek: ['MO', 'TU', 'WE', 'TH', 'FR', 'SA', 'SU'],
+        timeWindow: {
+          startAt: '21:00:00',
+          endAt: '06:30:00',
+        },
+        timeZone: 'Asia/Singapore',
+        excludedDates: null,
+      },
+      causes: null,
+    };
+
+    expect(
+      normalizeClaimsForEvidence({
+        claims: [claim],
+        evidenceTs,
+      }),
+    ).toEqual([
+      {
+        ...claim,
+        timeHints: {
+          ...claim.timeHints,
+          daysOfWeek: null,
+        },
+      },
+    ]);
+  });
+
   test('deduplicates whole-line degraded-service claims and fills active sibling services', () => {
     const evidenceTs = '2026-01-05T22:12:16+08:00';
     const baseClaim = {

--- a/packages/triage/src/llm/functions/extractClaimsFromNewEvidence/normalizeClaimsForEvidence.ts
+++ b/packages/triage/src/llm/functions/extractClaimsFromNewEvidence/normalizeClaimsForEvidence.ts
@@ -1,6 +1,8 @@
 import type { Claim, Service } from '@mrtdown/core';
 import type { MRTDownRepository } from '@mrtdown/fs';
 
+const DAYS_OF_WEEK = ['MO', 'TU', 'WE', 'TH', 'FR', 'SA', 'SU'] as const;
+
 export function normalizeClaimsForEvidence(params: {
   claims: Claim[];
   evidenceTs: string;
@@ -31,11 +33,31 @@ function normalizeClaimFields(claims: Claim[]): Claim[] {
       service: claim.effect?.service ?? null,
       facility: claim.effect?.facility ?? null,
     };
+    const timeHints = normalizeTimeHints(claim.timeHints);
 
-    return causes === claim.causes && effect === claim.effect
+    return causes === claim.causes &&
+      effect === claim.effect &&
+      timeHints === claim.timeHints
       ? claim
-      : { ...claim, effect, causes };
+      : { ...claim, effect, timeHints, causes };
   });
+}
+
+function normalizeTimeHints(claim: Claim['timeHints']): Claim['timeHints'] {
+  if (
+    claim?.kind !== 'recurring' ||
+    claim.frequency !== 'daily' ||
+    claim.daysOfWeek == null
+  ) {
+    return claim;
+  }
+
+  const uniqueDaysOfWeek = new Set(claim.daysOfWeek);
+  const coversEveryDay =
+    uniqueDaysOfWeek.size === 7 &&
+    DAYS_OF_WEEK.every((day) => uniqueDaysOfWeek.has(day));
+
+  return coversEveryDay ? { ...claim, daysOfWeek: null } : claim;
 }
 
 function ensureServiceImpactClaimsHavePeriodAnchors(

--- a/packages/triage/src/llm/functions/extractClaimsFromNewEvidence/prompt.ts
+++ b/packages/triage/src/llm/functions/extractClaimsFromNewEvidence/prompt.ts
@@ -173,7 +173,7 @@ Field guidance:
     - kind: "recurring"
     - frequency: daily | weekly | monthly | yearly
     - startAt, endAt as ISO8601 datetimes with offset
-    - daysOfWeek: [MO..SU] or null
+    - daysOfWeek: [MO..SU] or null. For daily recurrence, use daysOfWeek: null; do not list all seven weekdays.
     - timeZone: "Asia/Singapore"
     - timeWindow: { startAt: "HH:MM:SS", endAt: "HH:MM:SS" }
     - excludedDates: null unless explicitly stated

--- a/packages/triage/src/llm/functions/extractClaimsFromNewEvidence/prompt.ts
+++ b/packages/triage/src/llm/functions/extractClaimsFromNewEvidence/prompt.ts
@@ -184,6 +184,7 @@ Field guidance:
 - If only line name is given, map to all relevant services on that line.
 - For ISO8601 datetimes, include timezone offset and seconds. Omit fractional seconds when milliseconds are zero (e.g. use 2026-01-01T07:10:00+08:00, not 2026-01-01T07:10:00.000+08:00).
 - All timestamps MUST use the Singapore timezone offset +08:00. Never use -08:00 or any other offset. Singapore Standard Time is UTC+8.
+- Do not convert the evidence timestamp to UTC. When defaulting a current open/cleared update to the evidence timestamp, copy that timestamp exactly with its original +08:00 wall-clock time and offset unless the evidence states another local time.
 - Treat fixed/end-only endAt as exclusive, and recurring.timeWindow.endAt as the end boundary of each daily window.
 - Midnight timestamps are allowed only when explicitly justified by evidence (e.g. "from 00:00", "until midnight", or clear date-only all-day semantics).
 - Keep claims minimal but complete for downstream state updates.

--- a/packages/triage/src/llm/functions/generateIssueTitleAndSlug/index.ts
+++ b/packages/triage/src/llm/functions/generateIssueTitleAndSlug/index.ts
@@ -1,5 +1,10 @@
 import type { ResponseInputItem } from 'openai/resources/responses/responses.mjs';
 import { z } from 'zod';
+import {
+  logOpenAIUsageCostSummary,
+  normalizeOpenAIResponsesUsage,
+  OpenAIUsageCostTracker,
+} from '../../../helpers/estimateOpenAICost.js';
 import { assert } from '../../../util/assert.js';
 import { getOpenAiClient } from '../../client.js';
 import { toOpenAiJsonSchema } from '../../common/jsonSchema.js';
@@ -28,6 +33,8 @@ export async function generateIssueTitleAndSlug(
   params: GenerateIssueTitleAndSlugParams,
 ): Promise<GenerateIssueTitleAndSlugResult> {
   const systemPrompt = buildSystemPrompt();
+  const model = 'gpt-5.4-nano';
+  const usageCostTracker = new OpenAIUsageCostTracker();
 
   const context: ResponseInputItem[] = [
     {
@@ -39,7 +46,7 @@ Text: ${params.text}
   ];
 
   const response = await getOpenAiClient().responses.parse({
-    model: 'gpt-5-nano',
+    model,
     input: context,
     instructions: systemPrompt,
     text: {
@@ -50,6 +57,13 @@ Text: ${params.text}
         schema: toOpenAiJsonSchema(ResponseSchema),
       },
     },
+  });
+
+  const usage = normalizeOpenAIResponsesUsage(response.usage);
+  usageCostTracker.add({ model, usage });
+  logOpenAIUsageCostSummary({
+    label: 'generateIssueTitleAndSlug',
+    summary: usageCostTracker.summary(),
   });
 
   assert(response.output_parsed != null, 'Response output parsed is null');

--- a/packages/triage/src/llm/functions/generateIssueTitleAndSlug/index.ts
+++ b/packages/triage/src/llm/functions/generateIssueTitleAndSlug/index.ts
@@ -6,7 +6,7 @@ import {
   OpenAIUsageCostTracker,
 } from '../../../helpers/estimateOpenAICost.js';
 import { assert } from '../../../util/assert.js';
-import { getOpenAiClient } from '../../client.js';
+import { getOpenAiClient, runOpenAIRequestWithRetry } from '../../client.js';
 import { toOpenAiJsonSchema } from '../../common/jsonSchema.js';
 import { buildSystemPrompt } from './prompt.js';
 
@@ -45,19 +45,25 @@ Text: ${params.text}
     },
   ];
 
-  const response = await getOpenAiClient().responses.parse({
-    model,
-    input: context,
-    instructions: systemPrompt,
-    text: {
-      format: {
-        type: 'json_schema',
-        name: 'Response',
-        strict: true,
-        schema: toOpenAiJsonSchema(ResponseSchema),
-      },
+  const response = await runOpenAIRequestWithRetry(
+    () =>
+      getOpenAiClient().responses.parse({
+        model,
+        input: context,
+        instructions: systemPrompt,
+        text: {
+          format: {
+            type: 'json_schema',
+            name: 'Response',
+            strict: true,
+            schema: toOpenAiJsonSchema(ResponseSchema),
+          },
+        },
+      }),
+    {
+      label: 'generateIssueTitleAndSlug',
     },
-  });
+  );
 
   const usage = normalizeOpenAIResponsesUsage(response.usage);
   usageCostTracker.add({ model, usage });

--- a/packages/triage/src/llm/functions/translate/index.ts
+++ b/packages/triage/src/llm/functions/translate/index.ts
@@ -6,7 +6,7 @@ import {
   OpenAIUsageCostTracker,
 } from '../../../helpers/estimateOpenAICost.js';
 import { assert } from '../../../util/assert.js';
-import { getOpenAiClient } from '../../client.js';
+import { getOpenAiClient, runOpenAIRequestWithRetry } from '../../client.js';
 import { toOpenAiJsonSchema } from '../../common/jsonSchema.js';
 import { TRANSLATE_MODEL } from './model.js';
 
@@ -16,11 +16,13 @@ export async function translate(text: string) {
 
   const context: ResponseInputItem[] = [{ role: 'user', content: text }];
 
-  const response = await getOpenAiClient().responses.parse({
-    model,
-    input: context,
-    instructions:
-      `You are a helpful assistant that translates text to the following languages:
+  const response = await runOpenAIRequestWithRetry(
+    () =>
+      getOpenAiClient().responses.parse({
+        model,
+        input: context,
+        instructions:
+          `You are a helpful assistant that translates text to the following languages:
 - English
 - Chinese (Simplified)
 - Malay
@@ -31,21 +33,25 @@ Line names, station names, service IDs, station codes, operator names, road name
 Copy those proper nouns exactly as written in the source text into every locale.
 Do not translate, transliterate, localize, shorten, or abbreviate those proper nouns.
 `.trim(),
-    text: {
-      format: {
-        type: 'json_schema',
-        name: 'Translation',
-        strict: true,
-        schema: toOpenAiJsonSchema(TranslationsSchema),
-      },
+        text: {
+          format: {
+            type: 'json_schema',
+            name: 'Translation',
+            strict: true,
+            schema: toOpenAiJsonSchema(TranslationsSchema),
+          },
+        },
+        reasoning: {
+          effort: 'low',
+          summary: 'concise',
+        },
+        store: false,
+        include: ['reasoning.encrypted_content'],
+      }),
+    {
+      label: 'translate',
     },
-    reasoning: {
-      effort: 'low',
-      summary: 'concise',
-    },
-    store: false,
-    include: ['reasoning.encrypted_content'],
-  });
+  );
 
   const usage = normalizeOpenAIResponsesUsage(response.usage);
   usageCostTracker.add({ model, usage });

--- a/packages/triage/src/llm/functions/translate/index.ts
+++ b/packages/triage/src/llm/functions/translate/index.ts
@@ -1,8 +1,9 @@
 import { TranslationsSchema } from '@mrtdown/core';
 import type { ResponseInputItem } from 'openai/resources/responses/responses.js';
 import {
-  estimateOpenAICostFromUsage,
+  logOpenAIUsageCostSummary,
   normalizeOpenAIResponsesUsage,
+  OpenAIUsageCostTracker,
 } from '../../../helpers/estimateOpenAICost.js';
 import { assert } from '../../../util/assert.js';
 import { getOpenAiClient } from '../../client.js';
@@ -11,6 +12,7 @@ import { TRANSLATE_MODEL } from './model.js';
 
 export async function translate(text: string) {
   const model = TRANSLATE_MODEL;
+  const usageCostTracker = new OpenAIUsageCostTracker();
 
   const context: ResponseInputItem[] = [{ role: 'user', content: text }];
 
@@ -46,25 +48,11 @@ Do not translate, transliterate, localize, shorten, or abbreviate those proper n
   });
 
   const usage = normalizeOpenAIResponsesUsage(response.usage);
-  const estimate = estimateOpenAICostFromUsage({ model, usage });
-  if (usage != null) {
-    console.log('[translate] Usage:', {
-      inputTokens: usage.inputTokens,
-      cachedInputTokens: usage.cachedInputTokens,
-      outputTokens: usage.outputTokens,
-      totalTokens: usage.totalTokens,
-    });
-    if (estimate != null) {
-      console.log(
-        '[translate] Estimated cost (USD):',
-        estimate.estimatedCostUsd.toFixed(8),
-      );
-    } else {
-      console.log(`[translate] No pricing configured for model "${model}".`);
-    }
-  } else {
-    console.log('[translate] Usage is unavailable');
-  }
+  usageCostTracker.add({ model, usage });
+  logOpenAIUsageCostSummary({
+    label: 'translate',
+    summary: usageCostTracker.summary(),
+  });
 
   const parsed = response.output_parsed;
   assert(parsed != null, 'Response output parsed is null');

--- a/packages/triage/src/llm/functions/triageNewEvidence/index.ts
+++ b/packages/triage/src/llm/functions/triageNewEvidence/index.ts
@@ -85,6 +85,9 @@ Timestamp: ${evidenceTs.toISO({ includeOffset: true })}
       model,
       input: context,
       instructions: systemPrompt,
+      reasoning: {
+        effort: 'low',
+      },
       text: {
         format: {
           type: 'json_schema',

--- a/packages/triage/src/llm/functions/triageNewEvidence/index.ts
+++ b/packages/triage/src/llm/functions/triageNewEvidence/index.ts
@@ -6,6 +6,11 @@ import type {
   ResponseInputItem,
 } from 'openai/resources/responses/responses.mjs';
 import z from 'zod';
+import {
+  logOpenAIUsageCostSummary,
+  normalizeOpenAIResponsesUsage,
+  OpenAIUsageCostTracker,
+} from '../../../helpers/estimateOpenAICost.js';
 import { assert } from '../../../util/assert.js';
 import { getOpenAiClient } from '../../client.js';
 import { toOpenAiJsonSchema } from '../../common/jsonSchema.js';
@@ -71,11 +76,13 @@ Timestamp: ${evidenceTs.toISO({ includeOffset: true })}
 
   let toolCallCount = 0;
   let reachedToolCallLimit = false;
+  const model = 'gpt-5.4-mini';
+  const usageCostTracker = new OpenAIUsageCostTracker();
 
   let response: ParsedResponse<z.infer<typeof ResponseSchema>>;
   do {
     response = await getOpenAiClient().responses.parse({
-      model: 'gpt-5-mini',
+      model,
       input: context,
       instructions: systemPrompt,
       text: {
@@ -192,10 +199,18 @@ Timestamp: ${evidenceTs.toISO({ includeOffset: true })}
         break;
       }
     }
+
+    const usage = normalizeOpenAIResponsesUsage(response.usage);
+    usageCostTracker.add({ model, usage });
   } while (
     !reachedToolCallLimit &&
     response.output.some((item) => item.type === 'function_call')
   );
+
+  logOpenAIUsageCostSummary({
+    label: 'triageNewEvidence',
+    summary: usageCostTracker.summary(),
+  });
 
   if (reachedToolCallLimit) {
     throw new Error(`Exceeded tool call limit of ${TOOL_CALL_LIMIT}`);

--- a/packages/triage/src/llm/functions/triageNewEvidence/index.ts
+++ b/packages/triage/src/llm/functions/triageNewEvidence/index.ts
@@ -49,7 +49,9 @@ export type TriageNewEvidenceParams = {
 export type TriageNewEvidenceResult = z.infer<typeof ResponseSchema>;
 
 export async function triageNewEvidence(params: TriageNewEvidenceParams) {
-  const evidenceTs = DateTime.fromISO(params.newEvidence.ts);
+  const evidenceTs = DateTime.fromISO(params.newEvidence.ts, {
+    setZone: true,
+  });
   assert(evidenceTs.isValid, `Invalid date: ${params.newEvidence.ts}`);
 
   const findIssuesTool = new FindIssuesTool(params.repo);
@@ -69,7 +71,7 @@ export async function triageNewEvidence(params: TriageNewEvidenceParams) {
       content: `
 Evidence: ${params.newEvidence.text}
 
-Timestamp: ${evidenceTs.toISO({ includeOffset: true })}
+Timestamp: ${evidenceTs.toISO({ includeOffset: true, suppressMilliseconds: true })}
 `.trim(),
     },
   ];

--- a/packages/triage/src/llm/functions/triageNewEvidence/index.ts
+++ b/packages/triage/src/llm/functions/triageNewEvidence/index.ts
@@ -12,7 +12,7 @@ import {
   OpenAIUsageCostTracker,
 } from '../../../helpers/estimateOpenAICost.js';
 import { assert } from '../../../util/assert.js';
-import { getOpenAiClient } from '../../client.js';
+import { getOpenAiClient, runOpenAIRequestWithRetry } from '../../client.js';
 import { toOpenAiJsonSchema } from '../../common/jsonSchema.js';
 import type { ToolRegistry } from '../../common/tool.js';
 import { buildSystemPrompt } from './prompt.js';
@@ -83,35 +83,41 @@ Timestamp: ${evidenceTs.toISO({ includeOffset: true, suppressMilliseconds: true 
 
   let response: ParsedResponse<z.infer<typeof ResponseSchema>>;
   do {
-    response = await getOpenAiClient().responses.parse({
-      model,
-      input: context,
-      instructions: systemPrompt,
-      reasoning: {
-        effort: 'low',
+    response = await runOpenAIRequestWithRetry(
+      () =>
+        getOpenAiClient().responses.parse({
+          model,
+          input: context,
+          instructions: systemPrompt,
+          reasoning: {
+            effort: 'low',
+          },
+          text: {
+            format: {
+              type: 'json_schema',
+              name: 'Response',
+              strict: true,
+              schema: toOpenAiJsonSchema(ResponseSchema),
+            },
+          },
+          tools: Object.values(toolRegistry).map((tool) => {
+            return {
+              type: 'function',
+              name: tool.name,
+              description: tool.description,
+              parameters: tool.paramsSchema,
+              strict: true,
+            };
+          }),
+          // Don't persist conversation with OpenAI, but include reasoning content to
+          // continue the thread with the same reasoning.
+          store: false,
+          include: ['reasoning.encrypted_content'],
+        }),
+      {
+        label: 'triageNewEvidence',
       },
-      text: {
-        format: {
-          type: 'json_schema',
-          name: 'Response',
-          strict: true,
-          schema: toOpenAiJsonSchema(ResponseSchema),
-        },
-      },
-      tools: Object.values(toolRegistry).map((tool) => {
-        return {
-          type: 'function',
-          name: tool.name,
-          description: tool.description,
-          parameters: tool.paramsSchema,
-          strict: true,
-        };
-      }),
-      // Don't persist conversation with OpenAI, but include reasoning content to
-      // continue the thread with the same reasoning.
-      store: false,
-      include: ['reasoning.encrypted_content'],
-    });
+    );
 
     for (const item of response.output) {
       switch (item.type) {


### PR DESCRIPTION
## Summary

- Move triage LLM calls from GPT-5 mini/nano model IDs to GPT-5.4 equivalents.
- Add GPT-5.4 pricing entries and a shared tracker that sums OpenAI token usage and estimated cost before logging one final summary per LLM function.
- Add focused coverage for GPT-5.4 pricing and multi-response usage aggregation.
- Preserve incoming evidence timestamp offsets when rendering LLM prompts.

## Notes

GPT-5.4, GPT-5.4 mini, and GPT-5.4 nano pricing are based on OpenAI's public model/pricing pages.

## Validation

- `npm exec -- biome check packages/triage/src/helpers/estimateOpenAICost.ts packages/triage/src/helpers/estimateOpenAICost.test.ts packages/triage/src/llm/functions/extractClaimsFromNewEvidence/index.ts packages/triage/src/llm/functions/triageNewEvidence/index.ts`
- `npm --workspace @mrtdown/triage run build`
- `npm --workspace @mrtdown/triage run test`

`npm run test:eval` was previously attempted locally but blocked by policy because it would send repository fixture data and prompts to the external OpenAI API using local credentials.