### PR TITLE
fix: stabilize triage eval matching

### DIFF
--- a/packages/triage/src/llm/functions/triageNewEvidence/index.ts
+++ b/packages/triage/src/llm/functions/triageNewEvidence/index.ts
@@ -89,7 +89,6 @@ Timestamp: ${evidenceTs.toISO({ includeOffset: true, suppressMilliseconds: true 
           model,
           input: context,
           instructions: systemPrompt,
-          temperature: 0,
           reasoning: {
             effort: 'low',
           },

--- a/packages/triage/src/llm/functions/triageNewEvidence/index.ts
+++ b/packages/triage/src/llm/functions/triageNewEvidence/index.ts
@@ -89,6 +89,7 @@ Timestamp: ${evidenceTs.toISO({ includeOffset: true, suppressMilliseconds: true 
           model,
           input: context,
           instructions: systemPrompt,
+          temperature: 0,
           reasoning: {
             effort: 'low',
           },

--- a/packages/triage/src/llm/functions/triageNewEvidence/prompt.ts
+++ b/packages/triage/src/llm/functions/triageNewEvidence/prompt.ts
@@ -17,6 +17,17 @@ DECISION PROCESS:
 5. Compare evidence location and timing with existing issue scope
 6. Return appropriate classification with clear reasoning
 
+TIME MATCHING:
+- Resolve relative time words against the evidence Timestamp. For example,
+  "today" and "tonight" mean the local calendar date of the evidence
+  timestamp, and "tomorrow" means the next local calendar date.
+- Same service/line and same issue type are not sufficient for planned works.
+  Existing maintenance must overlap the resolved evidence time window. If the
+  evidence says "tonight" on 2026-06-22, do not attach it to an existing
+  maintenance issue whose active period starts on 2026-06-29.
+- If a candidate issue has the right service/type but a different planned
+  maintenance date or non-overlapping active period, return part-of-new-issue.
+
 TOOL USE GUIDANCE:
 - findIssues(query): search by service names, line names/IDs, station names/IDs, source text, or issue title.
 - findIssuesByDateRange(startAt, endAt): search by issue date, evidence timestamps, and active impact periods. Use this before creating a new issue when evidence references a prior incident date such as "on May 18" or only gives generic wording like "fell in front of an oncoming train".
@@ -71,6 +82,9 @@ MAINTENANCE:
 - Service-level planned works that affect operating hours or service availability
 - Examples: early line closures, reduced service windows, system upgrades affecting all trains
 - NOT about specific facility or asset repairs/renewals (those are infra)
+- Link to an existing maintenance issue only when the service/line matches and
+  the planned work window overlaps. Separate planned work windows on the same
+  service are separate issues.
 
 INFRASTRUCTURE:
 - Specific facility or asset breakdowns that need repair or renewal


### PR DESCRIPTION
## Summary

- Make triage resolve relative time words like `today`, `tonight`, and `tomorrow` against the evidence timestamp.
- Require planned maintenance matches to overlap the candidate issue's planned work window, so same-line maintenance on a different date is treated as a new issue.
- Set `temperature: 0` for `triageNewEvidence` Responses calls to reduce eval variance.

## Root Cause

After moving to `gpt-5.4-mini`, the triage eval could attach `2026-06-22` "tonight" maintenance evidence to the existing `2026-06-29` Island Line maintenance issue because the prompt did not explicitly require planned-work date overlap.

## Validation

- `npm run build:triage`
- `npm run lint -- packages/triage/src/llm/functions/triageNewEvidence/index.ts packages/triage/src/llm/functions/triageNewEvidence/prompt.ts`
- `npm run test:triage`

Note: the targeted paid eval was not run locally because external OpenAI API execution was blocked in this environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced the triage system's logic for resolving time-related evidence and matching maintenance issues to planned work windows, ensuring more accurate issue classification and linking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->