### PR TITLE
feat: add estimated station departure schedules

### DIFF
--- a/.changeset/quick-trains-estimate.md
+++ b/.changeset/quick-trains-estimate.md
@@ -1,0 +1,5 @@
+---
+"@mrtdown/core": patch
+---
+
+Add source-backed service frequency profiles, station-level frequency windows, and enumerated estimated departures.

--- a/data/service/DTL_MAIN_E.json
+++ b/data/service/DTL_MAIN_E.json
@@ -454,6 +454,31 @@
                     "start": "05:50",
                     "end": "00:41"
                 }
+            },
+            "estimatedFrequency": {
+                "source": {
+                    "url": "https://www.lta.gov.sg/content/ltagov/en/getting_around/public_transport/rail_network.html",
+                    "description": "LTA system-wide train frequency guidance; 07:00-09:00 peak applied to weekdays for estimation",
+                    "retrievedAt": "2026-07-16"
+                },
+                "defaultHeadway": {
+                    "minSeconds": 300,
+                    "maxSeconds": 420,
+                    "representativeSeconds": 360
+                },
+                "periods": [
+                    {
+                        "id": "weekday_morning_peak",
+                        "dayType": "weekdays",
+                        "start": "07:00",
+                        "end": "09:00",
+                        "headway": {
+                            "minSeconds": 120,
+                            "maxSeconds": 180,
+                            "representativeSeconds": 150
+                        }
+                    }
+                ]
             }
         }
     ]

--- a/data/service/DTL_MAIN_W.json
+++ b/data/service/DTL_MAIN_W.json
@@ -454,6 +454,31 @@
                     "start": "05:54",
                     "end": "00:46"
                 }
+            },
+            "estimatedFrequency": {
+                "source": {
+                    "url": "https://www.lta.gov.sg/content/ltagov/en/getting_around/public_transport/rail_network.html",
+                    "description": "LTA system-wide train frequency guidance; 07:00-09:00 peak applied to weekdays for estimation",
+                    "retrievedAt": "2026-07-16"
+                },
+                "defaultHeadway": {
+                    "minSeconds": 300,
+                    "maxSeconds": 420,
+                    "representativeSeconds": 360
+                },
+                "periods": [
+                    {
+                        "id": "weekday_morning_peak",
+                        "dayType": "weekdays",
+                        "start": "07:00",
+                        "end": "09:00",
+                        "headway": {
+                            "minSeconds": 120,
+                            "maxSeconds": 180,
+                            "representativeSeconds": 150
+                        }
+                    }
+                ]
             }
         }
     ]

--- a/data/service/EWL_MAIN_E.json
+++ b/data/service/EWL_MAIN_E.json
@@ -1068,6 +1068,31 @@
                     "start": "05:42",
                     "end": "00:37"
                 }
+            },
+            "estimatedFrequency": {
+                "source": {
+                    "url": "https://www.lta.gov.sg/content/ltagov/en/getting_around/public_transport/rail_network.html",
+                    "description": "LTA system-wide train frequency guidance; 07:00-09:00 peak applied to weekdays for estimation",
+                    "retrievedAt": "2026-07-16"
+                },
+                "defaultHeadway": {
+                    "minSeconds": 300,
+                    "maxSeconds": 420,
+                    "representativeSeconds": 360
+                },
+                "periods": [
+                    {
+                        "id": "weekday_morning_peak",
+                        "dayType": "weekdays",
+                        "start": "07:00",
+                        "end": "09:00",
+                        "headway": {
+                            "minSeconds": 120,
+                            "maxSeconds": 180,
+                            "representativeSeconds": 150
+                        }
+                    }
+                ]
             }
         }
     ]

--- a/data/service/EWL_MAIN_W.json
+++ b/data/service/EWL_MAIN_W.json
@@ -1068,6 +1068,31 @@
                     "start": "05:44",
                     "end": "00:46"
                 }
+            },
+            "estimatedFrequency": {
+                "source": {
+                    "url": "https://www.lta.gov.sg/content/ltagov/en/getting_around/public_transport/rail_network.html",
+                    "description": "LTA system-wide train frequency guidance; 07:00-09:00 peak applied to weekdays for estimation",
+                    "retrievedAt": "2026-07-16"
+                },
+                "defaultHeadway": {
+                    "minSeconds": 300,
+                    "maxSeconds": 420,
+                    "representativeSeconds": 360
+                },
+                "periods": [
+                    {
+                        "id": "weekday_morning_peak",
+                        "dayType": "weekdays",
+                        "start": "07:00",
+                        "end": "09:00",
+                        "headway": {
+                            "minSeconds": 120,
+                            "maxSeconds": 180,
+                            "representativeSeconds": 150
+                        }
+                    }
+                ]
             }
         }
     ]

--- a/data/service/NEL_MAIN_N.json
+++ b/data/service/NEL_MAIN_N.json
@@ -330,6 +330,31 @@
                     "start": "05:53",
                     "end": "00:30"
                 }
+            },
+            "estimatedFrequency": {
+                "source": {
+                    "url": "https://www.lta.gov.sg/content/ltagov/en/getting_around/public_transport/rail_network.html",
+                    "description": "LTA system-wide train frequency guidance; 07:00-09:00 peak applied to weekdays for estimation",
+                    "retrievedAt": "2026-07-16"
+                },
+                "defaultHeadway": {
+                    "minSeconds": 300,
+                    "maxSeconds": 420,
+                    "representativeSeconds": 360
+                },
+                "periods": [
+                    {
+                        "id": "weekday_morning_peak",
+                        "dayType": "weekdays",
+                        "start": "07:00",
+                        "end": "09:00",
+                        "headway": {
+                            "minSeconds": 120,
+                            "maxSeconds": 180,
+                            "representativeSeconds": 150
+                        }
+                    }
+                ]
             }
         }
     ]

--- a/data/service/NEL_MAIN_S.json
+++ b/data/service/NEL_MAIN_S.json
@@ -330,6 +330,31 @@
                     "start": "05:59",
                     "end": "23:58"
                 }
+            },
+            "estimatedFrequency": {
+                "source": {
+                    "url": "https://www.lta.gov.sg/content/ltagov/en/getting_around/public_transport/rail_network.html",
+                    "description": "LTA system-wide train frequency guidance; 07:00-09:00 peak applied to weekdays for estimation",
+                    "retrievedAt": "2026-07-16"
+                },
+                "defaultHeadway": {
+                    "minSeconds": 300,
+                    "maxSeconds": 420,
+                    "representativeSeconds": 360
+                },
+                "periods": [
+                    {
+                        "id": "weekday_morning_peak",
+                        "dayType": "weekdays",
+                        "start": "07:00",
+                        "end": "09:00",
+                        "headway": {
+                            "minSeconds": 120,
+                            "maxSeconds": 180,
+                            "representativeSeconds": 150
+                        }
+                    }
+                ]
             }
         }
     ]

--- a/data/service/NSL_MAIN_N.json
+++ b/data/service/NSL_MAIN_N.json
@@ -857,6 +857,31 @@
                     "start": "05:40",
                     "end": "01:00"
                 }
+            },
+            "estimatedFrequency": {
+                "source": {
+                    "url": "https://www.lta.gov.sg/content/ltagov/en/getting_around/public_transport/rail_network.html",
+                    "description": "LTA system-wide train frequency guidance; 07:00-09:00 peak applied to weekdays for estimation",
+                    "retrievedAt": "2026-07-16"
+                },
+                "defaultHeadway": {
+                    "minSeconds": 300,
+                    "maxSeconds": 420,
+                    "representativeSeconds": 360
+                },
+                "periods": [
+                    {
+                        "id": "weekday_morning_peak",
+                        "dayType": "weekdays",
+                        "start": "07:00",
+                        "end": "09:00",
+                        "headway": {
+                            "minSeconds": 120,
+                            "maxSeconds": 180,
+                            "representativeSeconds": 150
+                        }
+                    }
+                ]
             }
         }
     ]

--- a/data/service/NSL_MAIN_S.json
+++ b/data/service/NSL_MAIN_S.json
@@ -857,6 +857,31 @@
                     "start": "05:35",
                     "end": "23:58"
                 }
+            },
+            "estimatedFrequency": {
+                "source": {
+                    "url": "https://www.lta.gov.sg/content/ltagov/en/getting_around/public_transport/rail_network.html",
+                    "description": "LTA system-wide train frequency guidance; 07:00-09:00 peak applied to weekdays for estimation",
+                    "retrievedAt": "2026-07-16"
+                },
+                "defaultHeadway": {
+                    "minSeconds": 300,
+                    "maxSeconds": 420,
+                    "representativeSeconds": 360
+                },
+                "periods": [
+                    {
+                        "id": "weekday_morning_peak",
+                        "dayType": "weekdays",
+                        "start": "07:00",
+                        "end": "09:00",
+                        "headway": {
+                            "minSeconds": 120,
+                            "maxSeconds": 180,
+                            "representativeSeconds": 150
+                        }
+                    }
+                ]
             }
         }
     ]

--- a/data/service/TEL_MAIN_N.json
+++ b/data/service/TEL_MAIN_N.json
@@ -318,6 +318,31 @@
                     "start": "05:56",
                     "end": "00:42"
                 }
+            },
+            "estimatedFrequency": {
+                "source": {
+                    "url": "https://www.lta.gov.sg/content/ltagov/en/getting_around/public_transport/rail_network.html",
+                    "description": "LTA system-wide train frequency guidance; 07:00-09:00 peak applied to weekdays for estimation",
+                    "retrievedAt": "2026-07-16"
+                },
+                "defaultHeadway": {
+                    "minSeconds": 300,
+                    "maxSeconds": 420,
+                    "representativeSeconds": 360
+                },
+                "periods": [
+                    {
+                        "id": "weekday_morning_peak",
+                        "dayType": "weekdays",
+                        "start": "07:00",
+                        "end": "09:00",
+                        "headway": {
+                            "minSeconds": 120,
+                            "maxSeconds": 180,
+                            "representativeSeconds": 150
+                        }
+                    }
+                ]
             }
         }
     ]

--- a/data/service/TEL_MAIN_S.json
+++ b/data/service/TEL_MAIN_S.json
@@ -318,6 +318,31 @@
                     "start": "05:56",
                     "end": "00:31"
                 }
+            },
+            "estimatedFrequency": {
+                "source": {
+                    "url": "https://www.lta.gov.sg/content/ltagov/en/getting_around/public_transport/rail_network.html",
+                    "description": "LTA system-wide train frequency guidance; 07:00-09:00 peak applied to weekdays for estimation",
+                    "retrievedAt": "2026-07-16"
+                },
+                "defaultHeadway": {
+                    "minSeconds": 300,
+                    "maxSeconds": 420,
+                    "representativeSeconds": 360
+                },
+                "periods": [
+                    {
+                        "id": "weekday_morning_peak",
+                        "dayType": "weekdays",
+                        "start": "07:00",
+                        "end": "09:00",
+                        "headway": {
+                            "minSeconds": 120,
+                            "maxSeconds": 180,
+                            "representativeSeconds": 150
+                        }
+                    }
+                ]
             }
         }
     ]

--- a/data/station/BBS.json
+++ b/data/station/BBS.json
@@ -28,7 +28,7 @@
   "firstLastTrain": {
     "services": [
       {
-        "serviceId": "CCL_MAIN_CCW",
+        "serviceId": "CCL_BRANCH_CCW",
         "times": {
           "weekday": {
             "firstTrain": "05:39",
@@ -45,7 +45,7 @@
         }
       },
       {
-        "serviceId": "CCL_MAIN_CW",
+        "serviceId": "CCL_BRANCH_CW",
         "times": {
           "weekday": {
             "firstTrain": "05:54",

--- a/data/station/BFT.json
+++ b/data/station/BFT.json
@@ -42,7 +42,7 @@
   "firstLastTrain": {
     "services": [
       {
-        "serviceId": "CCL_EXT_CCW",
+        "serviceId": "CCL_LOOP_CCW",
         "times": {
           "weekday": {
             "firstTrain": "06:02",
@@ -59,7 +59,7 @@
         }
       },
       {
-        "serviceId": "CCL_EXT_CW",
+        "serviceId": "CCL_LOOP_CW",
         "times": {
           "weekday": {
             "firstTrain": "06:17",

--- a/data/station/BLY.json
+++ b/data/station/BLY.json
@@ -27,7 +27,7 @@
   "firstLastTrain": {
     "services": [
       {
-        "serviceId": "CCL_MAIN_CCW",
+        "serviceId": "CCL_BRANCH_CCW",
         "times": {
           "weekday": {
             "firstTrain": "05:16",
@@ -44,7 +44,7 @@
         }
       },
       {
-        "serviceId": "CCL_MAIN_CW",
+        "serviceId": "CCL_BRANCH_CW",
         "times": {
           "weekday": {
             "firstTrain": "05:47",

--- a/data/station/BNV.json
+++ b/data/station/BNV.json
@@ -69,7 +69,7 @@
         }
       },
       {
-        "serviceId": "CCL_MAIN_CW",
+        "serviceId": "CCL_BRANCH_CW",
         "times": {
           "weekday": {
             "firstTrain": "05:39",
@@ -86,7 +86,7 @@
         }
       },
       {
-        "serviceId": "CCL_MAIN_CCW",
+        "serviceId": "CCL_BRANCH_CCW",
         "times": {
           "weekday": {
             "firstTrain": "05:39",

--- a/data/station/BSH.json
+++ b/data/station/BSH.json
@@ -52,7 +52,7 @@
         }
       },
       {
-        "serviceId": "CCL_MAIN_CW",
+        "serviceId": "CCL_BRANCH_CW",
         "times": {
           "weekday": {
             "firstTrain": "05:40",
@@ -69,7 +69,7 @@
         }
       },
       {
-        "serviceId": "CCL_MAIN_CCW",
+        "serviceId": "CCL_BRANCH_CCW",
         "times": {
           "weekday": {
             "firstTrain": "05:23",

--- a/data/station/BTN.json
+++ b/data/station/BTN.json
@@ -35,7 +35,7 @@
   "firstLastTrain": {
     "services": [
       {
-        "serviceId": "CCL_MAIN_CCW",
+        "serviceId": "CCL_BRANCH_CCW",
         "times": {
           "weekday": {
             "firstTrain": "05:32",
@@ -52,7 +52,7 @@
         }
       },
       {
-        "serviceId": "CCL_MAIN_CW",
+        "serviceId": "CCL_BRANCH_CW",
         "times": {
           "weekday": {
             "firstTrain": "05:45",

--- a/data/station/CDT.json
+++ b/data/station/CDT.json
@@ -34,7 +34,7 @@
   "firstLastTrain": {
     "services": [
       {
-        "serviceId": "CCL_MAIN_CCW",
+        "serviceId": "CCL_BRANCH_CCW",
         "times": {
           "weekday": {
             "firstTrain": "05:28",
@@ -51,7 +51,7 @@
         }
       },
       {
-        "serviceId": "CCL_MAIN_CW",
+        "serviceId": "CCL_BRANCH_CW",
         "times": {
           "weekday": {
             "firstTrain": "05:34",
@@ -112,7 +112,8 @@
         "label": "A",
         "lineId": "CCL",
         "serviceIds": [
-          "CCL_MAIN_CCW"
+          "CCL_BRANCH_CCW",
+          "CCL_LOOP_CCW"
         ],
         "accessPoints": []
       },
@@ -121,7 +122,8 @@
         "label": "B",
         "lineId": "CCL",
         "serviceIds": [
-          "CCL_MAIN_CW"
+          "CCL_BRANCH_CW",
+          "CCL_LOOP_CW"
         ],
         "accessPoints": []
       },

--- a/data/station/DBG.json
+++ b/data/station/DBG.json
@@ -60,7 +60,7 @@
         }
       },
       {
-        "serviceId": "CCL_MAIN_CCW",
+        "serviceId": "CCL_BRANCH_CCW",
         "times": {
           "weekday": {
             "firstTrain": "05:37",

--- a/data/station/DKT.json
+++ b/data/station/DKT.json
@@ -28,7 +28,7 @@
   "firstLastTrain": {
     "services": [
       {
-        "serviceId": "CCL_MAIN_CCW",
+        "serviceId": "CCL_BRANCH_CCW",
         "times": {
           "weekday": {
             "firstTrain": "05:37",
@@ -45,7 +45,7 @@
         }
       },
       {
-        "serviceId": "CCL_MAIN_CW",
+        "serviceId": "CCL_BRANCH_CW",
         "times": {
           "weekday": {
             "firstTrain": "05:42",

--- a/data/station/EPN.json
+++ b/data/station/EPN.json
@@ -28,7 +28,7 @@
   "firstLastTrain": {
     "services": [
       {
-        "serviceId": "CCL_MAIN_CCW",
+        "serviceId": "CCL_BRANCH_CCW",
         "times": {
           "weekday": {
             "firstTrain": "05:41",
@@ -45,7 +45,7 @@
         }
       },
       {
-        "serviceId": "CCL_MAIN_CW",
+        "serviceId": "CCL_BRANCH_CW",
         "times": {
           "weekday": {
             "firstTrain": "05:52",

--- a/data/station/FRR.json
+++ b/data/station/FRR.json
@@ -26,7 +26,7 @@
   "firstLastTrain": {
     "services": [
       {
-        "serviceId": "CCL_MAIN_CCW",
+        "serviceId": "CCL_BRANCH_CCW",
         "times": {
           "weekday": {
             "firstTrain": "05:34",
@@ -43,7 +43,7 @@
         }
       },
       {
-        "serviceId": "CCL_MAIN_CW",
+        "serviceId": "CCL_BRANCH_CW",
         "times": {
           "weekday": {
             "firstTrain": "05:43",

--- a/data/station/HBF.json
+++ b/data/station/HBF.json
@@ -35,7 +35,7 @@
   "firstLastTrain": {
     "services": [
       {
-        "serviceId": "CCL_MAIN_CW",
+        "serviceId": "CCL_BRANCH_CW",
         "times": {
           "weekday": {
             "firstTrain": "05:30",

--- a/data/station/HLV.json
+++ b/data/station/HLV.json
@@ -28,7 +28,7 @@
   "firstLastTrain": {
     "services": [
       {
-        "serviceId": "CCL_MAIN_CCW",
+        "serviceId": "CCL_BRANCH_CCW",
         "times": {
           "weekday": {
             "firstTrain": "05:37",
@@ -45,7 +45,7 @@
         }
       },
       {
-        "serviceId": "CCL_MAIN_CW",
+        "serviceId": "CCL_BRANCH_CW",
         "times": {
           "weekday": {
             "firstTrain": "05:40",

--- a/data/station/HPV.json
+++ b/data/station/HPV.json
@@ -26,7 +26,7 @@
   "firstLastTrain": {
     "services": [
       {
-        "serviceId": "CCL_MAIN_CCW",
+        "serviceId": "CCL_BRANCH_CCW",
         "times": {
           "weekday": {
             "firstTrain": "05:38",
@@ -43,7 +43,7 @@
         }
       },
       {
-        "serviceId": "CCL_MAIN_CW",
+        "serviceId": "CCL_BRANCH_CW",
         "times": {
           "weekday": {
             "firstTrain": "05:32",

--- a/data/station/KRG.json
+++ b/data/station/KRG.json
@@ -28,7 +28,7 @@
   "firstLastTrain": {
     "services": [
       {
-        "serviceId": "CCL_MAIN_CCW",
+        "serviceId": "CCL_BRANCH_CCW",
         "times": {
           "weekday": {
             "firstTrain": "05:35",
@@ -45,7 +45,7 @@
         }
       },
       {
-        "serviceId": "CCL_MAIN_CW",
+        "serviceId": "CCL_BRANCH_CW",
         "times": {
           "weekday": {
             "firstTrain": "05:35",

--- a/data/station/LBD.json
+++ b/data/station/LBD.json
@@ -28,7 +28,7 @@
   "firstLastTrain": {
     "services": [
       {
-        "serviceId": "CCL_MAIN_CCW",
+        "serviceId": "CCL_BRANCH_CCW",
         "times": {
           "weekday": {
             "firstTrain": "05:42",
@@ -45,7 +45,7 @@
         }
       },
       {
-        "serviceId": "CCL_MAIN_CW",
+        "serviceId": "CCL_BRANCH_CW",
         "times": {
           "weekday": {
             "firstTrain": "05:34",

--- a/data/station/LRC.json
+++ b/data/station/LRC.json
@@ -27,7 +27,7 @@
   "firstLastTrain": {
     "services": [
       {
-        "serviceId": "CCL_MAIN_CCW",
+        "serviceId": "CCL_BRANCH_CCW",
         "times": {
           "weekday": {
             "firstTrain": "05:20",
@@ -44,7 +44,7 @@
         }
       },
       {
-        "serviceId": "CCL_MAIN_CW",
+        "serviceId": "CCL_BRANCH_CW",
         "times": {
           "weekday": {
             "firstTrain": "05:42",

--- a/data/station/MBT.json
+++ b/data/station/MBT.json
@@ -28,7 +28,7 @@
   "firstLastTrain": {
     "services": [
       {
-        "serviceId": "CCL_MAIN_CCW",
+        "serviceId": "CCL_BRANCH_CCW",
         "times": {
           "weekday": {
             "firstTrain": "05:35",
@@ -45,7 +45,7 @@
         }
       },
       {
-        "serviceId": "CCL_MAIN_CW",
+        "serviceId": "CCL_BRANCH_CW",
         "times": {
           "weekday": {
             "firstTrain": "05:44",

--- a/data/station/MPS.json
+++ b/data/station/MPS.json
@@ -34,7 +34,7 @@
   "firstLastTrain": {
     "services": [
       {
-        "serviceId": "CCL_MAIN_CCW",
+        "serviceId": "CCL_BRANCH_CCW",
         "times": {
           "weekday": {
             "firstTrain": "05:42",
@@ -51,7 +51,7 @@
         }
       },
       {
-        "serviceId": "CCL_MAIN_CW",
+        "serviceId": "CCL_BRANCH_CW",
         "times": {
           "weekday": {
             "firstTrain": "05:37",

--- a/data/station/MRB.json
+++ b/data/station/MRB.json
@@ -66,7 +66,7 @@
         }
       },
       {
-        "serviceId": "CCL_EXT_CCW",
+        "serviceId": "CCL_LOOP_CCW",
         "times": {
           "weekday": {
             "firstTrain": "05:59",

--- a/data/station/MRM.json
+++ b/data/station/MRM.json
@@ -28,7 +28,7 @@
   "firstLastTrain": {
     "services": [
       {
-        "serviceId": "CCL_MAIN_CCW",
+        "serviceId": "CCL_BRANCH_CCW",
         "times": {
           "weekday": {
             "firstTrain": "05:25",
@@ -45,7 +45,7 @@
         }
       },
       {
-        "serviceId": "CCL_MAIN_CW",
+        "serviceId": "CCL_BRANCH_CW",
         "times": {
           "weekday": {
             "firstTrain": "05:37",

--- a/data/station/NCH.json
+++ b/data/station/NCH.json
@@ -28,7 +28,7 @@
   "firstLastTrain": {
     "services": [
       {
-        "serviceId": "CCL_MAIN_CCW",
+        "serviceId": "CCL_BRANCH_CCW",
         "times": {
           "weekday": {
             "firstTrain": "05:45",
@@ -45,7 +45,7 @@
         }
       },
       {
-        "serviceId": "CCL_EXT_CCW",
+        "serviceId": "CCL_LOOP_CCW",
         "times": {
           "weekday": {
             "firstTrain": "06:07",
@@ -62,7 +62,7 @@
         }
       },
       {
-        "serviceId": "CCL_EXT_CW",
+        "serviceId": "CCL_LOOP_CW",
         "times": {
           "weekday": {
             "firstTrain": "06:12",
@@ -79,7 +79,7 @@
         }
       },
       {
-        "serviceId": "CCL_MAIN_CW",
+        "serviceId": "CCL_BRANCH_CW",
         "times": {
           "weekday": {
             "firstTrain": "05:48",

--- a/data/station/ONH.json
+++ b/data/station/ONH.json
@@ -28,7 +28,7 @@
   "firstLastTrain": {
     "services": [
       {
-        "serviceId": "CCL_MAIN_CCW",
+        "serviceId": "CCL_BRANCH_CCW",
         "times": {
           "weekday": {
             "firstTrain": "05:41",
@@ -45,7 +45,7 @@
         }
       },
       {
-        "serviceId": "CCL_MAIN_CW",
+        "serviceId": "CCL_BRANCH_CW",
         "times": {
           "weekday": {
             "firstTrain": "05:36",

--- a/data/station/PMN.json
+++ b/data/station/PMN.json
@@ -35,7 +35,7 @@
   "firstLastTrain": {
     "services": [
       {
-        "serviceId": "CCL_MAIN_CCW",
+        "serviceId": "CCL_BRANCH_CCW",
         "times": {
           "weekday": {
             "firstTrain": "05:43",
@@ -52,7 +52,7 @@
         }
       },
       {
-        "serviceId": "CCL_EXT_CCW",
+        "serviceId": "CCL_LOOP_CCW",
         "times": {
           "weekday": {
             "firstTrain": "06:05",
@@ -69,7 +69,7 @@
         }
       },
       {
-        "serviceId": "CCL_MAIN_CW",
+        "serviceId": "CCL_BRANCH_CW",
         "times": {
           "weekday": {
             "firstTrain": "05:50",
@@ -86,7 +86,7 @@
         }
       },
       {
-        "serviceId": "CCL_EXT_CW",
+        "serviceId": "CCL_LOOP_CW",
         "times": {
           "weekday": {
             "firstTrain": "06:15",

--- a/data/station/PPJ.json
+++ b/data/station/PPJ.json
@@ -27,7 +27,7 @@
   "firstLastTrain": {
     "services": [
       {
-        "serviceId": "CCL_MAIN_CCW",
+        "serviceId": "CCL_BRANCH_CCW",
         "times": {
           "weekday": {
             "firstTrain": "05:40",
@@ -44,7 +44,7 @@
         }
       },
       {
-        "serviceId": "CCL_MAIN_CW",
+        "serviceId": "CCL_BRANCH_CW",
         "times": {
           "weekday": {
             "firstTrain": "05:30",

--- a/data/station/PYL.json
+++ b/data/station/PYL.json
@@ -69,7 +69,7 @@
         }
       },
       {
-        "serviceId": "CCL_MAIN_CW",
+        "serviceId": "CCL_BRANCH_CW",
         "times": {
           "weekday": {
             "firstTrain": "05:40",
@@ -86,7 +86,7 @@
         }
       },
       {
-        "serviceId": "CCL_MAIN_CCW",
+        "serviceId": "CCL_BRANCH_CCW",
         "times": {
           "weekday": {
             "firstTrain": "05:40",

--- a/data/station/SDM.json
+++ b/data/station/SDM.json
@@ -28,7 +28,7 @@
   "firstLastTrain": {
     "services": [
       {
-        "serviceId": "CCL_MAIN_CCW",
+        "serviceId": "CCL_BRANCH_CCW",
         "times": {
           "weekday": {
             "firstTrain": "05:47",
@@ -45,7 +45,7 @@
         }
       },
       {
-        "serviceId": "CCL_MAIN_CW",
+        "serviceId": "CCL_BRANCH_CW",
         "times": {
           "weekday": {
             "firstTrain": "05:45",
@@ -62,7 +62,7 @@
         }
       },
       {
-        "serviceId": "CCL_EXT_CW",
+        "serviceId": "CCL_LOOP_CW",
         "times": {
           "weekday": {
             "firstTrain": "06:10",

--- a/data/station/SER.json
+++ b/data/station/SER.json
@@ -35,7 +35,7 @@
   "firstLastTrain": {
     "services": [
       {
-        "serviceId": "CCL_MAIN_CCW",
+        "serviceId": "CCL_BRANCH_CCW",
         "times": {
           "weekday": {
             "firstTrain": "05:18",
@@ -52,7 +52,7 @@
         }
       },
       {
-        "serviceId": "CCL_MAIN_CW",
+        "serviceId": "CCL_BRANCH_CW",
         "times": {
           "weekday": {
             "firstTrain": "05:44",

--- a/data/station/TLB.json
+++ b/data/station/TLB.json
@@ -28,7 +28,7 @@
   "firstLastTrain": {
     "services": [
       {
-        "serviceId": "CCL_MAIN_CCW",
+        "serviceId": "CCL_BRANCH_CCW",
         "times": {
           "weekday": {
             "firstTrain": "05:44",
@@ -45,7 +45,7 @@
         }
       },
       {
-        "serviceId": "CCL_MAIN_CW",
+        "serviceId": "CCL_BRANCH_CW",
         "times": {
           "weekday": {
             "firstTrain": "05:32",

--- a/data/station/TSG.json
+++ b/data/station/TSG.json
@@ -27,7 +27,7 @@
   "firstLastTrain": {
     "services": [
       {
-        "serviceId": "CCL_MAIN_CCW",
+        "serviceId": "CCL_BRANCH_CCW",
         "times": {
           "weekday": {
             "firstTrain": "05:44",
@@ -44,7 +44,7 @@
         }
       },
       {
-        "serviceId": "CCL_MAIN_CW",
+        "serviceId": "CCL_BRANCH_CW",
         "times": {
           "weekday": {
             "firstTrain": "05:35",

--- a/docs/plans/active/gtfs-static-realtime.md
+++ b/docs/plans/active/gtfs-static-realtime.md
@@ -88,11 +88,67 @@ Candidate follow-up tables:
 
 - `shapes.txt`, once geometry expectations are settled;
 - `transfers.txt`, once interchange and transfer rules are represented clearly;
-- `frequencies.txt`, if deterministic trip times are not the right model for
-  headway-based LRT or future high-frequency service representation.
+- `frequencies.txt`, using the estimated-frequency model once reviewed relative
+  stop times are available.
 
 Generated files should be treated as artifacts. The source of truth remains the
 canonical JSON data plus generator code and any reviewed GTFS mapping metadata.
+
+### Frequency Estimation Decision
+
+Canonical service revisions may store source-backed estimated headway ranges,
+including a deterministic representative value and calendar-specific override
+periods. Generator code combines those inputs with each station's canonical
+first and last train times to produce non-overlapping station-level windows.
+This preserves short starters and distinct weekday, Saturday, and
+Sunday/public-holiday bounds that a service-wide operating window cannot
+represent. A deterministic enumerator expands each window using intervals
+distributed as evenly as possible around the representative headway. This
+keeps frequency-window boundaries and the canonical last train aligned without
+adding an implausibly short final gap. Interior estimates are quantized to 30
+seconds, the smallest unit needed for the 150-second peak midpoint, rather than
+implying arbitrary second-level precision. Internal window ends are exclusive,
+while canonical first and last trains are retained and labelled as source
+anchors. Every interior departure is explicitly labelled as a frequency
+estimate. The generated schedules are artifacts and do not belong under
+`data/`.
+
+The initial profiles cover the current NEL, DTL, EWL main, NSL, and TEL service
+revisions using
+[LTA's system-wide rail guidance](https://www.lta.gov.sg/content/ltagov/en/getting_around/public_transport/rail_network.html):
+two to three minutes during the 07:00–09:00 peak and five to seven minutes
+otherwise. Because LTA does not specify the applicable days, the profiles treat
+the peak window as weekday-only and record that modelling assumption in the
+source description. The representative values are the range midpoints, 150 and
+360 seconds. These are explicitly estimates, not exact departures; a GTFS
+export should therefore map them to `frequencies.txt` with `exact_times=0`.
+
+CCL is deferred until its current service ids align with canonical station
+timings. The EWL airport shuttle and SKLRT/PGLRT services are deferred because
+their current service paths do not yet have complete directional station
+timings. BPLRT needs a separate loop-specific frequency assumption, and future
+CRL/JRL services do not yet have operating timings.
+
+Station-level windows are not directly `frequencies.txt` rows. A GTFS export
+must first group compatible windows into full-length and short-start trip
+patterns. These profiles do not invent that grouping or `stop_times.txt`;
+relative stop times still require reviewed segment runtime and dwell-time
+inputs.
+
+### Geometry And Stop Offset Estimation
+
+[LTA DataMall's geospatial datasets](https://datamall.lta.gov.sg/content/datamall/en/static-data.html)
+include rail infrastructure as ESRI shapefiles. Ordered station coordinates can
+label otherwise unlabelled linework by snapping each service path to nearby
+geometry. The resulting along-track distance is suitable for `shapes.txt`,
+distance metadata, and anomaly checks.
+
+Distance alone is not a sufficient timing model. Curves, acceleration,
+deceleration, dwell time, and minute-rounded source timings cause materially
+different effective speeds between adjacent stations. Stop offsets should be
+anchored to observed first/last-train chains where possible. Geometry may fill
+or flag gaps only through an explicit, calibrated estimation method whose
+assumptions and provenance are retained.
 
 ## GTFS Id Policy
 
@@ -117,10 +173,11 @@ generated counters, or file ordering into public ids.
 - Record missing source data, including agency timezone/language, route type,
   stop wheelchair/accessibility details, platform granularity, service
   calendars, and schedule/headway assumptions.
-- Decide whether the first feed represents planned canonical topology only or a
-  timetable-like approximation derived from operating windows.
+- Use source-backed frequency estimates for the initial timetable-like
+  approximation bounded by station first/last train times.
 - Document whether LRT loop services should use `stop_times.txt` trips,
-  `frequencies.txt`, or both.
+  `frequencies.txt`, or both; the MRT frequency profiles do not settle the LRT
+  representation.
 - Decide the initial feed path in the Pages artifact, such as
   `gtfs/static.zip`.
 
@@ -154,7 +211,8 @@ Exit criteria:
   or command orchestration.
 - Generate CSV tables with stable row ordering and reproducible zip output.
 - Generate `agency.txt`, `stops.txt`, `routes.txt`, `trips.txt`,
-  `stop_times.txt`, calendar data, and `feed_info.txt`.
+  `stop_times.txt`, calendar data, `feed_info.txt`, and `frequencies.txt` for
+  services with estimated frequency profiles.
 - Add CLI commands to generate, inspect, and validate GTFS output.
 - Add tests that compare generated fixture output against committed snapshots
   or normalized table rows.

--- a/docs/plans/active/gtfs-static-realtime.md
+++ b/docs/plans/active/gtfs-static-realtime.md
@@ -123,10 +123,12 @@ source description. The representative values are the range midpoints, 150 and
 360 seconds. These are explicitly estimates, not exact departures; a GTFS
 export should therefore map them to `frequencies.txt` with `exact_times=0`.
 
-CCL is deferred until its current service ids align with canonical station
-timings. The EWL airport shuttle and SKLRT/PGLRT services are deferred because
-their current service paths do not yet have complete directional station
-timings. BPLRT needs a separate loop-specific frequency assumption, and future
+CCL station timings now use the Stage 6 branch and loop service ids, but the
+current paths still lack complete directional timing coverage: branch services
+resolve 27 of 31 path positions and loop services resolve 4 of 31. The new
+CC30–CC32 stations also need sourced first/last-train times. The EWL airport
+shuttle and SKLRT/PGLRT services are similarly deferred for incomplete timing
+coverage. BPLRT needs a separate loop-specific frequency assumption, and future
 CRL/JRL services do not yet have operating timings.
 
 Station-level windows are not directly `frequencies.txt` rows. A GTFS export

--- a/packages/core/src/helpers/generateEstimatedStationFrequencySchedules.test.ts
+++ b/packages/core/src/helpers/generateEstimatedStationFrequencySchedules.test.ts
@@ -1,0 +1,399 @@
+import { describe, expect, test } from 'vitest';
+import {
+  type EstimatedFrequencyProfile,
+  EstimatedFrequencyProfileSchema,
+  type ServiceRevision,
+} from '../schema/Service.js';
+import type { Station } from '../schema/Station.js';
+import {
+  enumerateEstimatedStationDepartures,
+  generateEstimatedServiceStationFrequencySchedules,
+  generateEstimatedStationFrequencySchedule,
+} from './generateEstimatedStationFrequencySchedules.js';
+
+const estimatedFrequency = {
+  source: {
+    url: 'https://www.lta.gov.sg/example',
+    description: 'LTA system-wide train frequency guidance',
+    retrievedAt: '2026-07-16',
+  },
+  defaultHeadway: {
+    minSeconds: 300,
+    maxSeconds: 420,
+    representativeSeconds: 360,
+  },
+  periods: [
+    {
+      id: 'weekday_morning_peak',
+      dayType: 'weekdays',
+      start: '07:00',
+      end: '09:00',
+      headway: {
+        minSeconds: 120,
+        maxSeconds: 180,
+        representativeSeconds: 150,
+      },
+    },
+  ],
+} satisfies EstimatedFrequencyProfile;
+
+const revision = {
+  path: {
+    stations: [
+      { stationId: 'HBF', displayCode: 'NE1' },
+      { stationId: 'SKG', displayCode: 'NE16' },
+      { stationId: 'PGC', displayCode: 'NE18' },
+    ],
+  },
+  estimatedFrequency,
+} satisfies Pick<ServiceRevision, 'path' | 'estimatedFrequency'>;
+
+function station(
+  id: string,
+  times?: NonNullable<
+    NonNullable<Station['firstLastTrain']>['services'][number]['times']
+  >,
+): Pick<Station, 'id' | 'firstLastTrain'> {
+  return {
+    id,
+    firstLastTrain: times
+      ? { services: [{ serviceId: 'NEL_MAIN_N', times }] }
+      : undefined,
+  };
+}
+
+const harbourFront = station('HBF', {
+  weekday: { firstTrain: '05:47', lastTrain: '23:55' },
+  saturday: { firstTrain: '05:47', lastTrain: '23:55' },
+  sunday_public_holiday: { firstTrain: '06:07', lastTrain: '23:55' },
+});
+
+const sengkang = station('SKG', {
+  weekday: { firstTrain: '05:33', lastTrain: '00:27' },
+  saturday: { firstTrain: '05:33', lastTrain: '00:27' },
+  sunday_public_holiday: { firstTrain: '05:53', lastTrain: '00:27' },
+});
+
+describe('EstimatedFrequencyProfileSchema', () => {
+  test('accepts a representative headway within the published range', () => {
+    expect(
+      EstimatedFrequencyProfileSchema.safeParse(estimatedFrequency).success,
+    ).toBe(true);
+  });
+
+  test('rejects a representative headway outside the published range', () => {
+    const result = EstimatedFrequencyProfileSchema.safeParse({
+      ...estimatedFrequency,
+      defaultHeadway: {
+        ...estimatedFrequency.defaultHeadway,
+        representativeSeconds: 480,
+      },
+    });
+
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('generateEstimatedStationFrequencySchedule', () => {
+  test('clips weekday windows to HarbourFront timings', () => {
+    const schedule = generateEstimatedStationFrequencySchedule({
+      serviceId: 'NEL_MAIN_N',
+      revision,
+      station: harbourFront,
+      calendar: 'weekday',
+    });
+
+    expect(schedule).toMatchObject({
+      stationId: 'HBF',
+      displayCode: 'NE1',
+      stopSequence: 1,
+      sourceCalendar: 'weekday',
+      firstTrainTime: '05:47',
+      lastTrainTime: '23:55',
+    });
+    expect(schedule.windows).toEqual([
+      expect.objectContaining({
+        startTime: '05:47:00',
+        endTime: '07:00:00',
+        headwaySeconds: 360,
+        sourcePeriodId: null,
+      }),
+      expect.objectContaining({
+        startTime: '07:00:00',
+        endTime: '09:00:00',
+        headwaySeconds: 150,
+        sourcePeriodId: 'weekday_morning_peak',
+      }),
+      expect.objectContaining({
+        startTime: '09:00:00',
+        endTime: '23:55:00',
+        headwaySeconds: 360,
+        sourcePeriodId: null,
+      }),
+    ]);
+  });
+
+  test('preserves a short starter and an after-midnight last train', () => {
+    const schedule = generateEstimatedStationFrequencySchedule({
+      serviceId: 'NEL_MAIN_N',
+      revision,
+      station: sengkang,
+      calendar: 'weekday',
+    });
+
+    expect(schedule.firstTrainTime).toBe('05:33');
+    expect(schedule.lastTrainTime).toBe('00:27');
+    expect(schedule.windows.at(-1)).toMatchObject({
+      startTime: '09:00:00',
+      endTime: '24:27:00',
+    });
+  });
+
+  test('keeps Saturday and Sunday station bounds distinct', () => {
+    const saturday = generateEstimatedStationFrequencySchedule({
+      serviceId: 'NEL_MAIN_N',
+      revision,
+      station: harbourFront,
+      calendar: 'saturday',
+    });
+    const sunday = generateEstimatedStationFrequencySchedule({
+      serviceId: 'NEL_MAIN_N',
+      revision,
+      station: harbourFront,
+      calendar: 'sunday_public_holiday',
+    });
+
+    expect(saturday.firstTrainTime).toBe('05:47');
+    expect(saturday.windows).toHaveLength(1);
+    expect(sunday.firstTrainTime).toBe('06:07');
+    expect(sunday.windows).toHaveLength(1);
+  });
+
+  test('falls back to combined and daily source calendars', () => {
+    const combined = station('HBF', {
+      weekday_saturday: { firstTrain: '05:30', lastTrain: '23:30' },
+      daily: { firstTrain: '06:00', lastTrain: '23:00' },
+    });
+
+    expect(
+      generateEstimatedStationFrequencySchedule({
+        serviceId: 'NEL_MAIN_N',
+        revision,
+        station: combined,
+        calendar: 'saturday',
+      }).sourceCalendar,
+    ).toBe('weekday_saturday');
+    expect(
+      generateEstimatedStationFrequencySchedule({
+        serviceId: 'NEL_MAIN_N',
+        revision,
+        station: combined,
+        calendar: 'sunday_public_holiday',
+      }).sourceCalendar,
+    ).toBe('daily');
+  });
+
+  test('retains path stations without direction-specific timing', () => {
+    const schedule = generateEstimatedStationFrequencySchedule({
+      serviceId: 'NEL_MAIN_N',
+      revision,
+      station: station('PGC'),
+      calendar: 'weekday',
+    });
+
+    expect(schedule).toMatchObject({
+      stationId: 'PGC',
+      displayCode: 'NE18',
+      stopSequence: 3,
+      sourceCalendar: null,
+      firstTrainTime: null,
+      lastTrainTime: null,
+      windows: [],
+    });
+  });
+
+  test('rejects overlapping estimates at a station', () => {
+    const overlappingRevision = {
+      ...revision,
+      estimatedFrequency: {
+        ...estimatedFrequency,
+        periods: [
+          estimatedFrequency.periods[0],
+          {
+            ...estimatedFrequency.periods[0],
+            id: 'overlapping_peak',
+            start: '08:00',
+            end: '10:00',
+          },
+        ],
+      },
+    };
+
+    expect(() =>
+      generateEstimatedStationFrequencySchedule({
+        serviceId: 'NEL_MAIN_N',
+        revision: overlappingRevision,
+        station: harbourFront,
+        calendar: 'weekday',
+      }),
+    ).toThrow('Estimated frequency periods overlap');
+  });
+});
+
+describe('generateEstimatedServiceStationFrequencySchedules', () => {
+  test('returns every path station in order', () => {
+    const schedules = generateEstimatedServiceStationFrequencySchedules({
+      serviceId: 'NEL_MAIN_N',
+      revision,
+      stations: [station('PGC'), sengkang, harbourFront],
+      calendar: 'weekday',
+    });
+
+    expect(schedules.map(({ stationId }) => stationId)).toEqual([
+      'HBF',
+      'SKG',
+      'PGC',
+    ]);
+    expect(schedules.map(({ stopSequence }) => stopSequence)).toEqual([
+      1, 2, 3,
+    ]);
+  });
+
+  test('preserves repeated stops in loop service paths', () => {
+    const loopRevision = {
+      ...revision,
+      path: {
+        stations: [
+          { stationId: 'SKG', displayCode: 'STC' },
+          { stationId: 'HBF', displayCode: 'NE1' },
+          { stationId: 'SKG', displayCode: 'STC' },
+        ],
+      },
+    };
+
+    const schedules = generateEstimatedServiceStationFrequencySchedules({
+      serviceId: 'NEL_MAIN_N',
+      revision: loopRevision,
+      stations: [harbourFront, sengkang],
+      calendar: 'weekday',
+    });
+
+    expect(
+      schedules.map(({ stationId, stopSequence }) => [stationId, stopSequence]),
+    ).toEqual([
+      ['SKG', 1],
+      ['HBF', 2],
+      ['SKG', 3],
+    ]);
+  });
+});
+
+describe('enumerateEstimatedStationDepartures', () => {
+  test('enumerates the weekday northbound schedule at Outram Park', () => {
+    const outramParkRevision = {
+      ...revision,
+      path: {
+        stations: [{ stationId: 'OTP', displayCode: 'NE3' }],
+      },
+    };
+    const outramPark = station('OTP', {
+      weekday: { firstTrain: '05:48', lastTrain: '23:59' },
+    });
+    const schedule = generateEstimatedStationFrequencySchedule({
+      serviceId: 'NEL_MAIN_N',
+      revision: outramParkRevision,
+      station: outramPark,
+      calendar: 'weekday',
+    });
+
+    const departures = enumerateEstimatedStationDepartures(schedule);
+
+    expect(departures).toHaveLength(211);
+    expect(departures.slice(0, 3)).toMatchObject([
+      { time: '05:48:00', basis: 'first_train', headwaySeconds: 360 },
+      { time: '05:54:00', basis: 'frequency_estimate' },
+      { time: '06:00:00', basis: 'frequency_estimate' },
+    ]);
+    expect(
+      departures.filter(({ time }) => time >= '06:54:00' && time <= '07:05:00'),
+    ).toMatchObject([
+      { time: '06:54:00', basis: 'frequency_estimate' },
+      {
+        time: '07:00:00',
+        basis: 'frequency_estimate',
+        headwaySeconds: 150,
+        sourcePeriodId: 'weekday_morning_peak',
+      },
+      { time: '07:02:30', basis: 'frequency_estimate' },
+      { time: '07:05:00', basis: 'frequency_estimate' },
+    ]);
+    expect(
+      departures.filter(({ time }) => time >= '08:57:30' && time <= '09:06:00'),
+    ).toMatchObject([
+      { time: '08:57:30', headwaySeconds: 150 },
+      { time: '09:00:00', headwaySeconds: 360 },
+      { time: '09:06:00', headwaySeconds: 360 },
+    ]);
+    expect(departures.slice(-2)).toMatchObject([
+      { time: '23:53:00', basis: 'frequency_estimate' },
+      { time: '23:59:00', basis: 'last_train' },
+    ]);
+    for (const [index, departure] of departures.slice(0, -1).entries()) {
+      const nextDeparture = departures[index + 1];
+      expect(nextDeparture).toBeDefined();
+      const interval = (nextDeparture?.seconds ?? 0) - departure.seconds;
+      expect(interval).toBeGreaterThanOrEqual(
+        departure.headwayRangeSeconds.min,
+      );
+      expect(interval).toBeLessThanOrEqual(departure.headwayRangeSeconds.max);
+    }
+  });
+
+  test('deduplicates a last train that falls on the estimated sequence', () => {
+    const schedule = generateEstimatedStationFrequencySchedule({
+      serviceId: 'NEL_MAIN_N',
+      revision: {
+        ...revision,
+        path: { stations: [{ stationId: 'HBF', displayCode: 'NE1' }] },
+      },
+      station: station('HBF', {
+        saturday: { firstTrain: '06:00', lastTrain: '06:12' },
+      }),
+      calendar: 'saturday',
+    });
+
+    expect(enumerateEstimatedStationDepartures(schedule)).toMatchObject([
+      { time: '06:00:00', basis: 'first_train' },
+      { time: '06:06:00', basis: 'frequency_estimate' },
+      { time: '06:12:00', basis: 'last_train' },
+    ]);
+  });
+
+  test('uses service-day times after midnight', () => {
+    const schedule = generateEstimatedStationFrequencySchedule({
+      serviceId: 'NEL_MAIN_N',
+      revision: {
+        ...revision,
+        path: { stations: [{ stationId: 'SKG', displayCode: 'NE16' }] },
+      },
+      station: sengkang,
+      calendar: 'saturday',
+    });
+
+    expect(enumerateEstimatedStationDepartures(schedule).at(-1)).toMatchObject({
+      time: '24:27:00',
+      basis: 'last_train',
+    });
+  });
+
+  test('returns no departures when station timing is unavailable', () => {
+    const schedule = generateEstimatedStationFrequencySchedule({
+      serviceId: 'NEL_MAIN_N',
+      revision,
+      station: station('PGC'),
+      calendar: 'weekday',
+    });
+
+    expect(enumerateEstimatedStationDepartures(schedule)).toEqual([]);
+  });
+});

--- a/packages/core/src/helpers/generateEstimatedStationFrequencySchedules.test.ts
+++ b/packages/core/src/helpers/generateEstimatedStationFrequencySchedules.test.ts
@@ -369,6 +369,52 @@ describe('enumerateEstimatedStationDepartures', () => {
     ]);
   });
 
+  test('rejects a window shorter than its minimum headway', () => {
+    const schedule = generateEstimatedStationFrequencySchedule({
+      serviceId: 'NEL_MAIN_N',
+      revision: {
+        ...revision,
+        path: { stations: [{ stationId: 'HBF', displayCode: 'NE1' }] },
+      },
+      station: station('HBF', {
+        saturday: { firstTrain: '06:00', lastTrain: '06:02' },
+      }),
+      calendar: 'saturday',
+    });
+
+    expect(() => enumerateEstimatedStationDepartures(schedule)).toThrow(
+      'Estimated frequency window 06:00:00-06:02:00 cannot satisfy its 300-420 second headway range',
+    );
+  });
+
+  test('selects another interval count when quantization invalidates the ideal', () => {
+    const schedule = generateEstimatedStationFrequencySchedule({
+      serviceId: 'NEL_MAIN_N',
+      revision: {
+        path: { stations: [{ stationId: 'HBF', displayCode: 'NE1' }] },
+        estimatedFrequency: {
+          ...estimatedFrequency,
+          defaultHeadway: {
+            minSeconds: 190,
+            maxSeconds: 310,
+            representativeSeconds: 200,
+          },
+          periods: [],
+        },
+      },
+      station: station('HBF', {
+        saturday: { firstTrain: '06:00', lastTrain: '06:10' },
+      }),
+      calendar: 'saturday',
+    });
+
+    expect(enumerateEstimatedStationDepartures(schedule)).toMatchObject([
+      { time: '06:00:00', basis: 'first_train' },
+      { time: '06:05:00', basis: 'frequency_estimate' },
+      { time: '06:10:00', basis: 'last_train' },
+    ]);
+  });
+
   test('uses service-day times after midnight', () => {
     const schedule = generateEstimatedStationFrequencySchedule({
       serviceId: 'NEL_MAIN_N',

--- a/packages/core/src/helpers/generateEstimatedStationFrequencySchedules.ts
+++ b/packages/core/src/helpers/generateEstimatedStationFrequencySchedules.ts
@@ -393,26 +393,53 @@ function estimatedDepartureSeconds(
   const maximumIntervalCount = Math.floor(
     duration / window.headwayRangeSeconds.min,
   );
-  const intervalCount =
+  const candidateIntervalCounts =
     maximumIntervalCount >= minimumIntervalCount
-      ? Math.min(
-          Math.max(idealIntervalCount, minimumIntervalCount),
-          maximumIntervalCount,
+      ? Array.from(
+          {
+            length: maximumIntervalCount - minimumIntervalCount + 1,
+          },
+          (_, index) => minimumIntervalCount + index,
+        ).sort(
+          (first, second) =>
+            Math.abs(first - idealIntervalCount) -
+              Math.abs(second - idealIntervalCount) || first - second,
         )
-      : idealIntervalCount;
-  const departureCount = includeEnd ? intervalCount + 1 : intervalCount;
+      : [];
 
-  return Array.from({ length: departureCount }, (_, index) => {
-    if (index === intervalCount) {
-      return window.endSeconds;
+  for (const intervalCount of candidateIntervalCounts) {
+    const offsets = Array.from({ length: intervalCount + 1 }, (_, index) => {
+      if (index === intervalCount) {
+        return duration;
+      }
+
+      const unquantizedOffset = (duration * index) / intervalCount;
+      return (
+        Math.round(unquantizedOffset / ESTIMATED_DEPARTURE_QUANTUM_SECONDS) *
+        ESTIMATED_DEPARTURE_QUANTUM_SECONDS
+      );
+    });
+    const gapsAreValid = offsets.slice(0, -1).every((offset, index) => {
+      const nextOffset = offsets[index + 1];
+      if (nextOffset === undefined) {
+        return false;
+      }
+
+      const gap = nextOffset - offset;
+      return (
+        gap >= window.headwayRangeSeconds.min &&
+        gap <= window.headwayRangeSeconds.max
+      );
+    });
+    if (gapsAreValid) {
+      const emittedOffsets = includeEnd ? offsets : offsets.slice(0, -1);
+      return emittedOffsets.map((offset) => window.startSeconds + offset);
     }
+  }
 
-    const unquantizedOffset = (duration * index) / intervalCount;
-    const offset =
-      Math.round(unquantizedOffset / ESTIMATED_DEPARTURE_QUANTUM_SECONDS) *
-      ESTIMATED_DEPARTURE_QUANTUM_SECONDS;
-    return window.startSeconds + offset;
-  });
+  throw new Error(
+    `Estimated frequency window ${window.startTime}-${window.endTime} cannot satisfy its ${window.headwayRangeSeconds.min}-${window.headwayRangeSeconds.max} second headway range after ${ESTIMATED_DEPARTURE_QUANTUM_SECONDS}-second quantization`,
+  );
 }
 
 /**

--- a/packages/core/src/helpers/generateEstimatedStationFrequencySchedules.ts
+++ b/packages/core/src/helpers/generateEstimatedStationFrequencySchedules.ts
@@ -1,0 +1,462 @@
+import type {
+  EstimatedFrequencyPeriod,
+  EstimatedFrequencyProfile,
+  EstimatedHeadway,
+  ServiceDayType,
+  ServiceRevision,
+} from '../schema/Service.js';
+import type {
+  Station,
+  StationFirstLastTrainCalendar,
+  StationFirstLastTrainTime,
+} from '../schema/Station.js';
+
+const SECONDS_PER_DAY = 24 * 60 * 60;
+const ESTIMATED_DEPARTURE_QUANTUM_SECONDS = 30;
+
+export type EstimatedStationScheduleCalendar =
+  | 'weekday'
+  | 'saturday'
+  | 'sunday_public_holiday';
+
+export type EstimatedFrequencyWindow = {
+  startTime: string;
+  endTime: string;
+  startSeconds: number;
+  endSeconds: number;
+  headwaySeconds: number;
+  headwayRangeSeconds: {
+    min: number;
+    max: number;
+  };
+  sourcePeriodId: string | null;
+  exactTimes: false;
+};
+
+export type EstimatedStationFrequencySchedule = {
+  serviceId: string;
+  stationId: string;
+  displayCode: string;
+  stopSequence: number;
+  calendar: EstimatedStationScheduleCalendar;
+  sourceCalendar: StationFirstLastTrainCalendar | null;
+  firstTrainTime: string | null;
+  lastTrainTime: string | null;
+  windows: EstimatedFrequencyWindow[];
+};
+
+export type EstimatedStationDeparture = {
+  time: string;
+  seconds: number;
+  basis: 'first_train' | 'frequency_estimate' | 'last_train';
+  headwaySeconds: number;
+  headwayRangeSeconds: {
+    min: number;
+    max: number;
+  };
+  sourcePeriodId: string | null;
+};
+
+type StationInput = Pick<Station, 'id' | 'firstLastTrain'>;
+
+type ClippedPeriod = {
+  startSeconds: number;
+  endSeconds: number;
+  period: EstimatedFrequencyPeriod;
+};
+
+const calendarConfig: Record<
+  EstimatedStationScheduleCalendar,
+  {
+    dayType: ServiceDayType;
+    sourceCalendars: readonly StationFirstLastTrainCalendar[];
+  }
+> = {
+  weekday: {
+    dayType: 'weekdays',
+    sourceCalendars: ['weekday', 'weekday_saturday', 'daily'],
+  },
+  saturday: {
+    dayType: 'weekends',
+    sourceCalendars: ['saturday', 'weekday_saturday', 'daily'],
+  },
+  sunday_public_holiday: {
+    dayType: 'weekends',
+    sourceCalendars: ['sunday_public_holiday', 'daily'],
+  },
+};
+
+function parseTime(time: string): number {
+  const [hours, minutes, seconds = 0] = time.split(':').map(Number);
+
+  if (
+    hours === undefined ||
+    minutes === undefined ||
+    !Number.isInteger(hours) ||
+    !Number.isInteger(minutes) ||
+    !Number.isInteger(seconds)
+  ) {
+    throw new Error(
+      `Frequency generation requires whole-second times: ${time}`,
+    );
+  }
+
+  return hours * 60 * 60 + minutes * 60 + seconds;
+}
+
+function formatTime(totalSeconds: number): string {
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  return [hours, minutes, seconds]
+    .map((part) => String(part).padStart(2, '0'))
+    .join(':');
+}
+
+function toWindow(
+  startSeconds: number,
+  endSeconds: number,
+  headway: EstimatedHeadway,
+  sourcePeriodId: string | null,
+): EstimatedFrequencyWindow {
+  return {
+    startTime: formatTime(startSeconds),
+    endTime: formatTime(endSeconds),
+    startSeconds,
+    endSeconds,
+    headwaySeconds: headway.representativeSeconds,
+    headwayRangeSeconds: {
+      min: headway.minSeconds,
+      max: headway.maxSeconds,
+    },
+    sourcePeriodId,
+    exactTimes: false,
+  };
+}
+
+function clipPeriodToStationDay(
+  period: EstimatedFrequencyPeriod,
+  stationStart: number,
+  stationEnd: number,
+): ClippedPeriod[] {
+  const periodStart = parseTime(period.start);
+  let periodEnd = parseTime(period.end);
+  if (periodEnd <= periodStart) {
+    periodEnd += SECONDS_PER_DAY;
+  }
+
+  const clipped: ClippedPeriod[] = [];
+  for (const offset of [-SECONDS_PER_DAY, 0, SECONDS_PER_DAY]) {
+    const startSeconds = Math.max(stationStart, periodStart + offset);
+    const endSeconds = Math.min(stationEnd, periodEnd + offset);
+    if (startSeconds < endSeconds) {
+      clipped.push({ startSeconds, endSeconds, period });
+    }
+  }
+
+  return clipped;
+}
+
+function generateWindows(
+  profile: EstimatedFrequencyProfile,
+  timing: StationFirstLastTrainTime,
+  dayType: ServiceDayType,
+): EstimatedFrequencyWindow[] {
+  if (timing.firstTrain == null || timing.lastTrain == null) {
+    return [];
+  }
+
+  const stationStart = parseTime(timing.firstTrain);
+  let stationEnd = parseTime(timing.lastTrain);
+  if (stationEnd === stationStart) {
+    throw new Error('Station first and last train times must differ');
+  }
+  if (stationEnd < stationStart) {
+    stationEnd += SECONDS_PER_DAY;
+  }
+
+  const clippedPeriods = profile.periods
+    .filter((period) => period.dayType === dayType)
+    .flatMap((period) =>
+      clipPeriodToStationDay(period, stationStart, stationEnd),
+    );
+  const boundaries = [
+    stationStart,
+    stationEnd,
+    ...clippedPeriods.flatMap(({ startSeconds, endSeconds }) => [
+      startSeconds,
+      endSeconds,
+    ]),
+  ]
+    .filter((value, index, values) => values.indexOf(value) === index)
+    .sort((a, b) => a - b);
+
+  return boundaries.slice(0, -1).map((startSeconds, index) => {
+    const endSeconds = boundaries[index + 1];
+    if (endSeconds === undefined) {
+      throw new Error('Frequency window has no end boundary');
+    }
+
+    const activePeriods = clippedPeriods.filter(
+      (candidate) =>
+        candidate.startSeconds <= startSeconds &&
+        candidate.endSeconds >= endSeconds,
+    );
+    if (activePeriods.length > 1) {
+      throw new Error(
+        `Estimated frequency periods overlap: ${activePeriods
+          .map(({ period }) => period.id)
+          .join(', ')}`,
+      );
+    }
+
+    const activePeriod = activePeriods[0]?.period;
+    return toWindow(
+      startSeconds,
+      endSeconds,
+      activePeriod?.headway ?? profile.defaultHeadway,
+      activePeriod?.id ?? null,
+    );
+  });
+}
+
+function resolveTiming(
+  station: StationInput,
+  serviceId: string,
+  calendar: EstimatedStationScheduleCalendar,
+): {
+  sourceCalendar: StationFirstLastTrainCalendar;
+  timing: StationFirstLastTrainTime;
+} | null {
+  const serviceTiming = station.firstLastTrain?.services.find(
+    (candidate) => candidate.serviceId === serviceId,
+  );
+  if (!serviceTiming?.times) {
+    return null;
+  }
+
+  for (const sourceCalendar of calendarConfig[calendar].sourceCalendars) {
+    const timing = serviceTiming.times[sourceCalendar];
+    if (timing) {
+      return { sourceCalendar, timing };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Generates frequency windows bounded by one station's canonical first and
+ * last train times. This preserves short starters and calendar differences
+ * that cannot be represented by a service-wide operating window.
+ */
+function generateEstimatedStationFrequencyScheduleAtStop({
+  serviceId,
+  revision,
+  station,
+  calendar,
+  stopIndex,
+}: {
+  serviceId: string;
+  revision: Pick<ServiceRevision, 'path' | 'estimatedFrequency'>;
+  station: StationInput;
+  calendar: EstimatedStationScheduleCalendar;
+  stopIndex: number;
+}): EstimatedStationFrequencySchedule {
+  const profile = revision.estimatedFrequency;
+  if (!profile) {
+    throw new Error('Service revision has no estimated frequency profile');
+  }
+
+  const stop = revision.path.stations[stopIndex];
+  if (!stop || stop.stationId !== station.id) {
+    throw new Error(
+      `Station ${station.id} is not in the service revision path`,
+    );
+  }
+
+  const resolved = resolveTiming(station, serviceId, calendar);
+  return {
+    serviceId,
+    stationId: station.id,
+    displayCode: stop.displayCode,
+    stopSequence: stopIndex + 1,
+    calendar,
+    sourceCalendar: resolved?.sourceCalendar ?? null,
+    firstTrainTime: resolved?.timing.firstTrain ?? null,
+    lastTrainTime: resolved?.timing.lastTrain ?? null,
+    windows: resolved
+      ? generateWindows(
+          profile,
+          resolved.timing,
+          calendarConfig[calendar].dayType,
+        )
+      : [],
+  };
+}
+
+export function generateEstimatedStationFrequencySchedule({
+  serviceId,
+  revision,
+  station,
+  calendar,
+}: {
+  serviceId: string;
+  revision: Pick<ServiceRevision, 'path' | 'estimatedFrequency'>;
+  station: StationInput;
+  calendar: EstimatedStationScheduleCalendar;
+}): EstimatedStationFrequencySchedule {
+  const stopIndexes = revision.path.stations.flatMap((stop, index) =>
+    stop.stationId === station.id ? [index] : [],
+  );
+  if (stopIndexes.length !== 1) {
+    throw new Error(
+      stopIndexes.length === 0
+        ? `Station ${station.id} is not in the service revision path`
+        : `Station ${station.id} occurs more than once in the service revision path; generate the full service schedule instead`,
+    );
+  }
+
+  const stopIndex = stopIndexes[0];
+  if (stopIndex === undefined) {
+    throw new Error(`Service revision path has no stop for ${station.id}`);
+  }
+
+  return generateEstimatedStationFrequencyScheduleAtStop({
+    serviceId,
+    revision,
+    station,
+    calendar,
+    stopIndex,
+  });
+}
+
+/** Generates station schedules in service path order. */
+export function generateEstimatedServiceStationFrequencySchedules({
+  serviceId,
+  revision,
+  stations,
+  calendar,
+}: {
+  serviceId: string;
+  revision: Pick<ServiceRevision, 'path' | 'estimatedFrequency'>;
+  stations: readonly StationInput[];
+  calendar: EstimatedStationScheduleCalendar;
+}): EstimatedStationFrequencySchedule[] {
+  const stationById = new Map(stations.map((station) => [station.id, station]));
+
+  return revision.path.stations.map((stop, stopIndex) => {
+    const station = stationById.get(stop.stationId);
+    if (!station) {
+      throw new Error(`Station data is missing for ${stop.stationId}`);
+    }
+
+    return generateEstimatedStationFrequencyScheduleAtStop({
+      serviceId,
+      revision,
+      station,
+      calendar,
+      stopIndex,
+    });
+  });
+}
+
+function departureFromWindow(
+  seconds: number,
+  window: EstimatedFrequencyWindow,
+  basis: EstimatedStationDeparture['basis'],
+): EstimatedStationDeparture {
+  return {
+    time: formatTime(seconds),
+    seconds,
+    basis,
+    headwaySeconds: window.headwaySeconds,
+    headwayRangeSeconds: { ...window.headwayRangeSeconds },
+    sourcePeriodId: window.sourcePeriodId,
+  };
+}
+
+function estimatedDepartureSeconds(
+  window: EstimatedFrequencyWindow,
+  includeEnd: boolean,
+): number[] {
+  const duration = window.endSeconds - window.startSeconds;
+  const idealIntervalCount = Math.max(
+    1,
+    Math.round(duration / window.headwaySeconds),
+  );
+  const minimumIntervalCount = Math.max(
+    1,
+    Math.ceil(duration / window.headwayRangeSeconds.max),
+  );
+  const maximumIntervalCount = Math.floor(
+    duration / window.headwayRangeSeconds.min,
+  );
+  const intervalCount =
+    maximumIntervalCount >= minimumIntervalCount
+      ? Math.min(
+          Math.max(idealIntervalCount, minimumIntervalCount),
+          maximumIntervalCount,
+        )
+      : idealIntervalCount;
+  const departureCount = includeEnd ? intervalCount + 1 : intervalCount;
+
+  return Array.from({ length: departureCount }, (_, index) => {
+    if (index === intervalCount) {
+      return window.endSeconds;
+    }
+
+    const unquantizedOffset = (duration * index) / intervalCount;
+    const offset =
+      Math.round(unquantizedOffset / ESTIMATED_DEPARTURE_QUANTUM_SECONDS) *
+      ESTIMATED_DEPARTURE_QUANTUM_SECONDS;
+    return window.startSeconds + offset;
+  });
+}
+
+/**
+ * Expands a station's frequency windows into deterministic estimated train
+ * times. Departures are distributed evenly around the representative headway
+ * and quantized to 30 seconds, so window boundaries and the canonical last
+ * train remain aligned without implying unsupported precision. Internal window
+ * ends are exclusive; the final canonical last train is included.
+ */
+export function enumerateEstimatedStationDepartures(
+  schedule: EstimatedStationFrequencySchedule,
+): EstimatedStationDeparture[] {
+  const firstWindow = schedule.windows[0];
+  const lastWindow = schedule.windows.at(-1);
+  if (
+    !firstWindow ||
+    !lastWindow ||
+    schedule.firstTrainTime == null ||
+    schedule.lastTrainTime == null
+  ) {
+    return [];
+  }
+
+  const departureBySeconds = new Map<number, EstimatedStationDeparture>();
+  for (const [index, window] of schedule.windows.entries()) {
+    const isLastWindow = index === schedule.windows.length - 1;
+    for (const seconds of estimatedDepartureSeconds(window, isLastWindow)) {
+      departureBySeconds.set(
+        seconds,
+        departureFromWindow(seconds, window, 'frequency_estimate'),
+      );
+    }
+  }
+
+  departureBySeconds.set(
+    firstWindow.startSeconds,
+    departureFromWindow(firstWindow.startSeconds, firstWindow, 'first_train'),
+  );
+  departureBySeconds.set(
+    lastWindow.endSeconds,
+    departureFromWindow(lastWindow.endSeconds, lastWindow, 'last_train'),
+  );
+
+  return [...departureBySeconds.values()].sort(
+    (first, second) => first.seconds - second.seconds,
+  );
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,4 @@
+export * from './helpers/generateEstimatedStationFrequencySchedules.js';
 export * from './helpers/normalizeRecurringPeriod.js';
 export * from './helpers/resolvePeriods.js';
 export * from './schema/common.js';

--- a/packages/core/src/schema/Service.ts
+++ b/packages/core/src/schema/Service.ts
@@ -1,6 +1,56 @@
 import z from 'zod';
 import { OperatingHoursSchema, TranslationsSchema } from './common.js';
 
+export const ServiceDayTypeSchema = z.enum(['weekdays', 'weekends']);
+export type ServiceDayType = z.infer<typeof ServiceDayTypeSchema>;
+
+export const EstimatedHeadwaySchema = z
+  .object({
+    minSeconds: z.number().int().positive(),
+    maxSeconds: z.number().int().positive(),
+    representativeSeconds: z.number().int().positive(),
+  })
+  .refine(
+    ({ minSeconds, maxSeconds, representativeSeconds }) =>
+      minSeconds <= representativeSeconds &&
+      representativeSeconds <= maxSeconds,
+    {
+      message:
+        'representativeSeconds must be between minSeconds and maxSeconds',
+      path: ['representativeSeconds'],
+    },
+  );
+export type EstimatedHeadway = z.infer<typeof EstimatedHeadwaySchema>;
+
+export const EstimatedFrequencyPeriodSchema = z
+  .object({
+    id: z.string().min(1),
+    dayType: ServiceDayTypeSchema,
+    start: z.iso.time(),
+    end: z.iso.time(),
+    headway: EstimatedHeadwaySchema,
+  })
+  .refine(({ start, end }) => start !== end, {
+    message: 'start and end must differ',
+    path: ['end'],
+  });
+export type EstimatedFrequencyPeriod = z.infer<
+  typeof EstimatedFrequencyPeriodSchema
+>;
+
+export const EstimatedFrequencyProfileSchema = z.object({
+  source: z.object({
+    url: z.url(),
+    description: z.string().min(1),
+    retrievedAt: z.iso.date(),
+  }),
+  defaultHeadway: EstimatedHeadwaySchema,
+  periods: z.array(EstimatedFrequencyPeriodSchema),
+});
+export type EstimatedFrequencyProfile = z.infer<
+  typeof EstimatedFrequencyProfileSchema
+>;
+
 export const ServiceRevisionSchema = z.object({
   id: z.string(),
   startAt: z.string(),
@@ -17,6 +67,7 @@ export const ServiceRevisionSchema = z.object({
     ),
   }),
   operatingHours: OperatingHoursSchema,
+  estimatedFrequency: EstimatedFrequencyProfileSchema.optional(),
 });
 export type ServiceRevision = z.infer<typeof ServiceRevisionSchema>;
 


### PR DESCRIPTION
## Summary

- add source-backed estimated headway schemas to service revisions
- generate deterministic frequency windows for every station in service-path order
- enumerate every estimated station departure from those windows
- retain canonical first/last trains as labelled source anchors and mark every interior time as `frequency_estimate`
- distribute estimated intervals within the published range, quantized to 30 seconds, so the final source anchor remains aligned without implying arbitrary precision
- preserve short starters, weekday/Saturday/Sunday differences, overnight `24:xx` times, missing terminal-direction timings, and repeated loop stops
- seed the current NEL, DTL, EWL main, NSL, and TEL directions with LTA-based peak and off-peak estimates
- migrate 62 CCL station timing references from retired main/extension IDs to the Stage 6 branch/loop IDs
- document how LTA rail geometry can support shape matching and calibrated stop-offset estimation

## Why

LTA publishes rail frequency ranges rather than exact departures. A service-wide operating window collapses important station-level behavior: for example, northbound NEL begins at Sengkang before the first HarbourFront departure, and Saturday/Sunday station bounds differ. Frequency windows alone also cannot answer a direct question such as “what are all estimated trains at Outram Park?” The enumerator now provides that list while preserving the distinction between sourced and synthesized times.

The profile is extended only where every non-destination station in the current service path has directional first/last-train timing data. CCL station timings now use the Stage 6 branch/loop service IDs, but remain deferred because branch services resolve only 27 of 31 path positions and loop services resolve 4 of 31; CC30–CC32 also need sourced timings. The EWL airport shuttle and SKLRT/PGLRT are deferred for incomplete directional timings, BPLRT needs a loop-specific frequency assumption, and future CRL/JRL services do not yet have operating timings.

## Example

For weekday Outram Park, the canonical data and estimator produce:

- northbound: 211 departures from `05:48` to `23:59`
- southbound: 207 departures from `06:12` to `23:58`
- `07:00–09:00`: estimated 150-second peak intervals
- first and last departures: labelled source anchors
- all interior departures: labelled frequency estimates

## Geometry and stop offsets

LTA DataMall publishes rail infrastructure as ESRI shapefiles. Ordered station coordinates can label nearby linework and provide along-track distances for shapes and anomaly checks. Distance alone is not used as a timing model because acceleration, dwell, curves, and minute-rounded timing evidence produce materially different effective speeds between adjacent stations. Future stop offsets should be anchored to observed first/last-train chains and use geometry only through an explicit calibrated fallback.

## Impact

Consumers can now obtain full estimated departure lists at a station for weekday, Saturday, and Sunday/public-holiday calendars across ten current service directions. These independently estimated station lists are not directly GTFS `frequencies.txt` or coherent end-to-end trips: a GTFS export must still group compatible station schedules into full-length and short-start trip patterns and provide reviewed relative `stop_times.txt` offsets.

## Validation

- cross-line generation audit — 804 populated station-day schedules and 153,558 estimated/source-anchored departures
- profile coverage audit — exactly ten current revisions; no historical revisions
- CCL timing ID audit — 62 references migrated; zero retired station references remain
- `npm test` — 311 tests passed
- `npm run test:core` — 67 tests passed
- `npm run build:core`
- `npm run typecheck`
- `npm run data:validate`
- `npm run check`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added source-backed estimated train frequency profiles with default and weekday peak headways.
  * Added station-level frequency schedules and deterministic estimated departures (including representative headways and min/max ranges).
  * Enhanced departure support with first/last-train anchoring and overlap-safe departure enumeration.
* **Bug Fixes**
  * Corrected station timetable mappings to use Circle Line branch/loop services where applicable.
* **Documentation**
  * Expanded GTFS static/realtime planning guidance with frequency estimation decision rules and geometry/stop-offset estimation details.
* **Chores**
  * Prepared a patch release for the core package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->